### PR TITLE
Added pragma once to all headers

### DIFF
--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <depthai_bridge/ImageConverter.hpp>
 
 #include "depthai/depthai.hpp"

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -1,4 +1,4 @@
-
+#pragma once
 
 #include <depthai_bridge/ImageConverter.hpp>
 


### PR DESCRIPTION
Not all headers have the pragma once directive, causing compilation to fail if that header file is included multiple times in the same target. This PR fixes that.