### PR TITLE
Fill R and P by default

### DIFF
--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -294,7 +294,11 @@ ImageMsgs::CameraInfo ImageConverter::calibrationToCameraInfo(
     auto& projection = cameraData.P;
     auto& rotation = cameraData.R;
 #endif
-
+    // Set rotation to reasonable default even for non-stereo pairs
+    rotation[0] = rotation[4] = rotation[8] = 1;
+    for(size_t i = 0; i < 3; i++) {
+        std::copy(flatIntrinsics.begin() + i * 3, flatIntrinsics.begin() + (i + 1) * 3, projection.begin() + i * 4);
+    }
     std::copy(flatIntrinsics.begin(), flatIntrinsics.end(), intrinsics.begin());
 
     distCoeffs = calibHandler.getDistortionCoefficients(cameraId);


### PR DESCRIPTION
Also threw in everything available on an ImgFrame.

Note that I could not test on ROS2. 

There is also a separate commit to set R and P to valid defaults. I've seen nodes in the past care about this (arguably incorrectly, but in such cases there is no harm in setting it). I thought I was seeing it in rviz just now but it turned out to be something else. 