### PR TITLE
Pr publish imu transform

### DIFF
--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -50,6 +50,9 @@ if ( ament_cmake_FOUND )
     find_package(stereo_msgs REQUIRED)
     find_package(std_msgs REQUIRED)
     find_package(vision_msgs REQUIRED)
+    find_package(tf2 REQUIRED)
+    find_package(tf2_ros REQUIRED)
+    find_package(tf2_geometry_msgs REQUIRED)
 
     set(dependencies
         camera_info_manager
@@ -61,6 +64,9 @@ if ( ament_cmake_FOUND )
         stereo_msgs
         std_msgs
         vision_msgs
+        tf2
+        tf2_ros
+        tf2_geometry_msgs
       )
 
     include_directories(
@@ -137,6 +143,9 @@ elseif( CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE )
       stereo_msgs
       std_msgs
       vision_msgs
+      tf2
+      tf2_ros
+      tf2_geometry_msgs
     )
     find_package(Boost REQUIRED)
 
@@ -155,7 +164,7 @@ elseif( CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE )
     catkin_package(
       INCLUDE_DIRS include
       LIBRARIES ${PROJECT_NAME}
-      CATKIN_DEPENDS depthai_ros_msgs camera_info_manager roscpp sensor_msgs std_msgs vision_msgs image_transport cv_bridge stereo_msgs
+      CATKIN_DEPENDS depthai_ros_msgs camera_info_manager roscpp sensor_msgs std_msgs vision_msgs image_transport cv_bridge stereo_msgs tf2 tf2_ros tf2_geometry_msgs
     )
 
     list(APPEND DEPENDENCY_PUBLIC_LIBRARIES ${catkin_LIBRARIES})

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -7,9 +7,14 @@
 
 #include "depthai/depthai.hpp"
 
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
 #ifdef IS_ROS2
     #include "rclcpp/rclcpp.hpp"
     #include "sensor_msgs/msg/imu.hpp"
+    #include <geometry_msgs/msg/transform_stamped.hpp>
 #else
     #include <ros/ros.h>
 
@@ -25,20 +30,47 @@ namespace ros {
 #ifdef IS_ROS2
 namespace ImuMsgs = sensor_msgs::msg;
 using ImuPtr = ImuMsgs::Imu::SharedPtr;
+namespace rosOrigin = ::rclcpp;
+namespace GeometryMsg = geometry_msgs::msg;
 #else
 namespace ImuMsgs = sensor_msgs;
 using ImuPtr = ImuMsgs::Imu::Ptr;
+namespace rosOrigin = ::ros;
+namespace GeometryMsg = geometry_msgs;
 #endif
 class ImuConverter {
    public:
-    ImuConverter(const std::string& frameName);
+#ifdef IS_ROS2
+    ImuConverter(const std::string& frameName,
+                 std::shared_ptr<rosOrigin::Node> node,
+                 const bool publishTransform = false, 
+                 const std::string base_frame = "oak-d-base-frame",
+                 const std::string world_frame = "map");
+#else
+    ImuConverter(const std::string& frameName,
+                 const bool publishTransform = false, 
+                 const std::string base_frame = "oak-d-base-frame",
+                 const std::string world_frame = "map");
+#endif
 
     void toRosMsg(std::shared_ptr<dai::IMUData> inData, ImuMsgs::Imu& outImuMsg);
     ImuPtr toRosMsgPtr(const std::shared_ptr<dai::IMUData> inData);
 
    private:
+    void publishtransform(ImuMsgs::Imu& outImuMsg);
     uint32_t _sequenceNum;
     const std::string _frameName = "";
+    const bool _publishTransform = false;
+    const std::string _base_frame = "";
+    const std::string _world_frame = "";
+    GeometryMsg::TransformStamped imuToOakBase;
+    std::unique_ptr<tf2_ros::Buffer> tfBuffer = nullptr;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> br = nullptr;
+    std::shared_ptr<tf2_ros::TransformListener> tfListener = nullptr;
+
+    #ifdef IS_ROS2
+    std::shared_ptr<rosOrigin::Node> _node = nullptr;
+    #endif
 };
 
 }  // namespace ros

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -67,6 +67,9 @@
   <depend>std_msgs</depend>
   <depend>stereo_msgs</depend>
   <depend>vision_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -4,8 +4,53 @@
 namespace dai {
 
 namespace ros {
+#ifdef IS_ROS2
+    ImuConverter::ImuConverter(const std::string& frameName,
+                               std::shared_ptr<rosOrigin::Node> node,
+                               const bool publishTransform, 
+                               const std::string base_frame,
+                               const std::string world_frame) 
+: _frameName(frameName),
+  _node(node),
+  _publishTransform(publishTransform), 
+  _base_frame(base_frame),
+  _world_frame(world_frame), 
+  _sequenceNum(0) {
+    if(_publishTransform) {
+        tfBuffer = std::make_unique<tf2_ros::Buffer>(_node->get_clock());
+        tfListener = std::make_shared<tf2_ros::TransformListener>(*tfBuffer);
+        br = std::make_unique<tf2_ros::TransformBroadcaster>(*node);
 
-ImuConverter::ImuConverter(const std::string& frameName) : _frameName(frameName), _sequenceNum(0) {}
+        while(!tfBuffer->canTransform(_frameName, _base_frame, tf2::TimePointZero) && rclcpp::ok()) {
+            RCLCPP_INFO(node->get_logger(), tfBuffer->allFramesAsString());
+            RCLCPP_INFO(
+                    node->get_logger(), "waiting for IMU transform to become available");
+            rclcpp::sleep_for(std::chrono::milliseconds(30));
+        }
+        RCLCPP_INFO(node->get_logger(), "transform available");
+
+        imuToOakBase  = tfBuffer->lookupTransform(_frameName, _base_frame, tf2::TimePointZero);
+    }
+}
+#else
+    ImuConverter::ImuConverter(const std::string& frameName,
+                               const bool publishTransform, 
+                               const std::string base_frame,
+                               const std::string world_frame) 
+    : _frameName(frameName),
+      _publishTransform(publishTransform), 
+      _base_frame(base_frame),
+      _world_frame(world_frame), 
+      _sequenceNum(0) {
+        if(_publishTransform) {
+            tfBuffer = std::make_unique<tf2_ros::Buffer>();
+            tfListener = std::make_shared<tf2_ros::TransformListener>(*tfBuffer);
+            br = std::make_unique<tf2_ros::TransformBroadcaster>();
+            
+            imuToOakBase  = tfBuffer->lookupTransform(_frameName, _base_frame, rosOrigin::Time(0), rosOrigin::Duration(1.0) );
+        }
+    }
+#endif
 
 void ImuConverter::toRosMsg(std::shared_ptr<dai::IMUData> inData, ImuMsgs::Imu& outImuMsg) {
 // setting the header
@@ -46,6 +91,10 @@ void ImuConverter::toRosMsg(std::shared_ptr<dai::IMUData> inData, ImuMsgs::Imu& 
     }
 
     _sequenceNum++;
+
+    if(_publishTransform) {
+        publishtransform(outImuMsg);
+    }
 }
 
 ImuPtr ImuConverter::toRosMsgPtr(const std::shared_ptr<dai::IMUData> inData) {
@@ -57,6 +106,28 @@ ImuPtr ImuConverter::toRosMsgPtr(const std::shared_ptr<dai::IMUData> inData) {
 
     toRosMsg(inData, *ptr);
     return ptr;
+}
+
+void ImuConverter::publishtransform(ImuMsgs::Imu& outImuMsg){
+    GeometryMsg::TransformStamped transformStamped;
+
+    transformStamped.header.stamp = outImuMsg.header.stamp;
+    transformStamped.header.frame_id = _world_frame;
+
+    transformStamped.child_frame_id = _base_frame;
+
+    transformStamped.transform.rotation.x = outImuMsg.orientation.z;
+    transformStamped.transform.rotation.y = outImuMsg.orientation.y;
+    transformStamped.transform.rotation.z = outImuMsg.orientation.x * -1;
+    transformStamped.transform.rotation.w = outImuMsg.orientation.w;
+
+    tf2::doTransform(transformStamped, transformStamped, imuToOakBase);
+    transformStamped.header.stamp = outImuMsg.header.stamp;
+    transformStamped.header.frame_id = _world_frame;
+
+    transformStamped.child_frame_id = _base_frame;
+
+    br->sendTransform(transformStamped);
 }
 
 }  // namespace ros


### PR DESCRIPTION
Added feature to publish IMU transform in both ros and ros2. I added a boolean to the BridgePublisher that will allow publishing IMU without listening to the IMU message topic and to not force publishing the message if it is not being listened to. The boolean to publish the TF transform as well as the IMU frame and world frame are passed to the imuConverter object and initialized in the constructor. Once running, the flag in the BridgePublisher will cause the converter toRosMsg function to be called in order to publish the transform but not published.