### PR TITLE
Update underlay.repos

### DIFF
--- a/underlay.repos
+++ b/underlay.repos
@@ -2,8 +2,4 @@ repositories:
   luxonis/depthai-ros:
     type: git
     url: https://github.com/luxonis/depthai-ros.git
-    version: main
-  luxonis/depthai-ros-examples:
-    type: git
-    url: https://github.com/luxonis/depthai-ros-examples.git
-    version: main
+    version: ros-release


### PR DESCRIPTION
- Change luxonis/depthai-ros version from main to ros-release
- Remove luxonis/depthai-ros-examples since the examples where moved into luxonis/depthai-ros