### PR TITLE
Manual exposure

### DIFF
--- a/depthai_examples/launch/stereo_inertial_node.launch
+++ b/depthai_examples/launch/stereo_inertial_node.launch
@@ -86,6 +86,9 @@
         <param name="subpixel"              value="$(arg subpixel)"/>
         <param name="rectify"               value="$(arg rectify)" />
         <param name="depth_aligned"         value="$(arg depth_aligned)" />
+        <param name="manualExposure"        value="$(arg manualExposure)" />
+        <param name="expTime"               value="$(arg expTime)" />
+        <param name="sensIso"               value="$(arg sensIso)" />
         
         <param name="enableSpatialDetection"   value="$(arg enableSpatialDetection)" />
         <param name="syncNN"                   value="$(arg syncNN)" />

--- a/depthai_examples/launch/stereo_inertial_node.launch
+++ b/depthai_examples/launch/stereo_inertial_node.launch
@@ -24,6 +24,9 @@
     <arg name="subpixel"              default="true" />
     <arg name="rectify"               default="true" />
     <arg name="depth_aligned"         default="true" />
+    <arg name="manualExposure"        default="false"/>
+    <arg name="expTime"               default="20000"/>
+    <arg name="sensIso"               default="800" />
 
     <arg name="enableSpatialDetection" default="true" />
     <arg name="syncNN"                 default="true" />

--- a/depthai_examples/launch/stereo_inertial_node.launch.py
+++ b/depthai_examples/launch/stereo_inertial_node.launch.py
@@ -45,6 +45,9 @@ def generate_launch_description():
     subpixel       = LaunchConfiguration('subpixel', default = True)
     rectify        = LaunchConfiguration('rectify', default = True)
     depth_aligned  = LaunchConfiguration('depth_aligned', default = True)
+    manualExposure = LaunchConfiguration('manualExposure', default = False)
+    expTime        = LaunchConfiguration('expTime', default = 20000)
+    sensIso        = LaunchConfiguration('sensIso', default = 800)
 
     enableSpatialDetection  = LaunchConfiguration('enableSpatialDetection', default = True)
     syncNN                  = LaunchConfiguration('syncNN', default = True)
@@ -175,6 +178,21 @@ def generate_launch_description():
         'depth_aligned',
         default_value=depth_aligned,
         description='When depth_aligned is enabled depth map from stereo will be aligned to the RGB camera in the center.')
+
+    declare_manualExposure_cmd = DeclareLaunchArgument(
+        'manualExposure',
+        default_value=manualExposure,
+        description='When manualExposure is enabled, you can set the exposure time(expTime) and ISO(sensIso) of the stereo camera.')
+    
+    declare_expTime_cmd = DeclareLaunchArgument(
+        'expTime',
+        default_value=expTime,
+        description='Set the exposure time of the stereo camera. Default value is 20000')
+
+    declare_sensIso_cmd = DeclareLaunchArgument(
+        'sensIso',
+        default_value=sensIso,
+        description='Set the ISO of the stereo camera. Default value is 800')
 
     declare_enableSpatialDetection_cmd = DeclareLaunchArgument(
         'enableSpatialDetection',
@@ -315,6 +333,9 @@ def generate_launch_description():
                         {'rectify':                 rectify},
 
                         {'depth_aligned':           depth_aligned},
+                        {'manualExposure':          manualExposure},
+                        {'expTime':                 expTime},
+                        {'sensIso':                 sensIso},
                         {'stereo_fps':              stereo_fps},
                         {'confidence':              confidence},
                         {'LRchecktresh':            LRchecktresh},
@@ -424,6 +445,9 @@ def generate_launch_description():
     ld.add_action(declare_subpixel_cmd)
     ld.add_action(declare_rectify_cmd)
     ld.add_action(declare_depth_aligned_cmd)
+    ld.add_action(declare_manualExposure_cmd)
+    ld.add_action(declare_expTime_cmd)
+    ld.add_action(declare_sensIso_cmd)
 
     ld.add_action(declare_enableSpatialDetection_cmd)
     ld.add_action(declare_syncNN_cmd)

--- a/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
@@ -272,9 +272,9 @@ int main(int argc, char** argv) {
 
     std::string tfPrefix, mode, mxId, resourceBaseFolder, nnPath;
     std::string monoResolution = "720p", rgbResolution = "1080p";
-    int badParams = 0, stereo_fps, confidence, LRchecktresh, imuModeParam, detectionClassesCount;
+    int badParams = 0, stereo_fps, confidence, LRchecktresh, imuModeParam, detectionClassesCount, expTime, sensIso;
     int rgbScaleNumerator, rgbScaleDinominator, previewWidth, previewHeight;
-    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned;
+    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned, manualExposure;
     bool enableSpatialDetection, enableDotProjector, enableFloodLight;
     bool usb2Mode, poeMode, syncNN;
     double angularVelCovariance, linearAccelCovariance;
@@ -301,6 +301,9 @@ int main(int argc, char** argv) {
     badParams += !pnh.getParam("LRchecktresh", LRchecktresh);
     badParams += !pnh.getParam("monoResolution", monoResolution);
     badParams += !pnh.getParam("rgbResolution", rgbResolution);
+    badParams += !pnh.getParam("manualExposure", manualExposure);
+    badParams += !pnh.getParam("expTime", expTime);
+    badParams += !pnh.getParam("sensIso", sensIso);
 
     badParams += !pnh.getParam("rgbScaleNumerator", rgbScaleNumerator);
     badParams += !pnh.getParam("rgbScaleDinominator", rgbScaleDinominator);
@@ -397,6 +400,17 @@ int main(int argc, char** argv) {
     if(!poeMode) {
         std::cout << "Device USB status: " << usbStrings[static_cast<int32_t>(device->getUsbSpeed())] << std::endl;
     }
+
+    // Apply camera controls
+    auto controlQueue = device->getInputQueue("control");
+
+    //Set manual exposure
+    if(manualExposure){
+        dai::CameraControl ctrl;
+        ctrl.setManualExposure(expTime, sensIso);
+        controlQueue->send(ctrl);
+    }
+
 
     std::shared_ptr<dai::DataOutputQueue> stereoQueue;
     if(enableDepth) {

--- a/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros1_src/stereo_inertial_publisher.cpp
@@ -45,12 +45,17 @@ std::tuple<dai::Pipeline, int, int> createPipeline(bool enableDepth,
                                                    std::string nnPath) {
     dai::Pipeline pipeline;
     pipeline.setXLinkChunkSize(0);
+    auto controlIn = pipeline.create<dai::node::XLinkIn>();
     auto monoLeft = pipeline.create<dai::node::MonoCamera>();
     auto monoRight = pipeline.create<dai::node::MonoCamera>();
     auto stereo = pipeline.create<dai::node::StereoDepth>();
     auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
     auto imu = pipeline.create<dai::node::IMU>();
     auto xoutImu = pipeline.create<dai::node::XLinkOut>();
+
+    controlIn->setStreamName("control");
+    controlIn->out.link(monoRight->inputControl);
+    controlIn->out.link(monoLeft->inputControl);
 
     if(enableDepth) {
         xoutDepth->setStreamName("depth");

--- a/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
@@ -45,12 +45,17 @@ std::tuple<dai::Pipeline, int, int> createPipeline(bool enableDepth,
                                                    std::string nnPath) {
     dai::Pipeline pipeline;
 
+    auto controlIn = pipeline.create<dai::node::XLinkIn>();
     auto monoLeft = pipeline.create<dai::node::MonoCamera>();
     auto monoRight = pipeline.create<dai::node::MonoCamera>();
     auto stereo = pipeline.create<dai::node::StereoDepth>();
     auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
     auto imu = pipeline.create<dai::node::IMU>();
     auto xoutImu = pipeline.create<dai::node::XLinkOut>();
+
+    controlIn->setStreamName("control");
+    controlIn->out.link(monoRight->inputControl);
+    controlIn->out.link(monoLeft->inputControl);
 
     if(enableDepth) {
         xoutDepth->setStreamName("depth");
@@ -271,9 +276,9 @@ int main(int argc, char** argv) {
 
     std::string tfPrefix, mode, mxId, resourceBaseFolder, nnPath;
     std::string monoResolution = "720p", rgbResolution = "1080p";
-    int badParams = 0, stereo_fps, confidence, LRchecktresh, imuModeParam, detectionClassesCount;
+    int badParams = 0, stereo_fps, confidence, LRchecktresh, imuModeParam, detectionClassesCount, expTime, sensIso;
     int rgbScaleNumerator, rgbScaleDinominator, previewWidth, previewHeight;
-    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned;
+    bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned, manualExposure;
     bool enableSpatialDetection, enableDotProjector, enableFloodLight;
     bool usb2Mode, poeMode, syncNN;
     double angularVelCovariance, linearAccelCovariance;
@@ -300,6 +305,9 @@ int main(int argc, char** argv) {
     node->declare_parameter("LRchecktresh", 5);
     node->declare_parameter("monoResolution", "720p");
     node->declare_parameter("rgbResolution", "1080p");
+    node->declare_parameter("manualExposure", true);
+    node->declare_parameter("expTime", 20000);
+    node->declare_parameter("sensIso", 800);
     
     node->declare_parameter("rgbScaleNumerator",   2);
     node->declare_parameter("rgbScaleDinominator", 3);
@@ -341,6 +349,9 @@ int main(int argc, char** argv) {
     node->get_parameter("LRchecktresh", LRchecktresh);
     node->get_parameter("monoResolution", monoResolution);
     node->get_parameter("rgbResolution", rgbResolution);
+    node->get_parameter("manualExposure", manualExposure);
+    node->get_parameter("expTime", expTime);
+    node->get_parameter("sensIso", sensIso);
 
     node->get_parameter("rgbScaleNumerator", rgbScaleNumerator);
     node->get_parameter("rgbScaleDinominator", rgbScaleDinominator);
@@ -430,6 +441,17 @@ int main(int argc, char** argv) {
 
     if(!poeMode) {
         std::cout << "Device USB status: " << usbStrings[static_cast<int32_t>(device->getUsbSpeed())] << std::endl;
+    }
+
+
+    // Apply camera controls
+    auto controlQueue = device->getInputQueue("control");
+
+    //Set manual exposure
+    if(manualExposure){
+        dai::CameraControl ctrl;
+        ctrl.setManualExposure(expTime, sensIso);
+        controlQueue->send(ctrl);
     }
 
     std::shared_ptr<dai::DataOutputQueue> stereoQueue;

--- a/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
     node->declare_parameter("LRchecktresh", 5);
     node->declare_parameter("monoResolution", "720p");
     node->declare_parameter("rgbResolution", "1080p");
-    node->declare_parameter("manualExposure", true);
+    node->declare_parameter("manualExposure", false);
     node->declare_parameter("expTime", 20000);
     node->declare_parameter("sensIso", 800);
     


### PR DESCRIPTION
I added manual exposure setting functionality for ROS1's stero_inertial_node because this functionality is needed to use OAK-D in the out-door environment.