### PR TITLE
Use default C++ to build in Ubuntu 22.04

### DIFF
--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 project(depthai-ros VERSION 2.5.3 LANGUAGES CXX C)
 
+if(CMAKE_CXX_STANDARD LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 find_package(ament_cmake QUIET)
 
 if ( ament_cmake_FOUND )

--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 project(depthai-ros VERSION 2.5.3 LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 14)
-
 find_package(ament_cmake QUIET)
 
 if ( ament_cmake_FOUND )

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -3,9 +3,6 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(depthai_bridge VERSION 2.5.3 LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Update the policy setting to avoid an error when loading the ament_cmake package
 # at the current cmake version level
 if(POLICY CMP0057)

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -3,6 +3,10 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 project(depthai_bridge VERSION 2.5.3 LANGUAGES CXX C)
 
+if(CMAKE_CXX_STANDARD LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 # Update the policy setting to avoid an error when loading the ament_cmake package
 # at the current cmake version level
 if(POLICY CMP0057)

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 project(depthai_examples VERSION 2.5.3 LANGUAGES CXX C)
 
+if(CMAKE_CXX_STANDARD LESS 14)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_compile_options(-g)
 

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 project(depthai_examples VERSION 2.5.3 LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_compile_options(-g)
 


### PR DESCRIPTION
There's a `'error: ‘shared_mutex’ in namespace ‘std’ does not name a type'` otherwise (at least in catkin build using 'ros-o').

Removing the CMAKE_CXX_STANDARD 14 will result in C++ 17 used in Ubuntu 22.04, and 14 in 20.04 which should work as before- so this probably would break 18.04 with kinetic, so instead of removing the `14` could set it to `17`.