### PR TITLE
Added IR driver check instead of boardName (#132)

### DIFF
--- a/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/ros2_src/stereo_inertial_publisher.cpp
@@ -471,7 +471,8 @@ int main(int argc, char** argv) {
     }
 
 
-    if(boardName.find("PRO") != std::string::npos) {
+    std::vector<std::tuple<std::string, int, int>> irDrivers = device->getIrDrivers();
+    if(!irDrivers.empty()) {
         if(enableDotProjector) {
             device->setIrLaserDotProjectorBrightness(dotProjectormA);
         }


### PR DESCRIPTION
The same fix is required for ROS2.