### PR TITLE
Fix running stereo_inertial_node in a namespace

### DIFF
--- a/depthai_examples/launch/stereo_inertial_node.launch
+++ b/depthai_examples/launch/stereo_inertial_node.launch
@@ -120,8 +120,8 @@
 
     <node pkg="nodelet" type="nodelet" name="depth_image_convertion_nodelet"
         args="load depth_image_proc/convert_metric nodelet_manager">
-        <remap from="image_raw" to="/stereo_inertial_publisher/stereo/depth"/>    
-        <remap from="image" to="/stereo_inertial_publisher/stereo/image"/>
+        <remap from="image_raw" to="stereo_inertial_publisher/stereo/depth"/>    
+        <remap from="image" to="stereo_inertial_publisher/stereo/image"/>
     </node>
 
 
@@ -129,24 +129,24 @@
         args="load depth_image_proc/point_cloud_xyzrgb nodelet_manager">
         <param name="queue_size"          value="10"/>
 
-        <remap from="rgb/camera_info" to="/stereo_inertial_publisher/color/camera_info"/>
-        <remap from="rgb/image_rect_color" to="/stereo_inertial_publisher/color/image"/>
-        <remap from="depth_registered/image_rect" to="/stereo_inertial_publisher/stereo/image"/>    
-        <remap from="depth_registered/points" to="/stereo_inertial_publisher/stereo/points"/>
+        <remap from="rgb/camera_info" to="stereo_inertial_publisher/color/camera_info"/>
+        <remap from="rgb/image_rect_color" to="stereo_inertial_publisher/color/image"/>
+        <remap from="depth_registered/image_rect" to="stereo_inertial_publisher/stereo/image"/>    
+        <remap from="depth_registered/points" to="stereo_inertial_publisher/stereo/points"/>
     </node>
 
     <node if="$(eval arg('depth_aligned') == false)" pkg="nodelet" type="nodelet" name="depth_image_to_pointcloud"
         args="load depth_image_proc/point_cloud_xyz nodelet_manager">
         <param name="queue_size"          value="10"/>
-        <remap from="camera_info" to="/stereo_inertial_publisher/stereo/camera_info"/>
-        <remap from="image_rect" to="/stereo_inertial_publisher/stereo/image"/>    
-        <remap from="points" to="/stereo_inertial_publisher/stereo/points"/>
+        <remap from="camera_info" to="stereo_inertial_publisher/stereo/camera_info"/>
+        <remap from="image_rect" to="stereo_inertial_publisher/stereo/image"/>    
+        <remap from="points" to="stereo_inertial_publisher/stereo/points"/>
     </node>
 
 
     <node if="$(eval arg('enableMarkerPublish') == true)" type="markerPublisher.py" name="markerPublisher" pkg="depthai_examples">
-        <remap from="spatialDetections" to="/stereo_inertial_publisher/color/yolov4_Spatial_detections"/>
-        <remap from="spatialDetectionMarkers" to="/stereo_inertial_publisher/color/spatialDetectionMarkers"/>
+        <remap from="spatialDetections" to="stereo_inertial_publisher/color/yolov4_Spatial_detections"/>
+        <remap from="spatialDetectionMarkers" to="stereo_inertial_publisher/color/spatialDetectionMarkers"/>
     </node>
 
   <group if="$(eval arg('enableRviz') == true)">


### PR DESCRIPTION
The absolute topic prefixes have broken a part of the functionality when the node is run in a namespace. This PR fixes it.