### PR TITLE
Fixed nnName bugs.

### DIFF
--- a/depthai_examples/launch/stereo_inertial_node.launch.py
+++ b/depthai_examples/launch/stereo_inertial_node.launch.py
@@ -352,6 +352,7 @@ def generate_launch_description():
                         {'enableSpatialDetection':  enableSpatialDetection},
                         {'detectionClassesCount':   detectionClassesCount},
                         {'syncNN':                  syncNN},
+                        {'nnName':                  nnName},
                         
                         {'enableDotProjector':      enableDotProjector},
                         {'enableFloodLight':        enableFloodLight},

--- a/depthai_examples/src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/src/stereo_inertial_publisher.cpp
@@ -325,6 +325,7 @@ int main(int argc, char** argv) {
     node->declare_parameter("enableSpatialDetection", true);
     node->declare_parameter("detectionClassesCount", 80);
     node->declare_parameter("syncNN", true);
+    node->declare_parameter("nnName", "x");
 
     node->declare_parameter("enableDotProjector", false);
     node->declare_parameter("enableFloodLight", false);


### PR DESCRIPTION
In `stereo_inertial_publisher.cpp`, the `nnName` parameter was used but was not declared,and in `stereo_inertial_node.launch.py`,the `nnName` param is not passed to the node,too. This leads that edit `nnName` param  did not work,and user cannot use their custom model by changing 'nnName'.