### PR TITLE
Fix rgbd_pcl configuration

### DIFF
--- a/depthai_ros_driver/config/rgbd.yaml
+++ b/depthai_ros_driver/config/rgbd.yaml
@@ -5,4 +5,5 @@
       i_laser_dot_brightness: 0
       i_floodlight_brightness: 200
     stereo:
+      i_enable_distortion_correction: true
       i_subpixel: true

--- a/depthai_ros_driver/launch/rgbd_pcl.launch.py
+++ b/depthai_ros_driver/launch/rgbd_pcl.launch.py
@@ -35,19 +35,22 @@ def launch_setup(context, *args, **kwargs):
             target_container=name+"_container",
             composable_node_descriptions=[
                     ComposableNode(
-                        package="depth_image_proc",
-                        plugin="depth_image_proc::ConvertMetricNode",
-                        name="convert_metric_node",
-                        remappings=[('image_raw', name+'/stereo/image_raw'),
-                                            ('camera_info', name+'/stereo/camera_info'),
-                                            ('image', name+'/stereo/converted_depth')]
+                        package="image_proc",
+                        plugin="image_proc::RectifyNode",
+                        name="rectify_color_node",
+                        remappings=[('image', name+'/rgb/image_raw'),
+                                    ('camera_info', name+'/rgb/camera_info'),
+                                    ('image_rect', name+'/rgb/image_rect'),
+                                    ('image_rect/compressed', name+'/rgb/image_rect/compressed'),
+                                    ('image_rect/compressedDepth', name+'/rgb/image_rect/compressedDepth'),
+                                    ('image_rect/theora', name+'/rgb/image_rect/theora')]
                     ),
                     ComposableNode(
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzrgbNode',
                     name='point_cloud_xyzrgb_node',
-                    remappings=[('depth_registered/image_rect', name+'/stereo/converted_depth'),
-                                ('rgb/image_rect_color', name+'/rgb/image_raw'),
+                    remappings=[('depth_registered/image_rect', name+'/stereo/image_raw'),
+                                ('rgb/image_rect_color', name+'/rgb/image_rect'),
                                 ('rgb/camera_info', name+'/rgb/camera_info'),
                                 ('points', name+'/points')]
                     ),


### PR DESCRIPTION
PointCloudXyzrgbNode now support uint16 depth image, so there's no need to use ConvertMetricNode.
However, PointCloudXyzrgbNode reruires rectifiec/undistored images as input. Using wrong data may not be noticed with most OAK devices. But since I'm using OAK-D Pro W, the differences are significant.
Using unfixed config:
![rviz_screenshot_2023_04_01-13_01_14](https://user-images.githubusercontent.com/22918715/229267607-46a2296d-0f83-48db-8258-9c25e6135b87.png)
Using correct config:
![rviz_screenshot_2023_04_01-13_00_11](https://user-images.githubusercontent.com/22918715/229267629-e3982f68-0176-4c7d-935b-f802c2826ee7.png)
RTAB-Map configs may have the same issue. I'll check and test later.