### PR TITLE
fix resolution width/height, add THE_1440X1080 for IMX296

### DIFF
--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -32,38 +32,43 @@ void ImageSensor::getSizeFromResolution(const dai::ColorCameraProperties::Sensor
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_12_MP: {
-            height = 4056;
-            width = 3040;
+            width = 4056;
+            height = 3040;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_1200_P: {
-            height = 1920;
-            width = 1200;
+            width = 1920;
+            height = 1200;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_5_MP: {
-            height = 2592;
-            width = 1944;
+            width = 2592;
+            height = 1944;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_13_MP: {
-            height = 4208;
-            width = 3120;
+            width = 4208;
+            height = 3120;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_4000X3000: {
-            height = 4000;
-            width = 3000;
+            width = 4000;
+            height = 3000;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_5312X6000: {
-            height = 5312;
-            width = 6000;
+            width = 5312;
+            height = 6000;
             break;
         }
         case dai::ColorCameraProperties::SensorResolution::THE_48_MP: {
-            height = 8000;
-            width = 6000;
+            width = 8000;
+            height = 6000;
+            break;
+        }
+        case dai::ColorCameraProperties::SensorResolution::THE_1440X1080: {
+            width = 1440;
+            height = 1080;
             break;
         }
         default: {

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -67,7 +67,8 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
                         {"5MP", dai::ColorCameraProperties::SensorResolution::THE_5_MP},
                         {"4000x3000", dai::ColorCameraProperties::SensorResolution::THE_4000X3000},
                         {"5312X6000", dai::ColorCameraProperties::SensorResolution::THE_5312X6000},
-                        {"48_MP", dai::ColorCameraProperties::SensorResolution::THE_48_MP}};
+                        {"48_MP", dai::ColorCameraProperties::SensorResolution::THE_48_MP},
+                        {"1440X1080", dai::ColorCameraProperties::SensorResolution::THE_1440X1080}};
     declareAndLogParam<bool>("i_publish_topic", publish);
     declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket));
     declareAndLogParam<bool>("i_output_isp", true);


### PR DESCRIPTION
IMX296 was introduce in [de8136f02865f15c01fbf10e3bfe2de7d2c4dfc2](https://github.com/luxonis/depthai-core/commit/de8136f02865f15c01fbf10e3bfe2de7d2c4dfc2), which may need to be added to availableSensors later.