### PR TITLE
add DisparityWidth, Disparity Companding, SubpixelFractionalBits options

### DIFF
--- a/depthai_ros_driver/config/camera.yaml
+++ b/depthai_ros_driver/config/camera.yaml
@@ -91,6 +91,7 @@
       i_depth_filter_size: 5
       i_depth_preset: HIGH_ACCURACY
       i_disparity_width: DISPARITY_96
+      i_enable_companding: false
       i_enable_decimation_filter: false
       i_enable_distortion_correction: true
       i_enable_spatial_filter: false

--- a/depthai_ros_driver/config/camera.yaml
+++ b/depthai_ros_driver/config/camera.yaml
@@ -90,6 +90,7 @@
       i_board_socket_id: 0
       i_depth_filter_size: 5
       i_depth_preset: HIGH_ACCURACY
+      i_disparity_width: DISPARITY_96
       i_enable_decimation_filter: false
       i_enable_distortion_correction: true
       i_enable_spatial_filter: false

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -25,6 +25,7 @@ class StereoParamHandler : public BaseParamHandler {
 
    private:
     std::unordered_map<std::string, dai::node::StereoDepth::PresetMode> depthPresetMap;
+    std::unordered_map<std::string, dai::StereoDepthConfig::CostMatching::DisparityWidth> disparityWidthMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode> decimationModeMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode> temporalPersistencyMap;
 };

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -86,6 +86,9 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     auto config = stereo->initialConfig.get();
     config.costMatching.disparityWidth =
         utils::getValFromMap(declareAndLogParam<std::string>("i_disparity_width", "DISPARITY_96"), disparityWidthMap);
+    if(!config.algorithmControl.enableExtended) {
+        config.costMatching.enableCompanding = declareAndLogParam<bool>("i_enable_companding", false);
+    }
     config.postProcessing.temporalFilter.enable = declareAndLogParam<bool>("i_enable_temporal_filter", false);
     if(config.postProcessing.temporalFilter.enable) {
         config.postProcessing.temporalFilter.alpha = declareAndLogParam<float>("i_temporal_filter_alpha", 0.4);

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -72,7 +72,10 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     stereo->initialConfig.setLeftRightCheckThreshold(declareAndLogParam<int>("i_lrc_threshold", 10));
     stereo->initialConfig.setMedianFilter(static_cast<dai::MedianFilter>(declareAndLogParam<int>("i_depth_filter_size", 5)));
     stereo->initialConfig.setConfidenceThreshold(declareAndLogParam<int>("i_stereo_conf_threshold", 255));
-    stereo->initialConfig.setSubpixel(declareAndLogParam<bool>("i_subpixel", false));
+    if(declareAndLogParam<bool>("i_subpixel", false)) {
+        stereo->initialConfig.setSubpixel(true);
+        stereo->initialConfig.setSubpixelFractionalBits(declareAndLogParam<int>("i_subpixel_fractional_bits", 3));
+    }
     stereo->setExtendedDisparity(declareAndLogParam<bool>("i_extended_disp", false));
     stereo->setRectifyEdgeFillColor(declareAndLogParam<int>("i_rectify_edge_fill_color", 0));
     auto config = stereo->initialConfig.get();

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -13,6 +13,12 @@ StereoParamHandler::StereoParamHandler(rclcpp::Node* node, const std::string& na
         {"HIGH_ACCURACY", dai::node::StereoDepth::PresetMode::HIGH_ACCURACY},
         {"HIGH_DENSITY", dai::node::StereoDepth::PresetMode::HIGH_DENSITY},
     };
+
+    disparityWidthMap = {
+        {"DISPARITY_64", dai::StereoDepthConfig::CostMatching::DisparityWidth::DISPARITY_64},
+        {"DISPARITY_96", dai::StereoDepthConfig::CostMatching::DisparityWidth::DISPARITY_96},
+    };
+
     decimationModeMap = {{"PIXEL_SKIPPING", dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode::PIXEL_SKIPPING},
                          {"NON_ZERO_MEDIAN", dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode::NON_ZERO_MEDIAN},
                          {"NON_ZERO_MEAN", dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode::NON_ZERO_MEAN}};
@@ -27,7 +33,6 @@ StereoParamHandler::StereoParamHandler(rclcpp::Node* node, const std::string& na
         {"VALID_1_IN_LAST_5", dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode::VALID_1_IN_LAST_5},
         {"VALID_1_IN_LAST_8", dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode::VALID_1_IN_LAST_8},
         {"PERSISTENCY_INDEFINITELY", dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode::PERSISTENCY_INDEFINITELY},
-
     };
 }
 
@@ -79,6 +84,8 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     stereo->setExtendedDisparity(declareAndLogParam<bool>("i_extended_disp", false));
     stereo->setRectifyEdgeFillColor(declareAndLogParam<int>("i_rectify_edge_fill_color", 0));
     auto config = stereo->initialConfig.get();
+    config.costMatching.disparityWidth =
+        utils::getValFromMap(declareAndLogParam<std::string>("i_disparity_width", "DISPARITY_96"), disparityWidthMap);
     config.postProcessing.temporalFilter.enable = declareAndLogParam<bool>("i_enable_temporal_filter", false);
     if(config.postProcessing.temporalFilter.enable) {
         config.postProcessing.temporalFilter.alpha = declareAndLogParam<float>("i_temporal_filter_alpha", 0.4);


### PR DESCRIPTION
Adding these options can help with better Stereo Depth tuning.

Using DISPARITY_64 alone is not a good idea. But it's not the same when using it with other parameters. The doc says "Median filter postprocessing is supported only for 3 fractional bits". This is because the median filter supports a maximum of 1024 Disparity. For DISPARITY_96 and 4 fractional bits, the maximun disparity is 1520. However, for DISPARITY_64 and 4 fractional bits, the maximum disparity is 1008, which is just below the limit. Another choice is to use DISPARITY_64 with extended disparity and 3 fractional bits. It's maximun disparity is also 1008. Which means the disparity range is increased to 126, while median filter is still available.

Another way to increase disparity range is to enable Companding. Unlike extended disparity, it does not consume more HW resources. So it is useful for high resolution inputs.

After adding these options, I found the following two sets of good parameter combinations.
```
/oak:
  ros__parameters:
    stereo:
      i_depth_filter_size: 5
      i_disparity_width: DISPARITY_64
      i_enable_companding: false
      i_extended_disp: true
      i_subpixel: true
      i_subpixel_fractional_bits: 3
```
```
/oak:
  ros__parameters:
    stereo:
      i_depth_filter_size: 5
      i_disparity_width: DISPARITY_64
      i_enable_companding: true
      i_extended_disp: false
      i_subpixel: true
      i_subpixel_fractional_bits: 4
```