### PR TITLE
Add publisher_name to enable multiple YOLO cameras

### DIFF
--- a/depthai_examples/launch/yolov4_publisher.launch
+++ b/depthai_examples/launch/yolov4_publisher.launch
@@ -5,6 +5,7 @@
     <arg name="tf_prefix"             default="oak"         />
     <arg name="base_frame"            default="oak-d_frame" />
     <arg name="parent_frame"          default="oak-d-base-frame" />
+    <arg name="publisher_name"        default="yolov4_publisher" />
 
     <arg name="cam_pos_x"             default="0.0" /> <!-- Position respect to base frame (i.e. "base_link) -->
     <arg name="cam_pos_y"             default="0.0" /> <!-- Position respect to base frame (i.e. "base_link) -->
@@ -35,7 +36,7 @@
         <arg name="cam_yaw"         value="$(arg  cam_yaw)"     />
     </include>
 
-    <node name="yolov4_publisher" pkg="depthai_examples" type="yolov4_spatial_node" output="screen" required="true">
+    <node name="$(arg publisher_name)" pkg="depthai_examples" type="yolov4_spatial_node" output="screen" required="true">
         <param name="tf_prefix"           value="$(arg tf_prefix)"     />
         <param name="camera_param_uri"    value="$(arg camera_param_uri)"/>
         <param name="sync_nn"             value="$(arg sync_nn)"/>


### PR DESCRIPTION
Trying to launch multiple OAK-D devices with `yolov4_publisher.launch` results in the following errors, which shut down any additional nodes:
```
[ WARN] [1682021846.705231965]: Shutdown request received.
[ WARN] [1682021846.706189721]: Reason given for shutdown: [[/oak_state_publisher] Reason: new node registered with same name]
[ WARN] [1682021846.871090300]: Shutdown request received.
[ WARN] [1682021846.871929326]: Reason given for shutdown: [[/yolov4_publisher] Reason: new node registered with same name]
```

Additional `oak_state_publisher` instances can be launched by adjusting `camera_model`, `tf_prefix`, or `base_frame` arguments when launching `yolov4_publisher.launch`, but there are no arguments to enable multiple `yolov4_spatial_node` instances. This edit allows a node name to be specified as an argument, preventing the shutdown request and enabling multiple OAK-Ds to be launched with `yolov4_publisher.launch`.
