### PR TITLE
Update Depth Alignment

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -20,7 +20,7 @@ class StereoParamHandler : public BaseParamHandler {
    public:
     explicit StereoParamHandler(rclcpp::Node* node, const std::string& name);
     ~StereoParamHandler();
-    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& rightName);
+    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& leftName, const std::string& rightName);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
 
    private:

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -32,7 +32,7 @@ Stereo::Stereo(const std::string& daiNodeName,
     right = std::make_unique<SensorWrapper>(rightInfo.name, node, pipeline, device, rightInfo.socket, false);
 
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
-    ph->declareParams(stereoCamNode, rightInfo.name);
+    ph->declareParams(stereoCamNode, leftInfo.name, rightInfo.name);
     setXinXout(pipeline);
     left->link(stereoCamNode->left);
     right->link(stereoCamNode->right);
@@ -152,7 +152,17 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     stereoQ = device->getOutputQueue(stereoQName, ph->getParam<int>("i_max_q_size"), false);
     std::string tfPrefix;
     if(ph->getParam<bool>("i_align_depth")) {
-        tfPrefix = getTFPrefix("rgb");
+        switch(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))) {
+            case dai::CameraBoardSocket::RGB:
+                tfPrefix = getTFPrefix("rgb");
+                break;
+            case dai::CameraBoardSocket::LEFT:
+                tfPrefix = getTFPrefix(leftSensInfo.name);
+                break;
+            default:
+                tfPrefix = getTFPrefix(rightSensInfo.name);
+                break;
+        }
     } else {
         tfPrefix = getTFPrefix(rightSensInfo.name);
     }

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -37,14 +37,14 @@ StereoParamHandler::StereoParamHandler(rclcpp::Node* node, const std::string& na
 }
 
 StereoParamHandler::~StereoParamHandler() = default;
-void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& rightName) {
+void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& leftName, const std::string& rightName) {
     declareAndLogParam<int>("i_max_q_size", 30);
     declareAndLogParam<bool>("i_low_bandwidth", false);
     declareAndLogParam<int>("i_low_bandwidth_quality", 50);
     declareAndLogParam<bool>("i_output_disparity", false);
     declareAndLogParam<bool>("i_get_base_device_timestamp", false);
     declareAndLogParam<bool>("i_publish_topic", true);
-    
+
     declareAndLogParam<bool>("i_publish_left_rect", false);
     declareAndLogParam<bool>("i_left_rect_low_bandwidth", false);
     declareAndLogParam<int>("i_left_rect_low_bandwidth_quality", 50);
@@ -56,28 +56,38 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     stereo->setLeftRightCheck(declareAndLogParam<bool>("i_lr_check", true));
     int width = 1280;
     int height = 720;
-    dai::CameraBoardSocket socket = dai::CameraBoardSocket::RIGHT;
     if(declareAndLogParam<bool>("i_align_depth", true)) {
-        try {
-            width = getROSNode()->get_parameter("rgb.i_width").as_int();
-            height = getROSNode()->get_parameter("rgb.i_height").as_int();
-            socket = static_cast<dai::CameraBoardSocket>(getROSNode()->get_parameter("rgb.i_board_socket_id").as_int());
-        } catch(rclcpp::exceptions::ParameterNotDeclaredException& e) {
-            RCLCPP_ERROR(getROSNode()->get_logger(), "RGB parameters not set, defaulting to 1280x720 unless specified otherwise.");
-        }
-
-    } else {
-        try {
-            width = getROSNode()->get_parameter(rightName + ".i_width").as_int();
-            height = getROSNode()->get_parameter(rightName + ".i_height").as_int();
-            socket = static_cast<dai::CameraBoardSocket>(getROSNode()->get_parameter(rightName + ".i_board_socket_id").as_int());
-        } catch(rclcpp::exceptions::ParameterNotDeclaredException& e) {
-            RCLCPP_ERROR(getROSNode()->get_logger(), "Right parameters not set, defaulting to 1280x720 unless specified otherwise.");
+        switch(static_cast<dai::CameraBoardSocket>(declareAndLogParam<int>("i_board_socket_id", static_cast<int>(dai::CameraBoardSocket::RGB)))) {
+            case dai::CameraBoardSocket::RGB:
+                stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+                try {
+                    width = getROSNode()->get_parameter("rgb.i_width").as_int();
+                    height = getROSNode()->get_parameter("rgb.i_height").as_int();
+                } catch(rclcpp::exceptions::ParameterNotDeclaredException& e) {
+                    RCLCPP_ERROR(getROSNode()->get_logger(), "RGB parameters not set, defaulting to 1280x720 unless specified otherwise.");
+                }
+                break;
+            case dai::CameraBoardSocket::LEFT:
+                stereo->setDepthAlign(dai::StereoDepthProperties::DepthAlign::RECTIFIED_LEFT);
+                try {
+                    width = getROSNode()->get_parameter(leftName + ".i_width").as_int();
+                    height = getROSNode()->get_parameter(leftName + ".i_height").as_int();
+                } catch(rclcpp::exceptions::ParameterNotDeclaredException& e) {
+                    RCLCPP_ERROR(getROSNode()->get_logger(), "Left parameters not set, defaulting to 1280x720 unless specified otherwise.");
+                }
+                break;
+            default:
+                stereo->setDepthAlign(dai::StereoDepthProperties::DepthAlign::RECTIFIED_RIGHT);
+                try {
+                    width = getROSNode()->get_parameter(rightName + ".i_width").as_int();
+                    height = getROSNode()->get_parameter(rightName + ".i_height").as_int();
+                } catch(rclcpp::exceptions::ParameterNotDeclaredException& e) {
+                    RCLCPP_ERROR(getROSNode()->get_logger(), "Right parameters not set, defaulting to 1280x720 unless specified otherwise.");
+                }
+                break;
         }
     }
-    declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket));
-    stereo->setDepthAlign(socket);
-            
+
     if(declareAndLogParam<bool>("i_set_input_size", false)) {
         stereo->setInputResolution(declareAndLogParam<int>("i_input_width", 1280), declareAndLogParam<int>("i_input_height", 720));
     }


### PR DESCRIPTION
There is currently a misalignment issue using setDepthAlign(CameraBoardSocket camera). So I changed to use setDepthAlign(Properties::DepthAlign align). I also created an issue for this in https://github.com/luxonis/depthai-core/issues/840.

In addition, OAK cameras align depth image to DepthAlign::RECTIFIED_RIGHT by default. But for the convention of many applications, including OpenCV, depth image is aligned to the left camera. So I added this part of options, but the default behavior is still align to the right camera.