### PR TITLE
Handle ROS Time Shifts and C++14 Build Issue

### DIFF
--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -32,11 +32,10 @@ class DisparityConverter {
 
     /**
      * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
-     * 
+     *
      * @param update: bool whether to automatically update the ROS base time on message conversion
      */
-    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
-    {
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
         _updateRosBaseTimeOnToRosMsg = update;
     }
 

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -42,7 +42,6 @@ class DisparityConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{ 0 };
-    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -40,6 +40,9 @@ class DisparityConverter {
 
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -26,7 +26,7 @@ class DisparityConverter {
      * @brief Handles cases in which the ROS time shifts forward or backward
      *  Should be called at regular intervals or on-change of ROS time, depending
      *  on monitoring.
-     * 
+     *
      */
     void updateRosBaseTime();
 
@@ -41,7 +41,7 @@ class DisparityConverter {
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
-    int64_t _totalNsChange{ 0 };
+    int64_t _totalNsChange{0};
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -22,6 +22,14 @@ class DisparityConverter {
     DisparityConverter(
         const std::string frameName, float focalLength, float baseline = 7.5, float minDepth = 80, float maxDepth = 1100, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outImageMsg);
     DisparityImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
 

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -30,6 +30,16 @@ class DisparityConverter {
      */
     void updateRosBaseTime();
 
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     * 
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
+    {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outImageMsg);
     DisparityImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
 
@@ -42,6 +52,8 @@ class DisparityConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -38,6 +38,16 @@ class ImageConverter {
      */
     void updateRosBaseTime();
 
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     * 
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
+    {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
     void toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,
                                std::deque<ImageMsgs::Image>& outImageMsgs,
                                dai::RawImgFrame::Type type,
@@ -75,6 +85,8 @@ class ImageConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -29,6 +29,15 @@ class ImageConverter {
     // ImageConverter() = default;
     ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false);
     ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false);
+    
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,
                                std::deque<ImageMsgs::Image>& outImageMsgs,
                                dai::RawImgFrame::Type type,

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -40,11 +40,10 @@ class ImageConverter {
 
     /**
      * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
-     * 
+     *
      * @param update: bool whether to automatically update the ROS base time on message conversion
      */
-    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
-    {
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
         _updateRosBaseTimeOnToRosMsg = update;
     }
 

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -29,12 +29,12 @@ class ImageConverter {
     // ImageConverter() = default;
     ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false);
     ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false);
-    
+
     /**
      * @brief Handles cases in which the ROS time shifts forward or backward
      *  Should be called at regular intervals or on-change of ROS time, depending
      *  on monitoring.
-     * 
+     *
      */
     void updateRosBaseTime();
 
@@ -74,7 +74,7 @@ class ImageConverter {
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
-    int64_t _totalNsChange{ 0 };
+    int64_t _totalNsChange{0};
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -75,7 +75,6 @@ class ImageConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{ 0 };
-    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -73,6 +73,9 @@ class ImageConverter {
 
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -38,6 +38,9 @@ class ImgDetectionConverter {
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -19,6 +19,14 @@ class ImgDetectionConverter {
     // DetectionConverter() = default;
     ImgDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs);
 
     Detection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::ImgDetections> inNetData);

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -23,7 +23,7 @@ class ImgDetectionConverter {
      * @brief Handles cases in which the ROS time shifts forward or backward
      *  Should be called at regular intervals or on-change of ROS time, depending
      *  on monitoring.
-     * 
+     *
      */
     void updateRosBaseTime();
 
@@ -39,7 +39,7 @@ class ImgDetectionConverter {
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
-    int64_t _totalNsChange{ 0 };
+    int64_t _totalNsChange{0};
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -40,7 +40,6 @@ class ImgDetectionConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{ 0 };
-    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -29,11 +29,10 @@ class ImgDetectionConverter {
 
     /**
      * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
-     * 
+     *
      * @param update: bool whether to automatically update the ROS base time on message conversion
      */
-    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
-    {
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
         _updateRosBaseTimeOnToRosMsg = update;
     }
 

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -27,6 +27,16 @@ class ImgDetectionConverter {
      */
     void updateRosBaseTime();
 
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     * 
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
+    {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
     void toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs);
 
     Detection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::ImgDetections> inNetData);
@@ -40,6 +50,8 @@ class ImgDetectionConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -43,11 +43,10 @@ class ImuConverter {
 
     /**
      * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
-     * 
+     *
      * @param update: bool whether to automatically update the ROS base time on message conversion
      */
-    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
-    {
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
         _updateRosBaseTimeOnToRosMsg = update;
     }
 

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -32,6 +32,15 @@ class ImuConverter {
                  double magnetic_field_cov = 0.0,
                  bool enable_rotation = false);
     ~ImuConverter();
+    
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<ImuMsgs::Imu>& outImuMsgs);
     void toRosDaiMsg(std::shared_ptr<dai::IMUData> inData, std::deque<depthai_ros_msgs::ImuWithMagneticField>& outImuMsgs);
 

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -32,12 +32,12 @@ class ImuConverter {
                  double magnetic_field_cov = 0.0,
                  bool enable_rotation = false);
     ~ImuConverter();
-    
+
     /**
      * @brief Handles cases in which the ROS time shifts forward or backward
      *  Should be called at regular intervals or on-change of ROS time, depending
      *  on monitoring.
-     * 
+     *
      */
     void updateRosBaseTime();
 
@@ -120,7 +120,7 @@ class ImuConverter {
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
     // For handling ROS time shifts and debugging
-    int64_t _totalNsChange{ 0 };
+    int64_t _totalNsChange{0};
 
     void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
     void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -119,6 +119,9 @@ class ImuConverter {
     ImuSyncMethod _syncMode;
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 
     void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
     void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -121,7 +121,6 @@ class ImuConverter {
     ::ros::Time _rosBaseTime;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{ 0 };
-    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 
     void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
     void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -41,6 +41,16 @@ class ImuConverter {
      */
     void updateRosBaseTime();
 
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     * 
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
+    {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
     void toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<ImuMsgs::Imu>& outImuMsgs);
     void toRosDaiMsg(std::shared_ptr<dai::IMUData> inData, std::deque<depthai_ros_msgs::ImuWithMagneticField>& outImuMsgs);
 
@@ -121,6 +131,8 @@ class ImuConverter {
     ::ros::Time _rosBaseTime;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
 
     void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
     void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -19,6 +19,14 @@ class SpatialDetectionConverter {
     // DetectionConverter() = default;
     SpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsg);
 
     void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<vision_msgs::Detection3DArray>& opDetectionMsg);

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -23,7 +23,7 @@ class SpatialDetectionConverter {
      * @brief Handles cases in which the ROS time shifts forward or backward
      *  Should be called at regular intervals or on-change of ROS time, depending
      *  on monitoring.
-     * 
+     *
      */
     void updateRosBaseTime();
 
@@ -41,7 +41,7 @@ class SpatialDetectionConverter {
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
-    int64_t _totalNsChange{ 0 };
+    int64_t _totalNsChange{0};
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -29,11 +29,10 @@ class SpatialDetectionConverter {
 
     /**
      * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
-     * 
+     *
      * @param update: bool whether to automatically update the ROS base time on message conversion
      */
-    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
-    {
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
         _updateRosBaseTimeOnToRosMsg = update;
     }
 

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -42,7 +42,6 @@ class SpatialDetectionConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{ 0 };
-    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -40,6 +40,9 @@ class SpatialDetectionConverter {
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -27,6 +27,16 @@ class SpatialDetectionConverter {
      */
     void updateRosBaseTime();
 
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     * 
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true)
+    {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
     void toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsg);
 
     void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<vision_msgs::Detection3DArray>& opDetectionMsg);
@@ -42,6 +52,8 @@ class SpatialDetectionConverter {
     bool _getBaseDeviceTimestamp;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/depthaiUtility.hpp
+++ b/depthai_bridge/include/depthai_bridge/depthaiUtility.hpp
@@ -42,7 +42,7 @@ enum LogLevel { DEBUG, INFO, WARN, ERROR, FATAL };
 
 #define DEPTHAI_ROS_FATAL_STREAM_ONCE(loggerName, args) DEPTHAI_ROS_LOG_STREAM(loggerName, dai::ros::LogLevel::FATAL, true, args)
 
-static const int64_t ZERO_TIME_DELTA_NS { 100 };
+static const int64_t ZERO_TIME_DELTA_NS{100};
 
 inline ::ros::Time getFrameTime(::ros::Time rosBaseTime,
                                 std::chrono::time_point<std::chrono::steady_clock> steadyBaseTime,
@@ -55,12 +55,9 @@ inline ::ros::Time getFrameTime(::ros::Time rosBaseTime,
     return rosStamp;
 }
 
-inline void updateBaseTime(std::chrono::time_point<std::chrono::steady_clock> steadyBaseTime,
-                               ::ros::Time &rosBaseTime,
-                               int64_t &totalNsChange) {
+inline void updateBaseTime(std::chrono::time_point<std::chrono::steady_clock> steadyBaseTime, ::ros::Time& rosBaseTime, int64_t& totalNsChange) {
     ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime = std::chrono::steady_clock::now();
     // In nanoseconds
     auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - steadyBaseTime).count();
     uint64_t previousBaseTimeNs = rosBaseTime.toNSec();
@@ -68,12 +65,11 @@ inline void updateBaseTime(std::chrono::time_point<std::chrono::steady_clock> st
     uint64_t newBaseTimeNs = rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
     totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
+    if(::abs(diff) > ZERO_TIME_DELTA_NS) {
         // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(totalNsChange) << " ns. New time: " <<
-            std::to_string(rosBaseTime.toNSec()) << " ns.");
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ",
+                                 "ROS base time changed by " << std::to_string(diff) << " ns. Total change: " << std::to_string(totalNsChange)
+                                                             << " ns. New time: " << std::to_string(rosBaseTime.toNSec()) << " ns.");
     }
 }
 

--- a/depthai_bridge/include/depthai_bridge/depthaiUtility.hpp
+++ b/depthai_bridge/include/depthai_bridge/depthaiUtility.hpp
@@ -42,6 +42,8 @@ enum LogLevel { DEBUG, INFO, WARN, ERROR, FATAL };
 
 #define DEPTHAI_ROS_FATAL_STREAM_ONCE(loggerName, args) DEPTHAI_ROS_LOG_STREAM(loggerName, dai::ros::LogLevel::FATAL, true, args)
 
+static const int64_t ZERO_TIME_DELTA_NS { 100 };
+
 inline ::ros::Time getFrameTime(::ros::Time rosBaseTime,
                                 std::chrono::time_point<std::chrono::steady_clock> steadyBaseTime,
                                 std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration> currTimePoint) {
@@ -51,6 +53,28 @@ inline ::ros::Time getFrameTime(::ros::Time rosBaseTime,
     auto rosStamp = currTime.fromNSec(nSec);
     DEPTHAI_ROS_DEBUG_STREAM("PRINT TIMESTAMP: ", "rosStamp -> " << rosStamp << "  rosBaseTime -> " << rosBaseTime);
     return rosStamp;
+}
+
+inline void updateBaseTime(std::chrono::time_point<std::chrono::steady_clock> steadyBaseTime,
+                               ::ros::Time &rosBaseTime,
+                               int64_t &totalNsChange) {
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = rosBaseTime.toNSec();
+    rosBaseTime = rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns. Total change: " << std::to_string(totalNsChange) << " ns. New time: " <<
+            std::to_string(rosBaseTime.toNSec()) << " ns.");
+    }
 }
 
 template <typename T>

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -24,8 +24,7 @@ void DisparityConverter::updateRosBaseTime() {
 }
 
 void DisparityConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outDispImageMsgs) {
-    if(_updateRosBaseTimeOnToRosMsg)
-    {
+    if(_updateRosBaseTimeOnToRosMsg) {
         updateRosBaseTime();
     }
     std::chrono::_V2::steady_clock::time_point tstamp;

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -30,11 +30,13 @@ void DisparityConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -21,24 +21,7 @@ DisparityConverter::DisparityConverter(
 
 void DisparityConverter::updateRosBaseTime()
 {
-    ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
-    // In nanoseconds
-    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
-    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
-    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
-    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
-    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    _totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
-        // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
-            std::to_string(_rosBaseTime.toNSec()) << " ns.");
-    }
-
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
 void DisparityConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outDispImageMsgs) {

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -19,8 +19,7 @@ DisparityConverter::DisparityConverter(
     _rosBaseTime = ::ros::Time::now();
 }
 
-void DisparityConverter::updateRosBaseTime()
-{
+void DisparityConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -24,6 +24,10 @@ void DisparityConverter::updateRosBaseTime() {
 }
 
 void DisparityConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outDispImageMsgs) {
+    if(_updateRosBaseTimeOnToRosMsg)
+    {
+        updateRosBaseTime();
+    }
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)
         tstamp = inData->getTimestampDevice();

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -96,8 +96,7 @@ void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData
 }
 
 void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<ImageMsgs::Image>& outImageMsgs) {
-    if(_updateRosBaseTimeOnToRosMsg)
-    {
+    if(_updateRosBaseTimeOnToRosMsg) {
         updateRosBaseTime();
     }
     std::chrono::_V2::steady_clock::time_point tstamp;

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -45,11 +45,13 @@ void ImageConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -34,6 +34,26 @@ ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bo
     _rosBaseTime = ::ros::Time::now();
 }
 
+void ImageConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,
                                            std::deque<ImageMsgs::Image>& outImageMsgs,
                                            dai::RawImgFrame::Type type,

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -96,6 +96,10 @@ void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData
 }
 
 void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<ImageMsgs::Image>& outImageMsgs) {
+    if(_updateRosBaseTimeOnToRosMsg)
+    {
+        updateRosBaseTime();
+    }
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)
         tstamp = inData->getTimestampDevice();

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -36,24 +36,7 @@ ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bo
 
 void ImageConverter::updateRosBaseTime()
 {
-    ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
-    // In nanoseconds
-    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
-    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
-    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
-    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
-    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    _totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
-        // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
-            std::to_string(_rosBaseTime.toNSec()) << " ns.");
-    }
-
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
 void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -34,8 +34,7 @@ ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bo
     _rosBaseTime = ::ros::Time::now();
 }
 
-void ImageConverter::updateRosBaseTime()
-{
+void ImageConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -16,8 +16,7 @@ ImgDetectionConverter::ImgDetectionConverter(std::string frameName, int width, i
     _rosBaseTime = ::ros::Time::now();
 }
 
-void ImgDetectionConverter::updateRosBaseTime()
-{
+void ImgDetectionConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -21,8 +21,7 @@ void ImgDetectionConverter::updateRosBaseTime() {
 }
 
 void ImgDetectionConverter::toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
-    if(_updateRosBaseTimeOnToRosMsg)
-    {
+    if(_updateRosBaseTimeOnToRosMsg) {
         updateRosBaseTime();
     }
     // setting the header

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -21,6 +21,10 @@ void ImgDetectionConverter::updateRosBaseTime() {
 }
 
 void ImgDetectionConverter::toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+    if(_updateRosBaseTimeOnToRosMsg)
+    {
+        updateRosBaseTime();
+    }
     // setting the header
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -18,24 +18,7 @@ ImgDetectionConverter::ImgDetectionConverter(std::string frameName, int width, i
 
 void ImgDetectionConverter::updateRosBaseTime()
 {
-    ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
-    // In nanoseconds
-    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
-    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
-    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
-    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
-    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    _totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
-        // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
-            std::to_string(_rosBaseTime.toNSec()) << " ns.");
-    }
-
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
 void ImgDetectionConverter::toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -27,11 +27,13 @@ void ImgDetectionConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -39,11 +39,13 @@ void ImuConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -30,24 +30,7 @@ ImuConverter::~ImuConverter() = default;
 
 void ImuConverter::updateRosBaseTime()
 {
-    ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
-    // In nanoseconds
-    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
-    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
-    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
-    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
-    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    _totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
-        // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
-            std::to_string(_rosBaseTime.toNSec()) << " ns.");
-    }
-
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
 void ImuConverter::fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg) {

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -28,6 +28,26 @@ ImuConverter::ImuConverter(const std::string& frameName,
 
 ImuConverter::~ImuConverter() = default;
 
+void ImuConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void ImuConverter::fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg) {
     msg.linear_acceleration.x = report.x;
     msg.linear_acceleration.y = report.y;

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -86,8 +86,7 @@ void ImuConverter::fillImuMsg(dai::IMUReportMagneticField report, depthai_ros_ms
 }
 
 void ImuConverter::toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<ImuMsgs::Imu>& outImuMsgs) {
-    if(_updateRosBaseTimeOnToRosMsg)
-    {
+    if(_updateRosBaseTimeOnToRosMsg) {
         updateRosBaseTime();
     }
     if(_syncMode != ImuSyncMethod::COPY) {

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -28,8 +28,7 @@ ImuConverter::ImuConverter(const std::string& frameName,
 
 ImuConverter::~ImuConverter() = default;
 
-void ImuConverter::updateRosBaseTime()
-{
+void ImuConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -86,6 +86,10 @@ void ImuConverter::fillImuMsg(dai::IMUReportMagneticField report, depthai_ros_ms
 }
 
 void ImuConverter::toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<ImuMsgs::Imu>& outImuMsgs) {
+    if(_updateRosBaseTimeOnToRosMsg)
+    {
+        updateRosBaseTime();
+    }
     if(_syncMode != ImuSyncMethod::COPY) {
         FillImuData_LinearInterpolation(inData->packets, outImuMsgs);
     } else {

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -21,8 +21,7 @@ void SpatialDetectionConverter::updateRosBaseTime() {
 
 void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,
                                          std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsgs) {
-    if(_updateRosBaseTimeOnToRosMsg)
-    {
+    if(_updateRosBaseTimeOnToRosMsg) {
         updateRosBaseTime();
     }
     // setting the header

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -21,6 +21,10 @@ void SpatialDetectionConverter::updateRosBaseTime() {
 
 void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,
                                          std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsgs) {
+    if(_updateRosBaseTimeOnToRosMsg)
+    {
+        updateRosBaseTime();
+    }
     // setting the header
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -15,6 +15,26 @@ SpatialDetectionConverter::SpatialDetectionConverter(std::string frameName, int 
     _rosBaseTime = ::ros::Time::now();
 }
 
+void SpatialDetectionConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,
                                          std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsgs) {
     // setting the header

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -26,11 +26,13 @@ void SpatialDetectionConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -17,24 +17,7 @@ SpatialDetectionConverter::SpatialDetectionConverter(std::string frameName, int 
 
 void SpatialDetectionConverter::updateRosBaseTime()
 {
-    ::ros::Time currentRosTime = ::ros::Time::now();
-    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
-        std::chrono::steady_clock::now();
-    // In nanoseconds
-    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
-    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
-    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
-    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
-    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    _totalNsChange += diff;
-    if(::abs(diff) > ZERO_TIME_DELTA_NS)
-    {
-        // Has been updated
-        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
-            std::to_string(_rosBaseTime.toNSec()) << " ns.");
-    }
-
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
 void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -15,8 +15,7 @@ SpatialDetectionConverter::SpatialDetectionConverter(std::string frameName, int 
     _rosBaseTime = ::ros::Time::now();
 }
 
-void SpatialDetectionConverter::updateRosBaseTime()
-{
+void SpatialDetectionConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 

--- a/depthai_examples/launch/stereo_inertial_node.launch
+++ b/depthai_examples/launch/stereo_inertial_node.launch
@@ -58,6 +58,8 @@
     <arg name="enableRviz"            default="true"/>
     <arg name="enableMarkerPublish"   default="false" />
 
+    <arg name="enableRosBaseTimeUpdate" default="false" />  <!-- Used to handle when ROS time shifts and steady_clock does not -->
+
     <include file="$(find depthai_descriptions)/launch/urdf.launch">
         <arg name="base_frame"      value="$(arg  base_frame)"  />
         <arg name="parent_frame"    value="$(arg  parent_frame)"/>
@@ -114,6 +116,7 @@
         <param name="enableFloodLight"      value="$(arg enableFloodLight)" />
         <param name="dotProjectormA"        value="$(arg dotProjectormA)" />
         <param name="floodLightmA"          value="$(arg floodLightmA)" />
+        <param name="enableRosBaseTimeUpdate" value="$(arg enableRosBaseTimeUpdate)" />
     </node>            
 
     <node pkg="nodelet" type="nodelet" name="nodelet_manager"  args="manager" output="screen"/>

--- a/depthai_examples/src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/src/stereo_inertial_publisher.cpp
@@ -456,21 +456,18 @@ int main(int argc, char** argv) {
     }
 
     dai::rosBridge::ImageConverter converter(tfPrefix + "_left_camera_optical_frame", true);
-    if(enableRosBaseTimeUpdate)
-    {
+    if(enableRosBaseTimeUpdate) {
         converter.setUpdateRosBaseTimeOnToRosMsg();
     }
     dai::rosBridge::ImageConverter rightconverter(tfPrefix + "_right_camera_optical_frame", true);
-    if(enableRosBaseTimeUpdate)
-    {
+    if(enableRosBaseTimeUpdate) {
         rightconverter.setUpdateRosBaseTimeOnToRosMsg();
     }
     const std::string leftPubName = rectify ? std::string("left/image_rect") : std::string("left/image_raw");
     const std::string rightPubName = rectify ? std::string("right/image_rect") : std::string("right/image_raw");
 
     dai::rosBridge::ImuConverter imuConverter(tfPrefix + "_imu_frame", imuMode, linearAccelCovariance, angularVelCovariance);
-    if(enableRosBaseTimeUpdate)
-    {
+    if(enableRosBaseTimeUpdate) {
         imuConverter.setUpdateRosBaseTimeOnToRosMsg();
     }
 
@@ -493,8 +490,7 @@ int main(int argc, char** argv) {
     */
 
     dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
-    if(enableRosBaseTimeUpdate)
-    {
+    if(enableRosBaseTimeUpdate) {
         rgbConverter.setUpdateRosBaseTimeOnToRosMsg();
     }
     if(enableDepth) {

--- a/depthai_examples/src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/src/stereo_inertial_publisher.cpp
@@ -291,6 +291,7 @@ int main(int argc, char** argv) {
     int rgbScaleNumerator, rgbScaleDinominator, previewWidth, previewHeight;
     bool lrcheck, extended, subpixel, enableDepth, rectify, depth_aligned, manualExposure;
     bool enableSpatialDetection, enableDotProjector, enableFloodLight;
+    bool enableRosBaseTimeUpdate;
     bool usb2Mode, poeMode, syncNN;
     double angularVelCovariance, linearAccelCovariance;
     double dotProjectormA, floodLightmA;
@@ -330,6 +331,8 @@ int main(int argc, char** argv) {
     badParams += !pnh.getParam("enableSpatialDetection", enableSpatialDetection);
     badParams += !pnh.getParam("detectionClassesCount", detectionClassesCount);
     badParams += !pnh.getParam("syncNN", syncNN);
+
+    badParams += !pnh.getParam("enableRosBaseTimeUpdate", enableRosBaseTimeUpdate);
 
     // Applies only to PRO model
     badParams += !pnh.getParam("enableDotProjector", enableDotProjector);
@@ -453,11 +456,23 @@ int main(int argc, char** argv) {
     }
 
     dai::rosBridge::ImageConverter converter(tfPrefix + "_left_camera_optical_frame", true);
+    if(enableRosBaseTimeUpdate)
+    {
+        converter.setUpdateRosBaseTimeOnToRosMsg();
+    }
     dai::rosBridge::ImageConverter rightconverter(tfPrefix + "_right_camera_optical_frame", true);
+    if(enableRosBaseTimeUpdate)
+    {
+        rightconverter.setUpdateRosBaseTimeOnToRosMsg();
+    }
     const std::string leftPubName = rectify ? std::string("left/image_rect") : std::string("left/image_raw");
     const std::string rightPubName = rectify ? std::string("right/image_rect") : std::string("right/image_raw");
 
     dai::rosBridge::ImuConverter imuConverter(tfPrefix + "_imu_frame", imuMode, linearAccelCovariance, angularVelCovariance);
+    if(enableRosBaseTimeUpdate)
+    {
+        imuConverter.setUpdateRosBaseTimeOnToRosMsg();
+    }
 
     dai::rosBridge::BridgePublisher<sensor_msgs::Imu, dai::IMUData> imuPublish(
         imuQueue,
@@ -478,6 +493,10 @@ int main(int argc, char** argv) {
     */
 
     dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+    if(enableRosBaseTimeUpdate)
+    {
+        rgbConverter.setUpdateRosBaseTimeOnToRosMsg();
+    }
     if(enableDepth) {
         auto rightCameraInfo = converter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::RIGHT, width, height);
 

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_compile_options(-g)
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 ## is used, also find other catkin packages
 if(POLICY CMP0057)


### PR DESCRIPTION
## Overview
Author: @chacalnoir, @IntelligentJackal

## Issue
* ROS time updates are not always consistent with c++ steady_clock. Even when ROS time is running real-time without pausing, starting, stopping, etc., it has the ability to jump forward and backward. Since the converters use steady_clock, this means there is a time offset that often results in future timestamps and typically results in incorrectly located detections for a moving sensor.
* When building on an Ubuntu 20.04 system with ROS noetic, std::make_unique was not defined. std::make_unique is a C++14 capability, and the c++11 flag seemed to be messing up the build. Changing the flag to c++14 fixed the issue.

## Changes
* This PR adds the ability to reset the ROS base time by expecting that the ROS time update will be consistent with the steady_clock update. If they are not, the ROS base time is adjusted to result in a consistent time at the moment of call.
* If a user does not wish to use this capability, never calling this function results in the code acting the same as it always has.
* The build flag was updated from C++11 to C++14 to fix the build issue with std::make_unique

## Testing
This has been tested on an Ubuntu 20.04 system, ROS noetic, with the new function being called at regular intervals. The results were that the ROS base time was updated as expected.