### PR TITLE
Add CameraExposureOffset and Fix Disparity to Depth Computation

### DIFF
--- a/depthai_bridge/include/depthai_bridge/BridgePublisher.hpp
+++ b/depthai_bridge/include/depthai_bridge/BridgePublisher.hpp
@@ -29,7 +29,7 @@ class BridgePublisher {
     using ConvertFunc = std::function<void(std::shared_ptr<SimMsg>, std::deque<RosMsg>&)>;
 
     using CustomPublisher = typename std::
-        conditional<std::is_same<RosMsg, ImageMsgs::Image>::value, std::shared_ptr<image_transport::Publisher>, std::shared_ptr<rosOrigin::Publisher> >::type;
+        conditional<std::is_same<RosMsg, ImageMsgs::Image>::value, std::shared_ptr<image_transport::Publisher>, std::shared_ptr<rosOrigin::Publisher>>::type;
 
     BridgePublisher(std::shared_ptr<dai::DataOutputQueue> daiMessageQueue,
                     rosOrigin::NodeHandle nh,
@@ -45,7 +45,12 @@ class BridgePublisher {
                     ConvertFunc converter,
                     int queueSize,
                     ImageMsgs::CameraInfo cameraInfoData,
-                    std::string cameraName);
+                    std::string cameraName,
+                    std::vector<std::shared_ptr<dai::DataOutputQueue>> syncImageQueues = {},
+                    std::vector<std::string> syncImageTopics = {},
+                    std::vector<std::function<void(std::shared_ptr<dai::ImgFrame>, std::deque<ImageMsgs::Image>&)>> syncImageConverters = {},
+                    std::vector<ImageMsgs::CameraInfo> syncCameraInfo = {},
+                    std::vector<std::string> syncCameraNames = {});
 
     /**
      * Tag Dispacher function to to overload the Publisher to ImageTransport Publisher
@@ -76,18 +81,23 @@ class BridgePublisher {
 
     static const std::string LOG_TAG;
     std::shared_ptr<dai::DataOutputQueue> _daiMessageQueue;
+    std::vector<std::shared_ptr<dai::DataOutputQueue>> _syncImageQueues;
     ConvertFunc _converter;
+    std::vector<std::function<void(std::shared_ptr<dai::ImgFrame>, std::deque<ImageMsgs::Image>&)>> _syncImageConverters;
 
     rosOrigin::NodeHandle _nh;
     std::shared_ptr<rosOrigin::Publisher> _cameraInfoPublisher;
+    std::vector<std::shared_ptr<rosOrigin::Publisher>> _syncCameraInfoPublishers;
 
     image_transport::ImageTransport _it;
     ImageMsgs::CameraInfo _cameraInfoData;
     CustomPublisher _rosPublisher;
+    std::vector<std::shared_ptr<image_transport::Publisher>> _syncImagePublishers;
 
     std::thread _readingThread;
     std::string _rosTopic, _camInfoFrameId, _cameraName, _cameraParamUri;
     std::unique_ptr<camera_info_manager::CameraInfoManager> _camInfoManager;
+    std::vector<std::unique_ptr<camera_info_manager::CameraInfoManager>> _syncCamInfoManagers;
     bool _isCallbackAdded = false;
     bool _isImageMessage = false;  // used to enable camera info manager
 };
@@ -115,22 +125,43 @@ BridgePublisher<RosMsg, SimMsg>::BridgePublisher(std::shared_ptr<dai::DataOutput
 }
 
 template <class RosMsg, class SimMsg>
-BridgePublisher<RosMsg, SimMsg>::BridgePublisher(std::shared_ptr<dai::DataOutputQueue> daiMessageQueue,
-                                                 rosOrigin::NodeHandle nh,
-                                                 std::string rosTopic,
-                                                 ConvertFunc converter,
-                                                 int queueSize,
-                                                 ImageMsgs::CameraInfo cameraInfoData,
-                                                 std::string cameraName)
+BridgePublisher<RosMsg, SimMsg>::BridgePublisher(
+    std::shared_ptr<dai::DataOutputQueue> daiMessageQueue,
+    rosOrigin::NodeHandle nh,
+    std::string rosTopic,
+    ConvertFunc converter,
+    int queueSize,
+    ImageMsgs::CameraInfo cameraInfoData,
+    std::string cameraName,
+    std::vector<std::shared_ptr<dai::DataOutputQueue>> syncImageQueues,
+    std::vector<std::string> syncImageTopics,
+    std::vector<std::function<void(std::shared_ptr<dai::ImgFrame>, std::deque<ImageMsgs::Image>&)>> syncImageConverters,
+    std::vector<ImageMsgs::CameraInfo> syncCameraInfo,
+    std::vector<std::string> syncCameraNames)
     : _daiMessageQueue(daiMessageQueue),
       _nh(nh),
       _converter(converter),
       _it(_nh),
       _cameraInfoData(cameraInfoData),
       _rosTopic(rosTopic),
-      _cameraName(cameraName) {
+      _cameraName(cameraName),
+      _syncImageQueues(syncImageQueues),
+      _syncImageConverters(syncImageConverters) {
     // ROS_DEBUG_STREAM_NAMED(LOG_TAG, "Publisher Type : " << typeid(CustomPublisher).name());
     _rosPublisher = advertise(queueSize, std::is_same<RosMsg, ImageMsgs::Image>{});
+    if((syncImageQueues.size() | syncImageTopics.size() | syncImageConverters.size() | syncCameraInfo.size() | syncCameraNames.size())
+       == (syncImageQueues.size() & syncImageTopics.size() & syncImageConverters.size() & syncCameraInfo.size() & syncCameraNames.size())) {
+        for(size_t i = 0; i < syncImageTopics.size(); i++) {
+            _syncCamInfoManagers.emplace_back(
+                std::make_unique<camera_info_manager::CameraInfoManager>(rosOrigin::NodeHandle{_nh, syncCameraNames[i]}, syncCameraNames[i]));
+            _syncCamInfoManagers[i]->setCameraInfo(syncCameraInfo[i]);
+            _syncCameraInfoPublishers.emplace_back(
+                std::make_shared<rosOrigin::Publisher>(_nh.advertise<ImageMsgs::CameraInfo>(syncCameraNames[i] + "/camera_info", queueSize)));
+            _syncImagePublishers.emplace_back(std::make_shared<image_transport::Publisher>(_it.advertise(syncImageTopics[i], queueSize)));
+        }
+    } else {
+        throw std::runtime_error("sync params should have the same size");
+    }
 }
 
 template <class RosMsg, class SimMsg>
@@ -176,7 +207,7 @@ void BridgePublisher<RosMsg, SimMsg>::daiCallback(std::string name, std::shared_
 template <class RosMsg, class SimMsg>
 void BridgePublisher<RosMsg, SimMsg>::startPublisherThread() {
     if(_isCallbackAdded) {
-        std::runtime_error(
+        throw std::runtime_error(
             "addPublisherCallback() function adds a callback to the"
             "depthai which handles the publishing so no need to start"
             "the thread using startPublisherThread() ");
@@ -219,27 +250,53 @@ void BridgePublisher<RosMsg, SimMsg>::publishHelper(std::shared_ptr<SimMsg> inDa
     }
     mainSubCount = _rosPublisher->getNumSubscribers();
 
-    if(mainSubCount > 0 || infoSubCount > 0) {
-        _converter(inDataPtr, opMsgs);
+    _converter(inDataPtr, opMsgs);
 
-        while(opMsgs.size()) {
-            RosMsg currMsg = opMsgs.front();
-            if(mainSubCount > 0) {
-                _rosPublisher->publish(currMsg);
+    while(opMsgs.size()) {
+        RosMsg currMsg = opMsgs.front();
+
+        for(size_t i = 0; i < _syncImagePublishers.size(); i++) {
+            std::shared_ptr<dai::ImgFrame> syncImagePtr = _syncImageQueues[i]->get<dai::ImgFrame>();
+            while((uint32_t)syncImagePtr->getSequenceNum() < currMsg.header.seq) {
+                syncImagePtr = _syncImageQueues[i]->get<dai::ImgFrame>();
             }
 
-            if(infoSubCount > 0) {
-                // if (_isImageMessage){
-                //     _camInfoFrameId = curr.header.frame_id
-                // }
-                auto localCameraInfo = _camInfoManager->getCameraInfo();
-                localCameraInfo.header.seq = currMsg.header.seq;
-                localCameraInfo.header.stamp = currMsg.header.stamp;
-                localCameraInfo.header.frame_id = currMsg.header.frame_id;
-                _cameraInfoPublisher->publish(localCameraInfo);
+            int syncInfoSubCount = 0, syncMainSubCount = 0;
+            syncInfoSubCount = _syncCameraInfoPublishers[i]->getNumSubscribers();
+            syncMainSubCount = _syncImagePublishers[i]->getNumSubscribers();
+
+            if(syncInfoSubCount > 0 || syncMainSubCount > 0) {
+                std::deque<ImageMsgs::Image> syncImageMsgs;
+                _syncImageConverters[i](syncImagePtr, syncImageMsgs);
+
+                if(syncInfoSubCount > 0) {
+                    auto cameraInfo = _syncCamInfoManagers[i]->getCameraInfo();
+                    cameraInfo.header = syncImageMsgs.front().header;
+                    cameraInfo.header.stamp = currMsg.header.stamp;
+                    _syncCameraInfoPublishers[i]->publish(cameraInfo);
+                }
+
+                if(syncMainSubCount > 0) {
+                    ImageMsgs::Image imageMsg = syncImageMsgs.front();
+                    imageMsg.header.stamp = currMsg.header.stamp;
+                    _syncImagePublishers[i]->publish(imageMsg);
+                }
             }
-            opMsgs.pop_front();
         }
+
+        if(mainSubCount > 0) {
+            _rosPublisher->publish(currMsg);
+        }
+
+        if(infoSubCount > 0) {
+            // if (_isImageMessage){
+            //     _camInfoFrameId = curr.header.frame_id
+            // }
+            auto localCameraInfo = _camInfoManager->getCameraInfo();
+            localCameraInfo.header = currMsg.header;
+            _cameraInfoPublisher->publish(localCameraInfo);
+        }
+        opMsgs.pop_front();
     }
 }
 

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -27,7 +27,10 @@ using TimePoint = std::chrono::time_point<std::chrono::steady_clock, std::chrono
 class ImageConverter {
    public:
     // ImageConverter() = default;
-    ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false, dai::CameraExposureOffset offset = dai::CameraExposureOffset::END);
+    ImageConverter(const std::string frameName,
+                   bool interleaved,
+                   bool getBaseDeviceTimestamp = false,
+                   dai::CameraExposureOffset offset = dai::CameraExposureOffset::END);
     ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false, dai::CameraExposureOffset offset = dai::CameraExposureOffset::END);
 
     /**

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -27,8 +27,8 @@ using TimePoint = std::chrono::time_point<std::chrono::steady_clock, std::chrono
 class ImageConverter {
    public:
     // ImageConverter() = default;
-    ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false);
-    ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false);
+    ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false, dai::CameraExposureOffset offset = dai::CameraExposureOffset::END);
+    ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false, dai::CameraExposureOffset offset = dai::CameraExposureOffset::END);
 
     /**
      * @brief Handles cases in which the ROS time shifts forward or backward
@@ -82,6 +82,7 @@ class ImageConverter {
 
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    dai::CameraExposureOffset _offset;
     // For handling ROS time shifts and debugging
     int64_t _totalNsChange{0};
     // Whether to update the ROS base time on each message conversion

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -78,7 +78,7 @@ void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData
             break;
         }
         default: {
-            throw(std::runtime_error("Converted type not supported!"));
+            throw std::runtime_error("Converted type not supported!");
         }
     }
 
@@ -113,9 +113,9 @@ void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<
         tstamp = inData->getTimestamp();
     ImageMsgs::Image outImageMsg;
     StdMsgs::Header header;
-    header.frame_id = _frameName;
-
+    header.seq = (uint32_t)inData->getSequenceNum();
     header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    header.frame_id = _frameName;
 
     if(planarEncodingEnumMap.find(inData->getType()) != planarEncodingEnumMap.end()) {
         cv::Mat mat, output;
@@ -134,7 +134,7 @@ void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<
                 break;
 
             default:
-                std::runtime_error("Invalid dataType inputs..");
+                throw std::runtime_error("Invalid dataType inputs..");
                 break;
         }
         mat = cv::Mat(size, type, inData->getData().data());
@@ -208,7 +208,7 @@ void ImageConverter::toDaiMsg(const ImageMsgs::Image& inMsg, dai::ImgFrame& outD
             return pair.second == inMsg.encoding;
         });
         if(revEncodingIter == encodingEnumMap.end())
-            std::runtime_error(
+            throw std::runtime_error(
                 "Unable to find DAI encoding for the corresponding "
                 "sensor_msgs::image.encoding stream");
 
@@ -271,7 +271,7 @@ void ImageConverter::planarToInterleaved(const std::vector<uint8_t>& srcData, st
             destData[i * 3 + 2] = r;
         }
     } else {
-        std::runtime_error(
+        throw std::runtime_error(
             "If you encounter the scenario where you need this "
             "please create an issue on github");
     }
@@ -291,7 +291,7 @@ void ImageConverter::interleavedToPlanar(const std::vector<uint8_t>& srcData, st
             destData[i + w * h * 2] = r;
         }
     } else {
-        std::runtime_error(
+        throw std::runtime_error(
             "If you encounter the scenario where you need this "
             "please create an issue on github");
     }
@@ -305,7 +305,7 @@ cv::Mat ImageConverter::rosMsgtoCvMat(ImageMsgs::Image& inMsg) {
         cv::cvtColor(nv_frame, rgb, cv::COLOR_YUV2BGR_NV12);
         return rgb;
     } else {
-        std::runtime_error("This frature is still WIP");
+        throw std::runtime_error("This frature is still WIP");
         return rgb;
     }
 }

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -108,9 +108,9 @@ void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<
     }
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)
-        tstamp = inData->getTimestampDevice();
+        tstamp = inData->getTimestampDevice(_offset);
     else
-        tstamp = inData->getTimestamp();
+        tstamp = inData->getTimestamp(_offset);
     ImageMsgs::Image outImageMsg;
     StdMsgs::Header header;
     header.seq = (uint32_t)inData->getSequenceNum();

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -86,10 +86,10 @@ void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData
 
     // converting disparity
     if(type == dai::RawImgFrame::Type::RAW8) {
-        auto factor = (info.K[0] * info.P[3]);
+        auto factor = std::abs(info.P[3]) * 1000;
         cv::Mat depthOut = cv::Mat(cv::Size(output.cols, output.rows), CV_16UC1);
-        depthOut.forEach<short>([&output, &factor](short& pixel, const int* position) -> void {
-            auto disp = output.at<int8_t>(position);
+        depthOut.forEach<uint16_t>([&output, &factor](uint16_t& pixel, const int* position) -> void {
+            auto disp = output.at<uint8_t>(position);
             if(disp == 0)
                 pixel = 0;
             else

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -113,9 +113,9 @@ void ImageConverter::toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<
         tstamp = inData->getTimestamp(_offset);
     ImageMsgs::Image outImageMsg;
     StdMsgs::Header header;
-    header.seq = (uint32_t)inData->getSequenceNum();
-    header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
     header.frame_id = _frameName;
+
+    header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
 
     if(planarEncodingEnumMap.find(inData->getType()) != planarEncodingEnumMap.end()) {
         cv::Mat mat, output;

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -30,7 +30,11 @@ ImageConverter::ImageConverter(bool interleaved, bool getBaseDeviceTimestamp, da
 }
 
 ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp, dai::CameraExposureOffset offset)
-    : _frameName(frameName), _daiInterleaved(interleaved), _steadyBaseTime(std::chrono::steady_clock::now()), _getBaseDeviceTimestamp(getBaseDeviceTimestamp), _offset(offset) {
+    : _frameName(frameName),
+      _daiInterleaved(interleaved),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp),
+      _offset(offset) {
     _rosBaseTime = ::ros::Time::now();
 }
 

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -24,13 +24,13 @@ std::unordered_map<dai::RawImgFrame::Type, std::string> ImageConverter::planarEn
     {dai::RawImgFrame::Type::NV12, "rgb8"},
     {dai::RawImgFrame::Type::YUV420p, "rgb8"}};
 
-ImageConverter::ImageConverter(bool interleaved, bool getBaseDeviceTimestamp)
-    : _daiInterleaved(interleaved), _steadyBaseTime(std::chrono::steady_clock::now()), _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+ImageConverter::ImageConverter(bool interleaved, bool getBaseDeviceTimestamp, dai::CameraExposureOffset offset)
+    : _daiInterleaved(interleaved), _steadyBaseTime(std::chrono::steady_clock::now()), _getBaseDeviceTimestamp(getBaseDeviceTimestamp), _offset(offset) {
     _rosBaseTime = ::ros::Time::now();
 }
 
-ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp)
-    : _frameName(frameName), _daiInterleaved(interleaved), _steadyBaseTime(std::chrono::steady_clock::now()), _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp, dai::CameraExposureOffset offset)
+    : _frameName(frameName), _daiInterleaved(interleaved), _steadyBaseTime(std::chrono::steady_clock::now()), _getBaseDeviceTimestamp(getBaseDeviceTimestamp), _offset(offset) {
     _rosBaseTime = ::ros::Time::now();
 }
 
@@ -47,9 +47,9 @@ void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData
     }
     std::chrono::_V2::steady_clock::time_point tstamp;
     if(_getBaseDeviceTimestamp)
-        tstamp = inData->getTimestampDevice();
+        tstamp = inData->getTimestampDevice(_offset);
     else
-        tstamp = inData->getTimestamp();
+        tstamp = inData->getTimestamp(_offset);
     ImageMsgs::Image outImageMsg;
     StdMsgs::Header header;
     header.frame_id = _frameName;


### PR DESCRIPTION
## Overview
Author: Borong Yuan
These updates are mainly for SLAM applications.

- We prefer to use dai::CameraExposureOffset::MIDDLE for image timestamp. dai::CameraExposureOffset::END is set as default, which is almost consistent with previous behavior.
- ~~Some SLAM algorithms require the input images to have exactly the same timestamp. When we use a separate Publisher for each camera, the timestamps will not be exactly the same since the exposure is controlled individually. Only those algorithms that support approx sync can be used. Modified so that multiple synced images can now be published in one BridgePublisher. One image acts as the main image, and other images are synchronized with it by comparing sequenceNum. All images are assigned the exact same timestamp as the main image. For example, we want to publish exact synced left, right and depth images. We use the depth image as the main image since it always arrives last. In the callback function of depth image, we find the frame with the same sequenceNum from left and right image queues. They will arrive no later than the depth image, so there will be no blocking.~~ We found it easier to achieve exact sync without using BridgePublisher. So revert to the previous version.
- The disparity to depth computation was incorrect. You should do dimensional analysis. In [CameraInfo](http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/CameraInfo.html), abs(Tx) = fx' * baseline[m]. depth[mm] = fx' * baseline[mm] / disparity = fx' * abs(Tx) / fx' * 1000 / disparity = abs(P[3]) * 1000 / disparity.
- You shouldn't just declare std::runtime_error. It doesn't work. You should throw them.

## Changes
ROS distro: Noetic
List of changes:

- add CameraExposureOffset to ImageConverter
- fix disparity to depth computation

## Testing
Hardware used:
Depthai library version: v2.22.0
**_CI fails due to warnings generated by API changes._**

## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
