### PR TITLE
Add camera image orientation param

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
@@ -43,6 +43,7 @@ class SensorParamHandler : public BaseParamHandler {
     std::unordered_map<std::string, dai::MonoCameraProperties::SensorResolution> monoResolutionMap;
     std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
     std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
+    std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
 };
 }  // namespace param_handlers
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -71,7 +71,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
     if(declareAndLogParam<bool>("i_fsync_trigger", false)) {
         monoCam->initialControl.setExternalTrigger(declareAndLogParam<int>("i_num_frames_burst", 1), declareAndLogParam<int>("i_num_frames_discard", 0));
     }
-    monoCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_camera_img_orientation", "NORMAL"), cameraImageOrientationMap));
+    monoCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "NORMAL"), cameraImageOrientationMap));
 }
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam,
                                        dai::CameraBoardSocket socket,
@@ -139,7 +139,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     if(declareAndLogParam<bool>("i_fsync_trigger", false)) {
         colorCam->initialControl.setExternalTrigger(declareAndLogParam<int>("i_num_frames_burst", 1), declareAndLogParam<int>("i_num_frames_discard", 0));
     }
-    colorCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_camera_img_orientation", "NORMAL"), cameraImageOrientationMap));
+    colorCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "NORMAL"), cameraImageOrientationMap));
 }
 dai::CameraControl SensorParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& params) {
     dai::CameraControl ctrl;

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -32,6 +32,13 @@ void SensorParamHandler::declareCommonParams() {
         {"OUTPUT", dai::CameraControl::FrameSyncMode::OUTPUT},
         {"INPUT", dai::CameraControl::FrameSyncMode::INPUT},
     };
+    cameraImageOrientationMap = {
+        {"NORMAL", dai::CameraImageOrientation::NORMAL},
+        {"ROTATE_180_DEG", dai::CameraImageOrientation::ROTATE_180_DEG},
+        {"AUTO", dai::CameraImageOrientation::AUTO},
+        {"HORIZONTAL_MIRROR", dai::CameraImageOrientation::HORIZONTAL_MIRROR},
+        {"VERTICAL_FLIP", dai::CameraImageOrientation::VERTICAL_FLIP},
+    };
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam,
@@ -64,6 +71,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
     if(declareAndLogParam<bool>("i_fsync_trigger", false)) {
         monoCam->initialControl.setExternalTrigger(declareAndLogParam<int>("i_num_frames_burst", 1), declareAndLogParam<int>("i_num_frames_discard", 0));
     }
+    monoCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_camera_img_orientation", "NORMAL"), cameraImageOrientationMap));
 }
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam,
                                        dai::CameraBoardSocket socket,
@@ -131,6 +139,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     if(declareAndLogParam<bool>("i_fsync_trigger", false)) {
         colorCam->initialControl.setExternalTrigger(declareAndLogParam<int>("i_num_frames_burst", 1), declareAndLogParam<int>("i_num_frames_discard", 0));
     }
+    colorCam->setImageOrientation(utils::getValFromMap(declareAndLogParam<std::string>("i_camera_img_orientation", "NORMAL"), cameraImageOrientationMap));
 }
 dai::CameraControl SensorParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& params) {
     dai::CameraControl ctrl;


### PR DESCRIPTION
## Overview
Author: Jan Hernas

## Issue 
Issue link (if present): -
Issue description: I have the OAK camera installed on my robot upside down (rotated 180 degrees). The depthai api gives a couple of options for rotating the image. All I did was output them to a ROS parameter and enabled the user to set a parameter that will rotate the image if necessary.
Related PRs -

## Changes
ROS distro: Humble
List of changes: 
-Add a map from string to CameraImageOrientation
-Add a parameter for camera image orientation and set the image orientation based on this parameter both in color camera and mono camera

## Testing
Hardware used: OAK D-W, UpBoard 4000
Depthai library version: 2.22.0

## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
![Screenshot from 2023-08-08 11-35-09](https://github.com/luxonis/depthai-ros/assets/40989249/b782ee73-7b41-4548-9916-16472e73a326)