### PR TITLE
Change misleading error to a clearer message

### DIFF
--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -165,8 +165,7 @@ void Camera::startDevice() {
                             throw std::runtime_error("Device is already booted in different process.");
                         }
                     } else {
-                        RCLCPP_INFO(this->get_logger(), "Device info: MXID: %s, Name: %s", info.getMxId().c_str(), info.name.c_str());
-                        throw std::runtime_error("Unable to connect to the device, check if parameters match with given info.");
+                        RCLCPP_INFO(this->get_logger(), "Ignoring device info: MXID: %s, Name: %s", info.getMxId().c_str(), info.name.c_str());
                     }
                 }
             }


### PR DESCRIPTION
Hi,

We have a setup with 2 cameras. Upon starting, we set usb id on each camera nodes, and the current code throw an error upon searching the camera.

Actually, this error is nothing else than a simple "I've detected a camera but I won't use it because it does not match usb id", so this is very misleading, because each node throw a big red error about the camera not handled by this node.

This PR changes the severity to INFO and show a clearer message

Thanks,