### PR TITLE
Depth alignment update humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Additionally you can set `i.output_isp: false` to use `video` output and set cus
 ![](docs/param_rgb.gif)
 #### Setting Stereo parameters
 ![](docs/param_stereo.gif)
+##### Depth alignment
+When setting `stereo.i_align_depth: true`, stereo output is aligned to board socket specified by `stereo.i_board_socket_id` parameter (by default 0/CAM_A)
 
 #### Feature Tracker
 

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -4,10 +4,12 @@
 #include <string>
 
 #include "depthai/pipeline/Node.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 
 namespace dai {
 class Pipeline;
 class Device;
+class CameraFeatures;
 }  // namespace dai
 
 namespace rclcpp {
@@ -34,7 +36,7 @@ class BaseNode {
     rclcpp::Node* getROSNode();
     std::string getName();
     std::string getTFPrefix(const std::string& frameName = "");
-
+    std::string getFrameNameFromSocket(dai::CameraBoardSocket socket, std::vector<dai::CameraFeatures> camFeatures);
    private:
     rclcpp::Node* baseNode;
     std::string baseDAINodeName;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -20,7 +20,7 @@ class StereoParamHandler : public BaseParamHandler {
    public:
     explicit StereoParamHandler(rclcpp::Node* node, const std::string& name);
     ~StereoParamHandler();
-    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& rightName);
+    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& leftName, const std::string& rightName);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
 
    private:

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -9,6 +9,10 @@
 #include "depthai/pipeline/node/StereoDepth.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 
+namespace dai{
+    class CameraFeatures;
+}
+
 namespace rclcpp {
 class Node;
 class Parameter;
@@ -20,7 +24,7 @@ class StereoParamHandler : public BaseParamHandler {
    public:
     explicit StereoParamHandler(rclcpp::Node* node, const std::string& name);
     ~StereoParamHandler();
-    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::string& leftName, const std::string& rightName);
+    void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo, const std::vector<dai::CameraFeatures>& camFeatures);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
 
    private:

--- a/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
@@ -4,7 +4,13 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 #include <unordered_map>
+
+namespace dai {
+enum class CameraBoardSocket;
+struct CameraFeatures;
+}
 
 namespace depthai_ros_driver {
 namespace utils {
@@ -23,5 +29,6 @@ T getValFromMap(const std::string& name, const std::unordered_map<std::string, T
     }
 }
 std::string getUpperCaseStr(const std::string& string);
+std::string getSocketName(dai::CameraBoardSocket socket, std::vector<dai::CameraFeatures> camFeatures);
 }  // namespace utils
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/launch/pointcloud.launch.py
+++ b/depthai_ros_driver/launch/pointcloud.launch.py
@@ -39,7 +39,6 @@ def launch_setup(context, *args, **kwargs):
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyziNode',
                     name='point_cloud_xyzi',
-
                     remappings=[('depth/image_rect', name+'/stereo/image_raw'),
                                 ('intensity/image_rect', name+'/right/image_raw'),
                                 ('intensity/camera_info', name+'/right/camera_info'),

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -32,7 +32,7 @@ Stereo::Stereo(const std::string& daiNodeName,
     right = std::make_unique<SensorWrapper>(rightInfo.name, node, pipeline, device, rightInfo.socket, false);
 
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
-    ph->declareParams(stereoCamNode, rightInfo.name);
+    ph->declareParams(stereoCamNode, leftInfo.name, rightInfo.name);
     setXinXout(pipeline);
     left->link(stereoCamNode->left);
     right->link(stereoCamNode->right);
@@ -144,7 +144,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     stereoQ = device->getOutputQueue(stereoQName, ph->getParam<int>("i_max_q_size"), false);
     std::string tfPrefix;
     if(ph->getParam<bool>("i_align_depth")) {
-        tfPrefix = getTFPrefix("rgb");
+        tfPrefix = getTFPrefix(ph->getParam<std::string>("i_socket_name"));
     } else {
         tfPrefix = getTFPrefix(rightSensInfo.name);
     }

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -28,7 +28,8 @@ Stereo::Stereo(const std::string& daiNodeName,
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
     setNames();
-    for(auto f : device->getConnectedCameraFeatures()) {
+    auto features = device->getConnectedCameraFeatures();
+    for(auto f : features) {
         if(f.socket == leftSocket) {
             leftSensInfo = f;
         } else if(f.socket == rightSocket) {
@@ -41,7 +42,7 @@ Stereo::Stereo(const std::string& daiNodeName,
     left = std::make_unique<SensorWrapper>(leftSensInfo.name, node, pipeline, device, leftSensInfo.socket, false);
     right = std::make_unique<SensorWrapper>(rightSensInfo.name, node, pipeline, device, rightSensInfo.socket, false);
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
-    ph->declareParams(stereoCamNode, leftSensInfo.name, rightSensInfo.name);
+    ph->declareParams(stereoCamNode, features);
     setXinXout(pipeline);
     left->link(stereoCamNode->left);
     right->link(stereoCamNode->right);

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -41,7 +41,7 @@ Stereo::Stereo(const std::string& daiNodeName,
     left = std::make_unique<SensorWrapper>(leftSensInfo.name, node, pipeline, device, leftSensInfo.socket, false);
     right = std::make_unique<SensorWrapper>(rightSensInfo.name, node, pipeline, device, rightSensInfo.socket, false);
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
-    ph->declareParams(stereoCamNode, leftInfo.name, rightInfo.name);
+    ph->declareParams(stereoCamNode, leftSensInfo.name, rightSensInfo.name);
     setXinXout(pipeline);
     left->link(stereoCamNode->left);
     right->link(stereoCamNode->right);

--- a/depthai_ros_driver/src/utils.cpp
+++ b/depthai_ros_driver/src/utils.cpp
@@ -1,10 +1,27 @@
 #include "depthai_ros_driver/utils.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
+#include "depthai-shared/common/CameraFeatures.hpp"
 namespace depthai_ros_driver {
 namespace utils {
 std::string getUpperCaseStr(const std::string& string) {
     std::string upper = string;
     for(auto& c : upper) c = toupper(c);
     return upper;
+}
+std::string getSocketName(dai::CameraBoardSocket socket, std::vector<dai::CameraFeatures> camFeatures) {
+    std::string name;
+    for(auto& cam : camFeatures) {
+        if(cam.socket == socket) {
+            if(cam.name == "color"){
+                name = "rgb";
+            }
+            else{
+                name = cam.name;
+            }
+            return name;
+        }
+    }
+    throw std::runtime_error("Camera socket not found");
 }
 }  // namespace utils
 }  // namespace depthai_ros_driver


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): N/A
Issue description: Update alignment API for stereo node
Related PRs: https://github.com/luxonis/depthai-ros/pull/325

## Changes
ROS distro: Humble
List of changes: 
- `align_depth` parameter now aligns to the socket which was passed as `i_board_socket_id` parameter

## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
