### PR TITLE
get and set DisparityToDepthUseSpecTranslation

### DIFF
--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -105,6 +105,9 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     if(declareAndLogParam<bool>("i_enable_distortion_correction", false)) {
         stereo->enableDistortionCorrection(true);
     }
+    if(declareAndLogParam<bool>("i_set_disparity_to_depth_use_spec_translation", false)) {
+        stereo->setDisparityToDepthUseSpecTranslation(true);
+    }
 
     stereo->initialConfig.setBilateralFilterSigma(declareAndLogParam<int>("i_bilateral_sigma", 0));
     stereo->initialConfig.setLeftRightCheckThreshold(declareAndLogParam<int>("i_lrc_threshold", 10));


### PR DESCRIPTION
## Overview
This PR exposes this parameter (DisparityToDepthUseSpecTranslation) in the available parameters.

## Issue 
To get the best depth result we need to use the distance between lenses computed from the calibration. But for now, this parameter isn't available for ROS nodes.

## Changes
ROS distro: Humble
List of changes: add declare and set param in `stereo_param_handler.cpp`
```c++
if(declareAndLogParam<bool>("i_set_disparity_to_depth_use_spec_translation", false)) {
        stereo->setDisparityToDepthUseSpecTranslation(true);
    }
```

## Testing
Hardware used: OAK-D Pro Wide
Depthai library version: