### PR TITLE
fix initialization of 'has_imu' property in depthai_descriptions model

### DIFF
--- a/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
@@ -12,7 +12,7 @@
         <xacro:property name="has_imu" value="false" />
         <xacro:property name="baseline" value="0.075" />
 
-        <xacro:if value="${model == 'OAK-D'}">
+        <xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
             <xacro:property name="has_imu" value="true" />
         </xacro:if>
 


### PR DESCRIPTION
fix flag `has_imu` in xacro macro `depthai_camera` to also support the OAK-D PRO and POE models.

## Overview
Author: Jennifer Buehler

The flag `has_imu` in xacro macro `depthai_camera` is only set for the `OAK-D` model. With the other cameras which have an IMU it doesn't work.

It should  instead be
```xml
<xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
  <xacro:property name="has_imu" value="true" />
</xacro:if>
```

## Issue 
Issue link (if present): n/a

Issue description: the flag `has_imu` in the `depthai_camera` macro is only set to true for the 'OAK-D' model, although PRO and POE also have IMUs.

## Changes
ROS distro: humble, kinetic, probably all
List of changes: fix depthai_camera initialization of property `has_imu`

## Testing
Hardware used: Oak-D-Pro W
Depthai library version: current (2023-09-23) ROS kinetic package depthai-ros

## Visuals from testing
n/a, a screenshot of a non-existent IMU in RViz could be made but that's not really helpful