### PR TITLE
set resolution before obtaining size

### DIFF
--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -94,9 +94,9 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
         resString = sensor.defaultResolution;
     }
 
+    colorCam->setResolution(utils::getValFromMap(resString, dai_nodes::sensor_helpers::rgbResolutionMap));
     int width = colorCam->getResolutionWidth();
     int height = colorCam->getResolutionHeight();
-    colorCam->setResolution(utils::getValFromMap(resString, dai_nodes::sensor_helpers::rgbResolutionMap));
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
     if(declareAndLogParam<bool>("i_set_isp_scale", true)) {


### PR DESCRIPTION
## Overview
Author: @Serafadam

## Issue 
Issue link (if present): N/A
Issue description: This is a minor fix to obtain proper width and height for the sensor after setting resolution
Related PRs: N/A

## Changes
ROS distro: Humble
List of changes:
* Move resolution setter above size getters
## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
