### PR TITLE
Alpha scaling info update humble

### DIFF
--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -13,11 +13,11 @@ if(POLICY CMP0057)
 endif()
 
 set(opencv_version 4)
-find_package(OpenCV ${opencv_version} QUIET COMPONENTS imgproc highgui)
+find_package(OpenCV ${opencv_version} QUIET COMPONENTS imgproc highgui calib3d)
 if(NOT OpenCV_FOUND)
   message(STATUS "----------------Did not find OpenCV 4, trying OpenCV 3--------------")
   set(opencv_version 3)
-  find_package(OpenCV ${opencv_version} REQUIRED COMPONENTS imgproc highgui)
+  find_package(OpenCV ${opencv_version} REQUIRED COMPONENTS imgproc highgui calib3d)
 endif()
 
 
@@ -93,7 +93,8 @@ endif()
 target_link_libraries(${PROJECT_NAME}
                       depthai::core
                       opencv_imgproc
-                      opencv_highgui)
+                      opencv_highgui
+                      opencv_calib3d)
 
 ament_export_targets(depthai_bridgeTargets HAS_LIBRARY_TARGET)
 

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -74,6 +74,12 @@ class ImageConverter {
      */
     void reverseStereoSocketOrder();
 
+    /**
+     * @brief Sets the alpha scaling factor for the image.
+     * @param alphaScalingFactor: The alpha scaling factor to be used.
+     */
+    void setAlphaScaling(double alphaScalingFactor = 0.0);
+
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<ImageMsgs::Image>& outImageMsgs);
     ImageMsgs::Image toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> inData, const sensor_msgs::msg::CameraInfo& info = sensor_msgs::msg::CameraInfo());
     ImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
@@ -114,9 +120,11 @@ class ImageConverter {
     bool _fromBitstream = false;
     bool _convertDispToDepth = false;
     bool _addExpOffset = false;
+    bool _alphaScalingEnabled = false;
     dai::CameraExposureOffset _expOffset;
     bool _reverseStereoSocketOrder = false;
     double _baseline;
+    double _alphaScalingFactor = 0.0;
 };
 
 }  // namespace ros

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -2,6 +2,7 @@
 #include "depthai_bridge/ImageConverter.hpp"
 
 #include "depthai_bridge/depthaiUtility.hpp"
+#include "opencv2/calib3d.hpp"
 #include "opencv2/imgcodecs.hpp"
 
 namespace dai {
@@ -57,6 +58,11 @@ void ImageConverter::addExposureOffset(dai::CameraExposureOffset& offset) {
 
 void ImageConverter::reverseStereoSocketOrder() {
     _reverseStereoSocketOrder = true;
+}
+
+void ImageConverter::setAlphaScaling(double alphaScalingFactor) {
+    _alphaScalingEnabled = true;
+    _alphaScalingFactor = alphaScalingFactor;
 }
 
 ImageMsgs::Image ImageConverter::toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> inData, const sensor_msgs::msg::CameraInfo& info) {
@@ -375,11 +381,32 @@ ImageMsgs::CameraInfo ImageConverter::calibrationToCameraInfo(
         if(calibHandler.getStereoRightCameraId() == cameraId || calibHandler.getStereoLeftCameraId() == cameraId) {
             std::vector<std::vector<float>> stereoIntrinsics = calibHandler.getCameraIntrinsics(
                 calibHandler.getStereoRightCameraId(), cameraData.width, cameraData.height, topLeftPixelId, bottomRightPixelId);
+
+            if(_alphaScalingEnabled) {
+                cv::Mat cameraMatrix = cv::Mat(3, 3, CV_64F);
+                for(int i = 0; i < 3; i++) {
+                    for(int j = 0; j < 3; j++) {
+                        cameraMatrix.at<double>(i, j) = stereoIntrinsics[i][j];
+                    }
+                }
+                cv::Mat distCoefficients(distCoeffs);
+
+                cv::Mat newCameraMatrix = cv::getOptimalNewCameraMatrix(cameraMatrix, distCoefficients, cv::Size(width, height), _alphaScalingFactor);
+                // Copying the contents of newCameraMatrix to stereoIntrinsics
+                for(int i = 0; i < 3; i++) {
+                    for(int j = 0; j < 3; j++) {
+                        float newValue = static_cast<float>(newCameraMatrix.at<double>(i, j));
+                        stereoIntrinsics[i][j] = newValue;
+                        intrinsics[i * 3 + j] = newValue;
+                    }
+                }
+            }
             std::vector<double> stereoFlatIntrinsics(12), flatRectifiedRotation(9);
             for(int i = 0; i < 3; i++) {
                 std::copy(stereoIntrinsics[i].begin(), stereoIntrinsics[i].end(), stereoFlatIntrinsics.begin() + 4 * i);
                 stereoFlatIntrinsics[(4 * i) + 3] = 0;
             }
+
             // Check stereo socket order
             dai::CameraBoardSocket stereoSocketFirst = calibHandler.getStereoLeftCameraId();
             dai::CameraBoardSocket stereoSocketSecond = calibHandler.getStereoRightCameraId();

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -136,8 +136,8 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
         auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>(isLeft ? "i_left_rect_exposure_offset" : "i_right_rect_exposure_offset"));
         conv->addExposureOffset(offset);
     }
-    im = std::make_shared<camera_info_manager::CameraInfoManager>(
-        getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + sensorName).get(), "/rect");
+    im = std::make_shared<camera_info_manager::CameraInfoManager>(getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + sensorName).get(),
+                                                                  "/rect");
     if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
         conv->reverseStereoSocketOrder();
     }
@@ -213,7 +213,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
         stereoConv->reverseStereoSocketOrder();
     }
-    if(ph->getParam<bool>("i_enable_alpha_scaling")){
+    if(ph->getParam<bool>("i_enable_alpha_scaling")) {
         stereoConv->setAlphaScaling(ph->getParam<double>("i_alpha_scaling"));
     }
     stereoIM = std::make_shared<camera_info_manager::CameraInfoManager>(
@@ -232,14 +232,16 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
             stereoConv->convertDispToDepth(calibHandler.getBaselineDistance(rightSensInfo.socket, leftSensInfo.socket, false));
         }
     }
-    // remove distortion since image is rectified
-    for(auto& d : info.d) {
-        d = 0.0;
+    // remove distortion if alpha scaling is not enabled
+    if(!ph->getParam<bool>("i_enable_alpha_scaling")) {
+        for(auto& d : info.d) {
+            d = 0.0;
+        }
+        for(auto& r : info.r) {
+            r = 0.0;
+        }
+        info.r[0] = info.r[4] = info.r[8] = 1.0;
     }
-    for(auto& r : info.r) {
-        r = 0.0;
-    }
-    info.r[0] = info.r[4] = info.r[8] = 1.0;
 
     stereoIM->setCameraInfo(info);
     stereoQ = device->getOutputQueue(stereoQName, ph->getParam<int>("i_max_q_size"), false);

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -213,6 +213,9 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
         stereoConv->reverseStereoSocketOrder();
     }
+    if(ph->getParam<bool>("i_enable_alpha_scaling")){
+        stereoConv->setAlphaScaling(ph->getParam<double>("i_alpha_scaling"));
+    }
     stereoIM = std::make_shared<camera_info_manager::CameraInfoManager>(
         getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
     auto info = sensor_helpers::getCalibInfo(getROSNode()->get_logger(),

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -94,9 +94,9 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
         resString = sensor.defaultResolution;
     }
 
+    colorCam->setResolution(utils::getValFromMap(resString, dai_nodes::sensor_helpers::rgbResolutionMap));
     int width = colorCam->getResolutionWidth();
     int height = colorCam->getResolutionHeight();
-    colorCam->setResolution(utils::getValFromMap(resString, dai_nodes::sensor_helpers::rgbResolutionMap));
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
     if(declareAndLogParam<bool>("i_set_isp_scale", true)) {
@@ -114,7 +114,25 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
             RCLCPP_ERROR(getROSNode()->get_logger(), err_stream.str().c_str());
         }
     }
-    colorCam->setVideoSize(declareAndLogParam<int>("i_width", width), declareAndLogParam<int>("i_height", height));
+    int maxVideoWidth = 3840;
+    int maxVideoHeight = 2160;
+    int videoWidth = declareAndLogParam<int>("i_width", width);
+    int videoHeight = declareAndLogParam<int>("i_height", height);
+    if(videoWidth > maxVideoWidth) {
+        RCLCPP_WARN(getROSNode()->get_logger(),
+                    "Video width %d is greater than max video width %d. Setting video width to max video width.",
+                    videoWidth,
+                    maxVideoWidth);
+        videoWidth = maxVideoWidth;
+    }
+    if(videoHeight > maxVideoHeight) {
+        RCLCPP_WARN(getROSNode()->get_logger(),
+                    "Video height %d is greater than max video height %d. Setting video height to max video height.",
+                    videoHeight,
+                    maxVideoHeight);
+        videoHeight = maxVideoHeight;
+    }
+    colorCam->setVideoSize(videoWidth, videoHeight);
     colorCam->setPreviewKeepAspectRatio(declareAndLogParam("i_keep_preview_aspect_ratio", true));
     size_t iso = declareAndLogParam("r_iso", 800, getRangedIntDescriptor(100, 1600));
     size_t exposure = declareAndLogParam("r_exposure", 20000, getRangedIntDescriptor(1, 33000));


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/416#issuecomment-1752749654
Issue description: Updating CameraInfo based on alpha scaling
Related PRs: N/A

## Changes
ROS distro: Humble
List of changes:
- Added a method in ImageConverter to include Alpha Scaling when calculating intrinsics
- Minor bugfix regarding maximum Video size for RGB node

## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
