### PR TITLE
Update default resolution for stereo - Noetic

### DIFF
--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -9,9 +9,9 @@ namespace depthai_ros_driver {
 namespace dai_nodes {
 namespace sensor_helpers {
 std::vector<ImageSensor> availableSensors = {{"IMX378", "1080P", {"12MP", "4K", "1080P"}, true},
-                                             {"OV9282", "800P", {"800P", "720P", "400P"}, false},
-                                             {"OV9782", "800P", {"800P", "720P", "400P"}, true},
-                                             {"OV9281", "800P", {"800P", "720P", "400P"}, true},
+                                             {"OV9282", "720P", {"800P", "720P", "400P"}, false},
+                                             {"OV9782", "720P", {"800P", "720P", "400P"}, true},
+                                             {"OV9281", "720P", {"800P", "720P", "400P"}, true},
                                              {"IMX214", "1080P", {"13MP", "12MP", "4K", "1080P"}, true},
                                              {"IMX412", "1080P", {"13MP", "12MP", "4K", "1080P"}, true},
                                              {"OV7750", "480P", {"480P", "400P"}, false},


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/429 https://github.com/luxonis/depthai-ros/issues/427
Issue description: Frequency/timestamp issues after v2.8.1
Related PRs: N/A

## Changes
ROS distro: Noetic
List of changes:
- Changed default resolution for stereo cameras

## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
