### PR TITLE
Alpha scaling Noetic

### DIFF
--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -13,11 +13,11 @@ if(POLICY CMP0057)
 endif()
 
 set(opencv_version 4)
-find_package(OpenCV ${opencv_version} QUIET COMPONENTS imgproc highgui)
+find_package(OpenCV ${opencv_version} QUIET COMPONENTS imgproc highgui calib3d)
 if(NOT OpenCV_FOUND)
   message(STATUS "----------------Did not find OpenCV 4, trying OpenCV 3--------------")
   set(opencv_version 3)
-  find_package(OpenCV ${opencv_version} REQUIRED COMPONENTS imgproc highgui)
+  find_package(OpenCV ${opencv_version} REQUIRED COMPONENTS imgproc highgui calib3d)
 endif()
 
 set(catkin_FOUND 1)
@@ -87,6 +87,7 @@ target_link_libraries(${PROJECT_NAME}
   depthai::core
   opencv_imgproc
   opencv_highgui
+  opencv_calib3d
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -71,6 +71,12 @@ class ImageConverter {
      */
     void reverseStereoSocketOrder();
 
+    /**
+     * @brief Sets the alpha scaling factor for the image.
+     * @param alphaScalingFactor: The alpha scaling factor to be used.
+     */
+    void setAlphaScaling(double alphaScalingFactor = 0.0);
+
     ImageMsgs::Image toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> inData, const sensor_msgs::CameraInfo& info = sensor_msgs::CameraInfo());
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<ImageMsgs::Image>& outImageMsgs);
     ImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
@@ -114,6 +120,7 @@ class ImageConverter {
     dai::CameraExposureOffset _expOffset;
     bool _reverseStereoSocketOrder = false;
     double _baseline;
+    double _alphaScalingFactor = 0.0;
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -120,6 +120,7 @@ class ImageConverter {
     dai::CameraExposureOffset _expOffset;
     bool _reverseStereoSocketOrder = false;
     double _baseline;
+    bool _alphaScalingEnabled = false;
     double _alphaScalingFactor = 0.0;
 };
 

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -2,6 +2,7 @@
 #include "depthai_bridge/ImageConverter.hpp"
 
 #include "depthai_bridge/depthaiUtility.hpp"
+#include "opencv2/calib3d.hpp"
 #include "opencv2/imgcodecs.hpp"
 
 namespace dai {
@@ -51,6 +52,11 @@ void ImageConverter::convertDispToDepth(double baseline) {
 void ImageConverter::addExposureOffset(dai::CameraExposureOffset& offset) {
     _expOffset = offset;
     _addExpOffset = true;
+}
+
+void ImageConverter::setAlphaScaling(double alphaScalingFactor) {
+    _alphaScalingEnabled = true;
+    _alphaScalingFactor = alphaScalingFactor;
 }
 
 ImageMsgs::Image ImageConverter::toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> inData, const sensor_msgs::CameraInfo& info) {
@@ -360,6 +366,26 @@ ImageMsgs::CameraInfo ImageConverter::calibrationToCameraInfo(
         if(calibHandler.getStereoRightCameraId() == cameraId || calibHandler.getStereoLeftCameraId() == cameraId) {
             std::vector<std::vector<float>> stereoIntrinsics = calibHandler.getCameraIntrinsics(
                 calibHandler.getStereoRightCameraId(), cameraData.width, cameraData.height, topLeftPixelId, bottomRightPixelId);
+
+            if(_alphaScalingEnabled) {
+                cv::Mat cameraMatrix = cv::Mat(3, 3, CV_64F);
+                for(int i = 0; i < 3; i++) {
+                    for(int j = 0; j < 3; j++) {
+                        cameraMatrix.at<double>(i, j) = stereoIntrinsics[i][j];
+                    }
+                }
+                cv::Mat distCoefficients(distCoeffs);
+
+                cv::Mat newCameraMatrix = cv::getOptimalNewCameraMatrix(cameraMatrix, distCoefficients, cv::Size(width, height), _alphaScalingFactor);
+                // Copying the contents of newCameraMatrix to stereoIntrinsics
+                for(int i = 0; i < 3; i++) {
+                    for(int j = 0; j < 3; j++) {
+                        float newValue = static_cast<float>(newCameraMatrix.at<double>(i, j));
+                        stereoIntrinsics[i][j] = newValue;
+                        intrinsics[i * 3 + j] = newValue;
+                    }
+                }
+            }
             std::vector<double> stereoFlatIntrinsics(12), flatRectifiedRotation(9);
             for(int i = 0; i < 3; i++) {
                 std::copy(stereoIntrinsics[i].begin(), stereoIntrinsics[i].end(), stereoFlatIntrinsics.begin() + 4 * i);
@@ -393,7 +419,7 @@ ImageMsgs::CameraInfo ImageConverter::calibrationToCameraInfo(
             std::copy(stereoFlatIntrinsics.begin(), stereoFlatIntrinsics.end(), projection.begin());
             std::copy(flatRectifiedRotation.begin(), flatRectifiedRotation.end(), rotation.begin());
         }
-    }
+    }   
     cameraData.distortion_model = "rational_polynomial";
 
     return cameraData;

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -419,7 +419,7 @@ ImageMsgs::CameraInfo ImageConverter::calibrationToCameraInfo(
             std::copy(stereoFlatIntrinsics.begin(), stereoFlatIntrinsics.end(), projection.begin());
             std::copy(flatRectifiedRotation.begin(), flatRectifiedRotation.end(), rotation.begin());
         }
-    }   
+    }
     cameraData.distortion_model = "rational_polynomial";
 
     return cameraData;

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -9,9 +9,9 @@ namespace depthai_ros_driver {
 namespace dai_nodes {
 namespace sensor_helpers {
 std::vector<ImageSensor> availableSensors = {{"IMX378", "1080P", {"12MP", "4K", "1080P"}, true},
-                                             {"OV9282", "800P", {"800P", "720P", "400P"}, false},
-                                             {"OV9782", "800P", {"800P", "720P", "400P"}, true},
-                                             {"OV9281", "800P", {"800P", "720P", "400P"}, true},
+                                             {"OV9282", "720P", {"800P", "720P", "400P"}, false},
+                                             {"OV9782", "720P", {"800P", "720P", "400P"}, true},
+                                             {"OV9281", "720P", {"800P", "720P", "400P"}, true},
                                              {"IMX214", "1080P", {"13MP", "12MP", "4K", "1080P"}, true},
                                              {"IMX412", "1080P", {"13MP", "12MP", "4K", "1080P"}, true},
                                              {"OV7750", "480P", {"480P", "400P"}, false},

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -193,7 +193,9 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
         stereoConv->reverseStereoSocketOrder();
     }
-
+    if(ph->getParam<bool>("i_enable_alpha_scaling")) {
+        stereoConv->setAlphaScaling(ph->getParam<double>("i_alpha_scaling"));
+    }
     stereoIM = std::make_shared<camera_info_manager::CameraInfoManager>(ros::NodeHandle(getROSNode(), getName()), "/" + getName());
     auto info = sensor_helpers::getCalibInfo(*stereoConv,
                                              device,
@@ -208,14 +210,17 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
             stereoConv->convertDispToDepth(calibHandler.getBaselineDistance(rightSensInfo.socket, leftSensInfo.socket, false));
         }
     }
-    // remove distortion since image is rectified
-    for(auto& d : info.D) {
-        d = 0.0;
+    // remove distortion if alpha scaling is not enabled
+    if(!ph->getParam<bool>("i_enable_alpha_scaling")) {
+        for(auto& d : info.D) {
+            d = 0.0;
+        }
+        for(auto& r : info.R) {
+            r = 0.0;
+        }
+        info.R[0] = info.R[4] = info.R[8] = 1.0;
     }
-    for(auto& r : info.R) {
-        r = 0.0;
-    }
-    info.R[0] = info.R[4] = info.R[8] = 1.0;
+    im->setCameraInfo(info);
 
     stereoIM->setCameraInfo(info);
 

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -220,8 +220,6 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
         }
         info.R[0] = info.R[4] = info.R[8] = 1.0;
     }
-    im->setCameraInfo(info);
-
     stereoIM->setCameraInfo(info);
 
     stereoPubIT = it.advertiseCamera(getName() + "/image_raw", 1);

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -67,7 +67,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
         monoCam->setIsp3aFps(declareAndLogParam<int>("i_isp3a_fps", 10));
     }
     monoCam->setImageOrientation(
-        utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "NORMAL"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
+        utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "AUTO"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {
@@ -153,7 +153,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
         colorCam->setIsp3aFps(declareAndLogParam<int>("i_isp3a_fps", 10));
     }
     colorCam->setImageOrientation(
-        utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "NORMAL"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
+        utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "AUTO"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
 }
 dai::CameraControl SensorParamHandler::setRuntimeParams(parametersConfig& config) {
     dai::CameraControl ctrl;

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -109,7 +109,25 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
             ROS_ERROR(err_stream.str().c_str());
         }
     }
-    colorCam->setVideoSize(declareAndLogParam<int>("i_width", width), declareAndLogParam<int>("i_height", height));
+    int maxVideoWidth = 3840;
+    int maxVideoHeight = 2160;
+    int videoWidth = declareAndLogParam<int>("i_width", width);
+    int videoHeight = declareAndLogParam<int>("i_height", height);
+    if(videoWidth > maxVideoWidth) {
+        RCLCPP_WARN(getROSNode()->get_logger(),
+                    "Video width %d is greater than max video width %d. Setting video width to max video width.",
+                    videoWidth,
+                    maxVideoWidth);
+        videoWidth = maxVideoWidth;
+    }
+    if(videoHeight > maxVideoHeight) {
+        RCLCPP_WARN(getROSNode()->get_logger(),
+                    "Video height %d is greater than max video height %d. Setting video height to max video height.",
+                    videoHeight,
+                    maxVideoHeight);
+        videoHeight = maxVideoHeight;
+    }
+    colorCam->setVideoSize(videoWidth, videoHeight);
     colorCam->setPreviewKeepAspectRatio(declareAndLogParam("i_keep_preview_aspect_ratio", true));
     size_t iso = declareAndLogParam("r_iso", 800, getRangedIntDescriptor(100, 1600));
     size_t exposure = declareAndLogParam("r_exposure", 20000, getRangedIntDescriptor(1, 33000));

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -114,17 +114,11 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     int videoWidth = declareAndLogParam<int>("i_width", width);
     int videoHeight = declareAndLogParam<int>("i_height", height);
     if(videoWidth > maxVideoWidth) {
-        RCLCPP_WARN(getROSNode()->get_logger(),
-                    "Video width %d is greater than max video width %d. Setting video width to max video width.",
-                    videoWidth,
-                    maxVideoWidth);
+        ROS_WARN("Video width %d is greater than max video width %d. Setting video width to max video width.", videoWidth, maxVideoWidth);
         videoWidth = maxVideoWidth;
     }
     if(videoHeight > maxVideoHeight) {
-        RCLCPP_WARN(getROSNode()->get_logger(),
-                    "Video height %d is greater than max video height %d. Setting video height to max video height.",
-                    videoHeight,
-                    maxVideoHeight);
+        ROS_WARN("Video height %d is greater than max video height %d. Setting video height to max video height.", videoHeight, maxVideoHeight);
         videoHeight = maxVideoHeight;
     }
     colorCam->setVideoSize(videoWidth, videoHeight);


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/416#issuecomment-1752749654
Issue description: Updating CameraInfo based on alpha scaling
Related PRs: N/A

## Changes
ROS distro: Noetic
List of changes:
- Added a method in ImageConverter to include Alpha Scaling when calculating intrinsics
- Minor bugfix regarding maximum Video size for RGB node

## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
