### PR TITLE
Logger updates Noetic

### DIFF
--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -283,12 +283,15 @@ void Stereo::closeQueues() {
     if(ph->getParam<bool>("i_publish_topic")) {
         stereoQ->close();
     }
-    if(ph->getParam<bool>("i_publish_left_rect") || ph->getParam<bool>("i_publish_synced_rect_pair")) {
-        syncTimer.reset();
+    if(ph->getParam<bool>("i_publish_left_rect")) {
         leftRectQ->close();
     }
-    if(ph->getParam<bool>("i_publish_right_rect") || ph->getParam<bool>("i_publish_synced_rect_pair")) {
+    if(ph->getParam<bool>("i_publish_right_rect")) {
+        rightRectQ->close();
+    }
+    if(ph->getParam<bool>("i_publish_synced_rect_pair")) {
         syncTimer.reset();
+        leftRectQ->close();
         rightRectQ->close();
     }
     if(ph->getParam<bool>("i_left_rect_enable_feature_tracker")) {

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -68,8 +68,9 @@ std::string SysLogger::sysInfoToString(const dai::SystemInformation& sysInfo) {
 
 void SysLogger::produceDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat) {
     try {
-        auto logData = loggerQ->tryGet<dai::SystemInformation>();
-        if(logData) {
+        bool timeout;
+        auto logData = loggerQ->get<dai::SystemInformation>(std::chrono::seconds(5), timeout);
+        if(!timeout) {
             stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "System Information");
             stat.add("System Information", sysInfoToString(*logData));
         } else {


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/432
Issue description: Logger and rectified publishing updates
Related PRs

## Changes
ROS distro: Noetic
List of changes:
- Added timeout to the logger polling
- Updated closing queues in stereo node

## Testing
Hardware used: OAK-D-PRO
Depthai library version: 2.20.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
