### PR TITLE
Add more rotation vector types

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ Parameters:
   * `COPY`
   * `LINEAR_INTERPOLATE_GYRO`
   * `LINEAR_INTERPOLATE_ACCEL`
+* `i_rotation_vector_type` - type of rotation vector, for more information, refer to [this link](https://docs.luxonis.com/projects/api/en/latest/components/nodes/imu/). Available options:
+  * `ROTATION_VECTOR`
+  * `GAME_ROTATION_VECTOR`
+  * `GEOMAGNETIC_ROTATION_VECTOR`
+  * `ARVR_STABILIZED_ROTATION_VECTOR`
+  * `ARVR_STABILIZED_GAME_ROTATION_VECTOR`
 
 #### Stopping/starting camera for power saving/reconfiguration
 ![](docs/start_stop.gif)
@@ -451,6 +457,7 @@ For easier development inside isolated workspace, one can use Visual Studio Code
       i_max_batch_reports: 10
       i_message_type: IMU
       i_rot_cov: -1.0
+      i_rotation_vector_type: ROTATION_VECTOR
       i_sync_method: LINEAR_INTERPOLATE_ACCEL
       i_update_ros_base_time_on_ros_msg: false
     left:

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -33,6 +33,7 @@ class ImuConverter {
                  double rotation_cov = 0.0,
                  double magnetic_field_cov = 0.0,
                  bool enable_rotation = false,
+                 bool enable_magn = false,
                  bool getBaseDeviceTimestamp = false);
     ~ImuConverter();
 
@@ -99,9 +100,9 @@ class ImuConverter {
                 rotationHist.resize(accelHist.size());
             }
 
-            if(_enable_rotation && magnHist.size() == 0) {
+            if(_enable_magn && magnHist.size() == 0) {
                 magnHist.push_back(imuPackets[i].magneticField);
-            } else if(_enable_rotation && magnHist.back().sequence != imuPackets[i].magneticField.sequence) {
+            } else if(_enable_magn && magnHist.back().sequence != imuPackets[i].magneticField.sequence) {
                 magnHist.push_back(imuPackets[i].magneticField);
             } else {
                 magnHist.resize(accelHist.size());
@@ -112,7 +113,11 @@ class ImuConverter {
                     continue;
                 } else {
                     if(_enable_rotation) {
-                        interpolate(accelHist, gyroHist, rotationHist, magnHist, imuMsgs);
+                        if(_enable_magn) {
+                            interpolate(accelHist, gyroHist, rotationHist, magnHist, imuMsgs);
+                        } else {
+                            interpolate(accelHist, gyroHist, rotationHist, imuMsgs);
+                        }
                     } else {
                         interpolate(accelHist, gyroHist, imuMsgs);
                     }
@@ -123,7 +128,11 @@ class ImuConverter {
                     continue;
                 } else {
                     if(_enable_rotation) {
-                        interpolate(gyroHist, accelHist, rotationHist, magnHist, imuMsgs);
+                        if(_enable_magn) {
+                            interpolate(gyroHist, accelHist, rotationHist, magnHist, imuMsgs);
+                        } else {
+                            interpolate(gyroHist, accelHist, rotationHist, imuMsgs);
+                        }
                     } else {
                         interpolate(gyroHist, accelHist, imuMsgs);
                     }
@@ -135,6 +144,7 @@ class ImuConverter {
     uint32_t _sequenceNum;
     double _linear_accel_cov, _angular_velocity_cov, _rotation_cov, _magnetic_field_cov;
     bool _enable_rotation;
+    bool _enable_magn;
     const std::string _frameName = "";
     ImuSyncMethod _syncMode;
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
@@ -145,22 +155,33 @@ class ImuConverter {
     // Whether to update the ROS base time on each message conversion
     bool _updateRosBaseTimeOnToRosMsg{false};
 
-    void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportRotationVectorWAcc report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportMagneticField report, ImuMsgs::Imu& msg);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportAccelerometer report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportGyroscope report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportRotationVectorWAcc report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportMagneticField report);
 
-    void fillImuMsg(dai::IMUReportAccelerometer report, depthai_ros_msgs::msg::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportGyroscope report, depthai_ros_msgs::msg::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportRotationVectorWAcc report, depthai_ros_msgs::msg::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportMagneticField report, depthai_ros_msgs::msg::ImuWithMagneticField& msg);
+    void fillImuMsg(depthai_ros_msgs::msg::ImuWithMagneticField& msg, dai::IMUReportAccelerometer report);
+    void fillImuMsg(depthai_ros_msgs::msg::ImuWithMagneticField& msg, dai::IMUReportGyroscope report);
+    void fillImuMsg(depthai_ros_msgs::msg::ImuWithMagneticField& msg, dai::IMUReportRotationVectorWAcc report);
+    void fillImuMsg(depthai_ros_msgs::msg::ImuWithMagneticField& msg, dai::IMUReportMagneticField report);
 
     template <typename I, typename S, typename T, typename F, typename M>
-    void CreateUnitMessage(I first, S second, T third, F fourth, M& msg, std::chrono::_V2::steady_clock::time_point timestamp) {
-        fillImuMsg(first, msg);
-        fillImuMsg(second, msg);
-        fillImuMsg(third, msg);
-        fillImuMsg(fourth, msg);
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second, T third, F fourth) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
+        fillImuMsg(msg, third);
+        fillImuMsg(msg, fourth);
+
+        msg.header.frame_id = _frameName;
+
+        msg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, timestamp);
+    }
+
+    template <typename I, typename S, typename T, typename M>
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second, T third) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
+        fillImuMsg(msg, third);
 
         msg.header.frame_id = _frameName;
 
@@ -168,9 +189,9 @@ class ImuConverter {
     }
 
     template <typename I, typename S, typename M>
-    void CreateUnitMessage(I first, S second, M& msg, std::chrono::_V2::steady_clock::time_point timestamp) {
-        fillImuMsg(first, msg);
-        fillImuMsg(second, msg);
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
 
         msg.header.frame_id = _frameName;
 
@@ -205,7 +226,7 @@ class ImuConverter {
                             tstamp = currSecond.getTimestampDevice();
                         else
                             tstamp = currSecond.getTimestamp();
-                        CreateUnitMessage(interp, currSecond, msg, tstamp);
+                        CreateUnitMessage(msg, tstamp, interp, currSecond);
                         imuMsgs.push_back(msg);
                         second.pop_front();
                     } else if(currSecond.timestamp.get() > interp1.timestamp.get()) {
@@ -220,6 +241,61 @@ class ImuConverter {
                         }
                     } else {
                         second.pop_front();
+                    }
+                }
+                interp0 = interp1;
+            }
+        }
+        interpolated.push_back(interp0);
+    }
+
+    template <typename I, typename S, typename T, typename M>
+    void interpolate(std::deque<I>& interpolated, std::deque<S>& second, std::deque<T>& third, std::deque<M>& imuMsgs) {
+        I interp0, interp1;
+        S currSecond;
+        T currThird;
+        interp0.sequence = -1;
+        while(interpolated.size()) {
+            if(interp0.sequence == -1) {
+                interp0 = interpolated.front();
+                interpolated.pop_front();
+            } else {
+                interp1 = interpolated.front();
+                interpolated.pop_front();
+                // remove std::milli to get in seconds
+                std::chrono::duration<double, std::milli> duration_ms = interp1.timestamp.get() - interp0.timestamp.get();
+                double dt = duration_ms.count();
+                while(second.size()) {
+                    currSecond = second.front();
+                    currThird = third.front();
+                    if(currSecond.timestamp.get() > interp0.timestamp.get() && currSecond.timestamp.get() <= interp1.timestamp.get()) {
+                        // remove std::milli to get in seconds
+                        std::chrono::duration<double, std::milli> diff = currSecond.timestamp.get() - interp0.timestamp.get();
+                        const double alpha = diff.count() / dt;
+                        I interp = lerpImu(interp0, interp1, alpha);
+                        M msg;
+                        std::chrono::_V2::steady_clock::time_point tstamp;
+                        if(_getBaseDeviceTimestamp)
+                            tstamp = currSecond.getTimestampDevice();
+                        else
+                            tstamp = currSecond.getTimestamp();
+                        CreateUnitMessage(msg, tstamp, interp, currSecond, currThird);
+                        imuMsgs.push_back(msg);
+                        second.pop_front();
+                        third.pop_front();
+                    } else if(currSecond.timestamp.get() > interp1.timestamp.get()) {
+                        interp0 = interp1;
+                        if(interpolated.size()) {
+                            interp1 = interpolated.front();
+                            interpolated.pop_front();
+                            duration_ms = interp1.timestamp.get() - interp0.timestamp.get();
+                            dt = duration_ms.count();
+                        } else {
+                            break;
+                        }
+                    } else {
+                        second.pop_front();
+                        third.pop_front();
                     }
                 }
                 interp0 = interp1;
@@ -260,7 +336,7 @@ class ImuConverter {
                             tstamp = currSecond.getTimestampDevice();
                         else
                             tstamp = currSecond.getTimestamp();
-                        CreateUnitMessage(interp, currSecond, currThird, currFourth, msg, tstamp);
+                        CreateUnitMessage(msg, tstamp, interp, currSecond, currThird, currFourth);
                         imuMsgs.push_back(msg);
                         second.pop_front();
                         third.pop_front();

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai-shared/properties/IMUProperties.hpp"
 #include "depthai_bridge/ImuConverter.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 
@@ -32,6 +33,7 @@ class ImuParamHandler : public BaseParamHandler {
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
     std::unordered_map<std::string, dai::ros::ImuSyncMethod> imuSyncMethodMap;
     std::unordered_map<std::string, imu::ImuMsgType> imuMessagetTypeMap;
+    std::unordered_map<std::string, dai::IMUSensor> rotationVectorTypeMap;
     imu::ImuMsgType getMsgType();
     dai::ros::ImuSyncMethod getSyncMethod();
 };

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
@@ -27,12 +27,8 @@ class SensorParamHandler : public BaseParamHandler {
     explicit SensorParamHandler(rclcpp::Node* node, const std::string& name, dai::CameraBoardSocket socket);
     ~SensorParamHandler();
     void declareCommonParams(dai::CameraBoardSocket socket);
-    void declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam,
-                       dai_nodes::sensor_helpers::ImageSensor sensor,
-                       bool publish);
-    void declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam,
-                       dai_nodes::sensor_helpers::ImageSensor sensor,
-                       bool publish);
+    void declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish);
+    void declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
 
    private:

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
@@ -32,7 +32,7 @@ class PipelineGenerator {
      *
      * @return     The validated pipeline type.
      */
-    std::string validatePipeline(rclcpp::Node* node,const std::string& typeStr, int sensorNum);
+    std::string validatePipeline(rclcpp::Node* node, const std::string& typeStr, int sensorNum);
     /**
      * @brief      Creates the pipeline by using a plugin. Plugin types need to be of type depthai_ros_driver::pipeline_gen::BasePipeline.
      *

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -47,6 +47,7 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
                                                             ph->getParam<float>("i_rot_cov"),
                                                             ph->getParam<float>("i_mag_cov"),
                                                             ph->getParam<bool>("i_enable_rotation"),
+                                                            ph->getParam<bool>("i_enable_magn"),
                                                             ph->getParam<bool>("i_get_base_device_timestamp"));
     imuConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
     param_handlers::imu::ImuMsgType msgType = ph->getMsgType();

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -40,6 +40,8 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
     auto imuMode = ph->getSyncMethod();
     rclcpp::PublisherOptions options;
     options.qos_overriding_options = rclcpp::QosOverridingOptions();
+    param_handlers::imu::ImuMsgType msgType = ph->getMsgType();
+    bool enableMagn = msgType == param_handlers::imu::ImuMsgType::IMU_WITH_MAG || msgType == param_handlers::imu::ImuMsgType::IMU_WITH_MAG_SPLIT;
     imuConverter = std::make_unique<dai::ros::ImuConverter>(tfPrefix + "_frame",
                                                             imuMode,
                                                             ph->getParam<float>("i_acc_cov"),
@@ -47,10 +49,9 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
                                                             ph->getParam<float>("i_rot_cov"),
                                                             ph->getParam<float>("i_mag_cov"),
                                                             ph->getParam<bool>("i_enable_rotation"),
-                                                            ph->getParam<bool>("i_enable_magn"),
+                                                            enableMagn,
                                                             ph->getParam<bool>("i_get_base_device_timestamp"));
     imuConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-    param_handlers::imu::ImuMsgType msgType = ph->getMsgType();
     switch(msgType) {
         case param_handlers::imu::ImuMsgType::IMU: {
             rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + "/data", 10, options);

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -337,10 +337,10 @@ void Stereo::closeQueues() {
     if(ph->getParam<bool>("i_publish_topic")) {
         stereoQ->close();
     }
-    if(ph->getParam<bool>("i_publish_left_rect")){
+    if(ph->getParam<bool>("i_publish_left_rect")) {
         leftRectQ->close();
     }
-    if(ph->getParam<bool>("i_publish_right_rect")){
+    if(ph->getParam<bool>("i_publish_right_rect")) {
         rightRectQ->close();
     }
     if(ph->getParam<bool>("i_publish_synced_rect_pair")) {

--- a/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
@@ -30,7 +30,9 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
     if(declareAndLogParam<bool>("i_enable_rotation", false)) {
         if(rotationAvailable) {
             imu->enableIMUSensor(dai::IMUSensor::ROTATION_VECTOR, declareAndLogParam<int>("i_rot_freq", 400));
-            imu->enableIMUSensor(dai::IMUSensor::MAGNETOMETER_CALIBRATED, declareAndLogParam<int>("i_mag_freq", 100));
+            if(declareAndLogParam<bool>("i_enable_magn", false)) {
+                imu->enableIMUSensor(dai::IMUSensor::MAGNETOMETER_CALIBRATED, declareAndLogParam<int>("i_mag_freq", 100));
+            }
         } else {
             RCLCPP_ERROR(getROSNode()->get_logger(), "Rotation enabled but not available with current sensor");
             declareAndLogParam<bool>("i_enable_rotation", false, true);

--- a/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
@@ -18,8 +18,13 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
     };
     imuMessagetTypeMap = {
         {"IMU", imu::ImuMsgType::IMU}, {"IMU_WITH_MAG", imu::ImuMsgType::IMU_WITH_MAG}, {"IMU_WITH_MAG_SPLIT", imu::ImuMsgType::IMU_WITH_MAG_SPLIT}};
+    rotationVectorTypeMap = {{"ROTATION_VECTOR", dai::IMUSensor::ROTATION_VECTOR},
+                             {"GAME_ROTATION_VECTOR", dai::IMUSensor::GAME_ROTATION_VECTOR},
+                             {"GEOMAGNETIC_ROTATION_VECTOR", dai::IMUSensor::GEOMAGNETIC_ROTATION_VECTOR},
+                             {"ARVR_STABILIZED_ROTATION_VECTOR", dai::IMUSensor::ARVR_STABILIZED_ROTATION_VECTOR},
+                             {"ARVR_STABILIZED_GAME_ROTATION_VECTOR", dai::IMUSensor::ARVR_STABILIZED_GAME_ROTATION_VECTOR}};
     declareAndLogParam<bool>("i_get_base_device_timestamp", false);
-    declareAndLogParam<std::string>("i_message_type", "IMU");
+    auto messageType = declareAndLogParam<std::string>("i_message_type", "IMU");
     declareAndLogParam<std::string>("i_sync_method", "LINEAR_INTERPOLATE_ACCEL");
     declareAndLogParam<float>("i_acc_cov", 0.0);
     declareAndLogParam<float>("i_gyro_cov", 0.0);
@@ -29,8 +34,11 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
     bool rotationAvailable = imuType == "BNO086";
     if(declareAndLogParam<bool>("i_enable_rotation", false)) {
         if(rotationAvailable) {
-            imu->enableIMUSensor(dai::IMUSensor::ROTATION_VECTOR, declareAndLogParam<int>("i_rot_freq", 400));
-            if(declareAndLogParam<bool>("i_enable_magn", false)) {
+            auto rotationVecType = utils::getValFromMap(utils::getUpperCaseStr(declareAndLogParam<std::string>("i_rotation_vector_type", "ROTATION_VECTOR")),
+                                                        rotationVectorTypeMap);
+            imu->enableIMUSensor(rotationVecType, declareAndLogParam<int>("i_rot_freq", 400));
+            // if imu message type is IMU_WITH_MAG or IMU_WITH_MAG_SPLIT, enable magnetometer
+            if(messageType == "IMU_WITH_MAG" || messageType == "IMU_WITH_MAG_SPLIT") {
                 imu->enableIMUSensor(dai::IMUSensor::MAGNETOMETER_CALIBRATED, declareAndLogParam<int>("i_mag_freq", 100));
             }
         } else {


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/446
Issue description: Currently we enable magnetometer sensor when enabling rotation vector, which lowers the output frequency. This PR changes it so that magnetometer readings are being output only when the IMU message type is set to contain the mag data. Additionally, rotation vector types are parameterized now.
Related PRs

## Changes
ROS distro Humble:
List of changes:
- Add rotation vector types
- New template specialization in IMUConverter for converting three messages
- Reorder of parameters in IMU conversion methods
- New flag in IMU converter to enable magnetometer
## Testing
Hardware used: OAK-D-PRO-W
Depthai library version: 2.20


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
