### PR TITLE
Separate Magnetometer Noetic

### DIFF
--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -31,6 +31,7 @@ class ImuConverter {
                  double rotation_cov = 0.0,
                  double magnetic_field_cov = 0.0,
                  bool enable_rotation = false,
+                 bool enable_magn = false,
                  bool getBaseDeviceTimestamp = false);
     ~ImuConverter();
 
@@ -97,9 +98,9 @@ class ImuConverter {
                 rotationHist.resize(accelHist.size());
             }
 
-            if(_enable_rotation && magnHist.size() == 0) {
+            if(_enable_magn && magnHist.size() == 0) {
                 magnHist.push_back(imuPackets[i].magneticField);
-            } else if(_enable_rotation && magnHist.back().sequence != imuPackets[i].magneticField.sequence) {
+            } else if(_enable_magn && magnHist.back().sequence != imuPackets[i].magneticField.sequence) {
                 magnHist.push_back(imuPackets[i].magneticField);
             } else {
                 magnHist.resize(accelHist.size());
@@ -110,7 +111,11 @@ class ImuConverter {
                     continue;
                 } else {
                     if(_enable_rotation) {
-                        interpolate(accelHist, gyroHist, rotationHist, magnHist, imuMsgs);
+                        if(_enable_magn) {
+                            interpolate(accelHist, gyroHist, rotationHist, magnHist, imuMsgs);
+                        } else {
+                            interpolate(accelHist, gyroHist, rotationHist, imuMsgs);
+                        }
                     } else {
                         interpolate(accelHist, gyroHist, imuMsgs);
                     }
@@ -121,7 +126,11 @@ class ImuConverter {
                     continue;
                 } else {
                     if(_enable_rotation) {
-                        interpolate(gyroHist, accelHist, rotationHist, magnHist, imuMsgs);
+                        if(_enable_magn) {
+                            interpolate(gyroHist, accelHist, rotationHist, magnHist, imuMsgs);
+                        } else {
+                            interpolate(gyroHist, accelHist, rotationHist, imuMsgs);
+                        }
                     } else {
                         interpolate(gyroHist, accelHist, imuMsgs);
                     }
@@ -133,6 +142,7 @@ class ImuConverter {
     uint32_t _sequenceNum;
     double _linear_accel_cov, _angular_velocity_cov, _rotation_cov, _magnetic_field_cov;
     bool _enable_rotation;
+    bool _enable_magn;
     const std::string _frameName = "";
     ImuSyncMethod _syncMode;
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
@@ -143,22 +153,33 @@ class ImuConverter {
     bool _updateRosBaseTimeOnToRosMsg{false};
     bool _getBaseDeviceTimestamp;
 
-    void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportRotationVectorWAcc report, ImuMsgs::Imu& msg);
-    void fillImuMsg(dai::IMUReportMagneticField report, ImuMsgs::Imu& msg);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportAccelerometer report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportGyroscope report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportRotationVectorWAcc report);
+    void fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportMagneticField report);
 
-    void fillImuMsg(dai::IMUReportAccelerometer report, depthai_ros_msgs::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportGyroscope report, depthai_ros_msgs::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportRotationVectorWAcc report, depthai_ros_msgs::ImuWithMagneticField& msg);
-    void fillImuMsg(dai::IMUReportMagneticField report, depthai_ros_msgs::ImuWithMagneticField& msg);
+    void fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportAccelerometer report);
+    void fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportGyroscope report);
+    void fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportRotationVectorWAcc report);
+    void fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportMagneticField report);
 
     template <typename I, typename S, typename T, typename F, typename M>
-    void CreateUnitMessage(I first, S second, T third, F fourth, M& msg, std::chrono::_V2::steady_clock::time_point timestamp) {
-        fillImuMsg(first, msg);
-        fillImuMsg(second, msg);
-        fillImuMsg(third, msg);
-        fillImuMsg(fourth, msg);
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second, T third, F fourth) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
+        fillImuMsg(msg, third);
+        fillImuMsg(msg, fourth);
+
+        msg.header.frame_id = _frameName;
+
+        msg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, timestamp);
+    }
+
+    template <typename I, typename S, typename T, typename M>
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second, T third) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
+        fillImuMsg(msg, third);
 
         msg.header.frame_id = _frameName;
 
@@ -166,9 +187,9 @@ class ImuConverter {
     }
 
     template <typename I, typename S, typename M>
-    void CreateUnitMessage(I first, S second, M& msg, std::chrono::_V2::steady_clock::time_point timestamp) {
-        fillImuMsg(first, msg);
-        fillImuMsg(second, msg);
+    void CreateUnitMessage(M& msg, std::chrono::_V2::steady_clock::time_point timestamp, I first, S second) {
+        fillImuMsg(msg, first);
+        fillImuMsg(msg, second);
 
         msg.header.frame_id = _frameName;
 
@@ -203,7 +224,7 @@ class ImuConverter {
                             tstamp = currSecond.getTimestampDevice();
                         else
                             tstamp = currSecond.getTimestamp();
-                        CreateUnitMessage(interp, currSecond, msg, tstamp);
+                        CreateUnitMessage(msg, tstamp, interp, currSecond);
                         imuMsgs.push_back(msg);
                         second.pop_front();
                     } else if(currSecond.timestamp.get() > interp1.timestamp.get()) {
@@ -225,6 +246,62 @@ class ImuConverter {
         }
         interpolated.push_back(interp0);
     }
+
+        template <typename I, typename S, typename T, typename M>
+    void interpolate(std::deque<I>& interpolated, std::deque<S>& second, std::deque<T>& third, std::deque<M>& imuMsgs) {
+        I interp0, interp1;
+        S currSecond;
+        T currThird;
+        interp0.sequence = -1;
+        while(interpolated.size()) {
+            if(interp0.sequence == -1) {
+                interp0 = interpolated.front();
+                interpolated.pop_front();
+            } else {
+                interp1 = interpolated.front();
+                interpolated.pop_front();
+                // remove std::milli to get in seconds
+                std::chrono::duration<double, std::milli> duration_ms = interp1.timestamp.get() - interp0.timestamp.get();
+                double dt = duration_ms.count();
+                while(second.size()) {
+                    currSecond = second.front();
+                    currThird = third.front();
+                    if(currSecond.timestamp.get() > interp0.timestamp.get() && currSecond.timestamp.get() <= interp1.timestamp.get()) {
+                        // remove std::milli to get in seconds
+                        std::chrono::duration<double, std::milli> diff = currSecond.timestamp.get() - interp0.timestamp.get();
+                        const double alpha = diff.count() / dt;
+                        I interp = lerpImu(interp0, interp1, alpha);
+                        M msg;
+                        std::chrono::_V2::steady_clock::time_point tstamp;
+                        if(_getBaseDeviceTimestamp)
+                            tstamp = currSecond.getTimestampDevice();
+                        else
+                            tstamp = currSecond.getTimestamp();
+                        CreateUnitMessage(msg, tstamp, interp, currSecond, currThird);
+                        imuMsgs.push_back(msg);
+                        second.pop_front();
+                        third.pop_front();
+                    } else if(currSecond.timestamp.get() > interp1.timestamp.get()) {
+                        interp0 = interp1;
+                        if(interpolated.size()) {
+                            interp1 = interpolated.front();
+                            interpolated.pop_front();
+                            duration_ms = interp1.timestamp.get() - interp0.timestamp.get();
+                            dt = duration_ms.count();
+                        } else {
+                            break;
+                        }
+                    } else {
+                        second.pop_front();
+                        third.pop_front();
+                    }
+                }
+                interp0 = interp1;
+            }
+        }
+        interpolated.push_back(interp0);
+    }
+
 
     template <typename I, typename S, typename T, typename F, typename M>
     void interpolate(std::deque<I>& interpolated, std::deque<S>& second, std::deque<T>& third, std::deque<F>& fourth, std::deque<M>& imuMsgs) {
@@ -258,7 +335,7 @@ class ImuConverter {
                             tstamp = currSecond.getTimestampDevice();
                         else
                             tstamp = currSecond.getTimestamp();
-                        CreateUnitMessage(interp, currSecond, currThird, currFourth, msg, tstamp);
+                        CreateUnitMessage(msg, tstamp, interp, currSecond, currThird, currFourth);
                         imuMsgs.push_back(msg);
                         second.pop_front();
                         third.pop_front();

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -247,7 +247,7 @@ class ImuConverter {
         interpolated.push_back(interp0);
     }
 
-        template <typename I, typename S, typename T, typename M>
+    template <typename I, typename S, typename T, typename M>
     void interpolate(std::deque<I>& interpolated, std::deque<S>& second, std::deque<T>& third, std::deque<M>& imuMsgs) {
         I interp0, interp1;
         S currSecond;
@@ -301,7 +301,6 @@ class ImuConverter {
         }
         interpolated.push_back(interp0);
     }
-
 
     template <typename I, typename S, typename T, typename F, typename M>
     void interpolate(std::deque<I>& interpolated, std::deque<S>& second, std::deque<T>& third, std::deque<F>& fourth, std::deque<M>& imuMsgs) {

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -41,6 +41,13 @@ void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportAccelerometer rep
     msg.linear_acceleration.y = report.y;
     msg.linear_acceleration.z = report.z;
     msg.linear_acceleration_covariance = {_linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov};
+    if(!_enable_rotation){
+        msg.orientation.x = 0.0;
+        msg.orientation.y = 0.0;
+        msg.orientation.z = 0.0;
+        msg.orientation.w = 1.0;
+        msg.orientation_covariance = {-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    }
 }
 
 void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportGyroscope report) {

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -14,6 +14,7 @@ ImuConverter::ImuConverter(const std::string& frameName,
                            double rotation_cov,
                            double magnetic_field_cov,
                            bool enable_rotation,
+                           bool enable_magn,
                            bool getBaseDeviceTimestamp)
     : _frameName(frameName),
       _syncMode(syncMode),
@@ -22,6 +23,7 @@ ImuConverter::ImuConverter(const std::string& frameName,
       _rotation_cov(rotation_cov),
       _magnetic_field_cov(magnetic_field_cov),
       _enable_rotation(enable_rotation),
+      _enable_magn(enable_magn),
       _sequenceNum(0),
       _steadyBaseTime(std::chrono::steady_clock::now()),
       _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
@@ -34,21 +36,21 @@ void ImuConverter::updateRosBaseTime() {
     updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg) {
+void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportAccelerometer report) {
     msg.linear_acceleration.x = report.x;
     msg.linear_acceleration.y = report.y;
     msg.linear_acceleration.z = report.z;
     msg.linear_acceleration_covariance = {_linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov};
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg) {
+void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportGyroscope report) {
     msg.angular_velocity.x = report.x;
     msg.angular_velocity.y = report.y;
     msg.angular_velocity.z = report.z;
     msg.angular_velocity_covariance = {_angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov, 0.0, 0.0, 0.0, _angular_velocity_cov};
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportRotationVectorWAcc report, ImuMsgs::Imu& msg) {
+void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportRotationVectorWAcc report) {
     if(_enable_rotation) {
         msg.orientation.x = report.i;
         msg.orientation.y = report.j;
@@ -64,23 +66,23 @@ void ImuConverter::fillImuMsg(dai::IMUReportRotationVectorWAcc report, ImuMsgs::
     }
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportMagneticField report, ImuMsgs::Imu& msg) {
+void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportMagneticField report) {
     return;
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportAccelerometer report, depthai_ros_msgs::ImuWithMagneticField& msg) {
-    fillImuMsg(report, msg.imu);
+void ImuConverter::fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportAccelerometer report) {
+    fillImuMsg(msg.imu, report);
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportGyroscope report, depthai_ros_msgs::ImuWithMagneticField& msg) {
-    fillImuMsg(report, msg.imu);
+void ImuConverter::fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportGyroscope report) {
+    fillImuMsg(msg.imu, report);
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportRotationVectorWAcc report, depthai_ros_msgs::ImuWithMagneticField& msg) {
-    fillImuMsg(report, msg.imu);
+void ImuConverter::fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportRotationVectorWAcc report) {
+    fillImuMsg(msg.imu, report);
 }
 
-void ImuConverter::fillImuMsg(dai::IMUReportMagneticField report, depthai_ros_msgs::ImuWithMagneticField& msg) {
+void ImuConverter::fillImuMsg(depthai_ros_msgs::ImuWithMagneticField& msg, dai::IMUReportMagneticField report) {
     msg.field.magnetic_field.x = report.x;
     msg.field.magnetic_field.y = report.y;
     msg.field.magnetic_field.z = report.z;
@@ -104,7 +106,12 @@ void ImuConverter::toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<Imu
             else
                 tstamp = accel.getTimestamp();
 
-            CreateUnitMessage(accel, gyro, msg, tstamp);
+            if(_enable_rotation) {
+                auto rot = inData->packets[i].rotationVector;
+                CreateUnitMessage(msg, tstamp, accel, gyro, rot);
+            } else {
+                CreateUnitMessage(msg, tstamp, accel, gyro);
+            }
             outImuMsgs.push_back(msg);
         }
     }
@@ -129,9 +136,9 @@ void ImuConverter::toRosDaiMsg(std::shared_ptr<dai::IMUData> inData, std::deque<
             if(_enable_rotation) {
                 auto rot = inData->packets[i].rotationVector;
                 auto magn = inData->packets[i].magneticField;
-                CreateUnitMessage(accel, gyro, rot, magn, msg, tstamp);
+                CreateUnitMessage(msg, tstamp, accel, gyro, rot, magn);
             } else {
-                CreateUnitMessage(accel, gyro, msg, tstamp);
+                CreateUnitMessage(msg, tstamp, accel, gyro);
             }
             outImuMsgs.push_back(msg);
         }

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -41,7 +41,7 @@ void ImuConverter::fillImuMsg(ImuMsgs::Imu& msg, dai::IMUReportAccelerometer rep
     msg.linear_acceleration.y = report.y;
     msg.linear_acceleration.z = report.z;
     msg.linear_acceleration_covariance = {_linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov, 0.0, 0.0, 0.0, _linear_accel_cov};
-    if(!_enable_rotation){
+    if(!_enable_rotation) {
         msg.orientation.x = 0.0;
         msg.orientation.y = 0.0;
         msg.orientation.z = 0.0;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai-shared/properties/IMUProperties.hpp"
+#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai_bridge/ImuConverter.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 #include "depthai_ros_driver/parametersConfig.h"

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai-shared/properties/IMUProperties.hpp"
 #include "depthai_bridge/ImuConverter.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
@@ -32,6 +33,7 @@ class ImuParamHandler : public BaseParamHandler {
     dai::CameraControl setRuntimeParams(parametersConfig& config) override;
     std::unordered_map<std::string, dai::ros::ImuSyncMethod> imuSyncMethodMap;
     std::unordered_map<std::string, imu::ImuMsgType> imuMessagetTypeMap;
+    std::unordered_map<std::string, dai::IMUSensor> rotationVectorTypeMap;
     imu::ImuMsgType getMsgType();
     dai::ros::ImuSyncMethod getSyncMethod();
 };

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -40,15 +40,18 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
     auto tfPrefix = std::string(getROSNode().getNamespace()) + "_" + getName();
     tfPrefix.erase(0, 1);
     auto imuMode = ph->getSyncMethod();
+    param_handlers::imu::ImuMsgType msgType = ph->getMsgType();
+    bool enableMagn = msgType == param_handlers::imu::ImuMsgType::IMU_WITH_MAG || msgType == param_handlers::imu::ImuMsgType::IMU_WITH_MAG_SPLIT;
     imuConverter = std::make_unique<dai::ros::ImuConverter>(tfPrefix + "_frame",
                                                             imuMode,
                                                             ph->getParam<float>("i_acc_cov"),
                                                             ph->getParam<float>("i_gyro_cov"),
                                                             ph->getParam<float>("i_rot_cov"),
                                                             ph->getParam<float>("i_mag_cov"),
-                                                            ph->getParam<bool>("i_enable_rotation"));
+                                                            ph->getParam<bool>("i_enable_rotation"),
+                                                            enableMagn,
+                                                            ph->getParam<bool>("i_get_base_device_timestamp"));
     imuConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-    param_handlers::imu::ImuMsgType msgType = ph->getMsgType();
     switch(msgType) {
         case param_handlers::imu::ImuMsgType::IMU: {
             rosImuPub = getROSNode().advertise<sensor_msgs::Imu>(getName() + "/data", 10);

--- a/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
@@ -23,7 +23,7 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
                              {"ARVR_STABILIZED_GAME_ROTATION_VECTOR", dai::IMUSensor::ARVR_STABILIZED_GAME_ROTATION_VECTOR}};
     declareAndLogParam<bool>("i_get_base_device_timestamp", false);
     declareAndLogParam<int>("i_max_q_size", 30);
-    auto messageType = declareAndLogParam<std::string>("i_message_type", "IMU");    
+    auto messageType = declareAndLogParam<std::string>("i_message_type", "IMU");
     declareAndLogParam<std::string>("i_sync_method", "LINEAR_INTERPOLATE_ACCEL");
     declareAndLogParam<float>("i_acc_cov", 0.0);
     declareAndLogParam<float>("i_gyro_cov", 0.0);

--- a/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
@@ -16,9 +16,14 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
     };
     imuMessagetTypeMap = {
         {"IMU", imu::ImuMsgType::IMU}, {"IMU_WITH_MAG", imu::ImuMsgType::IMU_WITH_MAG}, {"IMU_WITH_MAG_SPLIT", imu::ImuMsgType::IMU_WITH_MAG_SPLIT}};
+    rotationVectorTypeMap = {{"ROTATION_VECTOR", dai::IMUSensor::ROTATION_VECTOR},
+                             {"GAME_ROTATION_VECTOR", dai::IMUSensor::GAME_ROTATION_VECTOR},
+                             {"GEOMAGNETIC_ROTATION_VECTOR", dai::IMUSensor::GEOMAGNETIC_ROTATION_VECTOR},
+                             {"ARVR_STABILIZED_ROTATION_VECTOR", dai::IMUSensor::ARVR_STABILIZED_ROTATION_VECTOR},
+                             {"ARVR_STABILIZED_GAME_ROTATION_VECTOR", dai::IMUSensor::ARVR_STABILIZED_GAME_ROTATION_VECTOR}};
     declareAndLogParam<bool>("i_get_base_device_timestamp", false);
     declareAndLogParam<int>("i_max_q_size", 30);
-    declareAndLogParam<std::string>("i_message_type", "IMU");
+    auto messageType = declareAndLogParam<std::string>("i_message_type", "IMU");    
     declareAndLogParam<std::string>("i_sync_method", "LINEAR_INTERPOLATE_ACCEL");
     declareAndLogParam<float>("i_acc_cov", 0.0);
     declareAndLogParam<float>("i_gyro_cov", 0.0);
@@ -28,8 +33,13 @@ void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const s
     bool rotationAvailable = imuType == "BNO086";
     if(declareAndLogParam<bool>("i_enable_rotation", false)) {
         if(rotationAvailable) {
-            imu->enableIMUSensor(dai::IMUSensor::ROTATION_VECTOR, declareAndLogParam<int>("i_rot_freq", 400));
-            imu->enableIMUSensor(dai::IMUSensor::MAGNETOMETER_CALIBRATED, declareAndLogParam<int>("i_mag_freq", 100));
+            auto rotationVecType = utils::getValFromMap(utils::getUpperCaseStr(declareAndLogParam<std::string>("i_rotation_vector_type", "ROTATION_VECTOR")),
+                                                        rotationVectorTypeMap);
+            imu->enableIMUSensor(rotationVecType, declareAndLogParam<int>("i_rot_freq", 400));
+            // if imu message type is IMU_WITH_MAG or IMU_WITH_MAG_SPLIT, enable magnetometer
+            if(messageType == "IMU_WITH_MAG" || messageType == "IMU_WITH_MAG_SPLIT") {
+                imu->enableIMUSensor(dai::IMUSensor::MAGNETOMETER_CALIBRATED, declareAndLogParam<int>("i_mag_freq", 100));
+            }
         } else {
             ROS_ERROR("Rotation enabled but not available with current sensor");
             declareAndLogParam<bool>("i_enable_rotation", false, true);


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/446
Issue description: Currently we enable magnetometer sensor when enabling rotation vector, which lowers the output frequency. This PR changes it so that magnetometer readings are being output only when the IMU message type is set to contain the mag data. Additionally, rotation vector types are parameterized now.
Related PRs

## Changes
ROS distro Noetic
List of changes:
- Add rotation vector types
- New template specialization in IMUConverter for converting three messages
- Reorder of parameters in IMU conversion methods
- New flag in IMU converter to enable magnetometer
## Testing
Hardware used: OAK-D-PRO-W
Depthai library version: 2.20


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
