### PR TITLE
Update SR and LR support

### DIFF
--- a/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
@@ -12,6 +12,10 @@
         <xacro:property name="has_imu" value="false" />
         <xacro:property name="baseline" value="0.075" />
 
+        <xacro:if value="${model in ['OAK-D-SR']}">
+            <xacro:property name="baseline" value="0.02" />
+        </xacro:if>
+
         <xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
             <xacro:property name="has_imu" value="true" />
         </xacro:if>
@@ -19,22 +23,25 @@
         <xacro:base camera_name="${camera_name}" parent="${parent}" camera_model="${camera_model}" base_frame="${base_frame}" cam_pos_x="${cam_pos_x}" cam_pos_y="${cam_pos_y}" cam_pos_z="${cam_pos_z}" cam_roll="${cam_roll}" cam_pitch="${cam_pitch}" cam_yaw="${cam_yaw}" has_imu="${has_imu}"/>
 
         <!-- RGB Camera -->
-        <link name="${camera_name}_rgb_camera_frame" />
+        <xacro:unless value="${model in ['OAK-D-SR']}">
+            <link name="${camera_name}_rgb_camera_frame" />
 
-        <joint name="${camera_name}_rgb_camera_joint" type="fixed">
-            <parent link="${base_frame}"/>
-            <child link="${camera_name}_rgb_camera_frame"/>
-            <origin xyz="0 0 0" rpy="0 0 0" />
-        </joint>
+            <joint name="${camera_name}_rgb_camera_joint" type="fixed">
+                <parent link="${base_frame}"/>
+                <child link="${camera_name}_rgb_camera_frame"/>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+            </joint>
 
-        <link name="${camera_name}_rgb_camera_optical_frame"/>
+            <link name="${camera_name}_rgb_camera_optical_frame"/>
 
-        <joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
-            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-            <parent link="${camera_name}_rgb_camera_frame"/>
-            <child link="${camera_name}_rgb_camera_optical_frame"/>
-        </joint>
-
+            <joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
+                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+                <parent link="${camera_name}_rgb_camera_frame"/>
+                <child link="${camera_name}_rgb_camera_optical_frame"/>
+            </joint>
+        </xacro:unless>
+        <xacro:unless value="${model in ['OAK-D-LR']}">
+            
         <!-- Left Camera -->
         <link name="${camera_name}_left_camera_frame" />
 
@@ -70,7 +77,44 @@
             <child link="${camera_name}_right_camera_optical_frame"/>
         </joint>
 
+        </xacro:unless>
 
+        <xacro:if value="${model in ['OAK-D-LR']}">
+
+        <!-- left Camera -->
+        <link name="${camera_name}_left_camera_frame" />
+
+        <joint name="${camera_name}_left_camera_joint" type="fixed">
+            <parent link="${base_frame}"/>
+            <child link="${camera_name}_left_camera_frame"/>
+            <origin xyz="0 0.1 0" rpy="0 0 0" />
+        </joint>
+
+        <link name="${camera_name}_left_camera_optical_frame"/>
+
+        <joint name="${camera_name}_left_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+            <parent link="${camera_name}_left_camera_frame"/>
+            <child link="${camera_name}_left_camera_optical_frame"/>
+        </joint>
+
+         <!-- right Camera -->
+        <link name="${camera_name}_right_camera_frame" />
+
+        <joint name="${camera_name}_right_camera_joint" type="fixed">
+            <parent link="${base_frame}"/>
+            <child link="${camera_name}_right_camera_frame"/>
+            <origin xyz="0 -0.05 0" rpy="0 0 0" />
+        </joint>
+
+        <link name="${camera_name}_right_camera_optical_frame"/>
+
+        <joint name="${camera_name}_right_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+            <parent link="${camera_name}_right_camera_frame"/>
+            <child link="${camera_name}_right_camera_optical_frame"/>
+        </joint>
+    </xacro:if>
     </xacro:macro>
 
 </robot>

--- a/depthai_ros_driver/config/camera.yaml
+++ b/depthai_ros_driver/config/camera.yaml
@@ -7,13 +7,3 @@
       i_pipeline_type: RGBD
     nn:
       i_nn_config_path: depthai_ros_driver/mobilenet
-    left:
-      i_publish_topic: true
-    right:
-      i_publish_topic: true
-    stereo:
-      i_enable_spatial_nn: true
-    stereo_nn:
-      i_nn_config_path: depthai_ros_driver/mobilenet
-    # right_nn:
-      # i_nn_config_path: depthai_ros_driver/mobilenet

--- a/depthai_ros_driver/config/camera.yaml
+++ b/depthai_ros_driver/config/camera.yaml
@@ -7,3 +7,13 @@
       i_pipeline_type: RGBD
     nn:
       i_nn_config_path: depthai_ros_driver/mobilenet
+    left:
+      i_publish_topic: true
+    right:
+      i_publish_topic: true
+    stereo:
+      i_enable_spatial_nn: true
+    stereo_nn:
+      i_nn_config_path: depthai_ros_driver/mobilenet
+    # right_nn:
+      # i_nn_config_path: depthai_ros_driver/mobilenet

--- a/depthai_ros_driver/config/oak_d_sr.yaml
+++ b/depthai_ros_driver/config/oak_d_sr.yaml
@@ -1,0 +1,6 @@
+/oak:
+  ros__parameters:
+    camera:
+      i_pipeline_type: 'Depth'
+    right:
+      i_publish_topic: true

--- a/depthai_ros_driver/config/sr_rgbd.yaml
+++ b/depthai_ros_driver/config/sr_rgbd.yaml
@@ -1,0 +1,9 @@
+/oak:
+  ros__parameters:
+    camera:
+      i_nn_type: none
+      i_pipeline_type: Depth
+    right:
+      i_publish_topic: true
+    stereo:
+      i_extended_disp: true

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "camera_info_manager/camera_info_manager.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/DataQueue.hpp"
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
@@ -16,6 +17,7 @@
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/param_handlers/nn_param_handler.hpp"
+#include "depthai_ros_driver/utils.hpp"
 #include "image_transport/camera_publisher.hpp"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/node.hpp"
@@ -35,12 +37,16 @@ class Detection : public BaseNode {
      * @param      node         The node
      * @param      pipeline     The pipeline
      */
-    Detection(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+    Detection(const std::string& daiNodeName,
+              rclcpp::Node* node,
+              std::shared_ptr<dai::Pipeline> pipeline,
+              const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A)
+        : BaseNode(daiNodeName, node, pipeline) {
         RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
         setNames();
         detectionNode = pipeline->create<T>();
         imageManip = pipeline->create<dai::node::ImageManip>();
-        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
         ph->declareParams(detectionNode, imageManip);
         RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
         imageManip->out.link(detectionNode->input);
@@ -55,12 +61,13 @@ class Detection : public BaseNode {
      */
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        auto tfPrefix = getTFPrefix("rgb");
+        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
+        auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
-            width = getROSNode()->get_parameter("rgb.i_preview_size").as_int();
-            height = getROSNode()->get_parameter("rgb.i_preview_size").as_int();
+            width = ph->getOtherNodeParam<int>(socketName, "i_preview_width");
+            height = ph->getOtherNodeParam<int>(socketName, "i_preview_height");
         } else {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 
 namespace dai {
@@ -25,7 +26,10 @@ namespace dai_nodes {
 
 class NNWrapper : public BaseNode {
    public:
-    explicit NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    explicit NNWrapper(const std::string& daiNodeName,
+                       rclcpp::Node* node,
+                       std::shared_ptr<dai::Pipeline> pipeline,
+                       const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNWrapper();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
@@ -41,7 +41,10 @@ namespace dai_nodes {
 namespace nn {
 class Segmentation : public BaseNode {
    public:
-    Segmentation(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
+    Segmentation(const std::string& daiNodeName,
+                 rclcpp::Node* node,
+                 std::shared_ptr<dai::Pipeline> pipeline,
+                 const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~Segmentation();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "cv_bridge/cv_bridge.h"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "image_transport/camera_publisher.hpp"
 #include "image_transport/image_transport.hpp"
@@ -40,7 +41,7 @@ namespace dai_nodes {
 namespace nn {
 class Segmentation : public BaseNode {
    public:
-    Segmentation(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    Segmentation(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~Segmentation();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -5,13 +5,13 @@
 #include <vector>
 
 #include "camera_info_manager/camera_info_manager.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/DataQueue.hpp"
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/ImageManip.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
-#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_bridge/SpatialDetectionConverter.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
@@ -29,7 +29,11 @@ namespace nn {
 template <typename T>
 class SpatialDetection : public BaseNode {
    public:
-    SpatialDetection(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A) : BaseNode(daiNodeName, node, pipeline) {
+    SpatialDetection(const std::string& daiNodeName,
+                     rclcpp::Node* node,
+                     std::shared_ptr<dai::Pipeline> pipeline,
+                     const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A)
+        : BaseNode(daiNodeName, node, pipeline) {
         RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
         setNames();
         spatialNode = pipeline->create<T>();
@@ -46,9 +50,7 @@ class SpatialDetection : public BaseNode {
     };
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        RCLCPP_INFO(getROSNode()->get_logger(), "Setting up queues for %s", getName().c_str());
-        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))); 
-        RCLCPP_INFO(getROSNode()->get_logger(), "Socket name: %s", socketName.c_str());
+        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
         auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -11,12 +11,14 @@
 #include "depthai/pipeline/node/ImageManip.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_bridge/SpatialDetectionConverter.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/dai_nodes/nn/nn_helpers.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/param_handlers/nn_param_handler.hpp"
+#include "depthai_ros_driver/utils.hpp"
 #include "image_transport/camera_publisher.hpp"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/node.hpp"
@@ -27,12 +29,12 @@ namespace nn {
 template <typename T>
 class SpatialDetection : public BaseNode {
    public:
-    SpatialDetection(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+    SpatialDetection(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A) : BaseNode(daiNodeName, node, pipeline) {
         RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
         setNames();
         spatialNode = pipeline->create<T>();
         imageManip = pipeline->create<dai::node::ImageManip>();
-        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
         ph->declareParams(spatialNode, imageManip);
         RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
         imageManip->out.link(spatialNode->input);
@@ -44,12 +46,15 @@ class SpatialDetection : public BaseNode {
     };
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        auto tfPrefix = getTFPrefix("rgb");
+        RCLCPP_INFO(getROSNode()->get_logger(), "Setting up queues for %s", getName().c_str());
+        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))); 
+        RCLCPP_INFO(getROSNode()->get_logger(), "Socket name: %s", socketName.c_str());
+        auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
-            width = getROSNode()->get_parameter("rgb.i_preview_size").as_int();
-            height = getROSNode()->get_parameter("rgb.i_preview_size").as_int();
+            width = ph->getOtherNodeParam<int>(socketName, "i_preview_width");
+            height = ph->getOtherNodeParam<int>(socketName, "i_preview_height");
         } else {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;
@@ -80,8 +85,8 @@ class SpatialDetection : public BaseNode {
         }
 
         if(ph->getParam<bool>("i_enable_passthrough_depth")) {
-            dai::CameraBoardSocket socket = static_cast<dai::CameraBoardSocket>(getROSNode()->get_parameter("stereo.i_board_socket_id").as_int());
-            if(!getROSNode()->get_parameter("stereo.i_align_depth").as_bool()) {
+            dai::CameraBoardSocket socket = static_cast<dai::CameraBoardSocket>(ph->getOtherNodeParam<int>("stereo", "i_board_socket_id"));
+            if(!ph->getOtherNodeParam<bool>("stereo", "i_align_depth")) {
                 tfPrefix = getTFPrefix("right");
             };
             ptDepthQ = device->getOutputQueue(ptDepthQName, ph->getParam<int>("i_max_q_size"), false);
@@ -93,8 +98,8 @@ class SpatialDetection : public BaseNode {
                                                                        *ptDepthImageConverter,
                                                                        device,
                                                                        socket,
-                                                                       getROSNode()->get_parameter("stereo.i_width").as_int(),
-                                                                       getROSNode()->get_parameter("stereo.i_height").as_int()));
+                                                                       ph->getOtherNodeParam<int>("stereo", "i_width"),
+                                                                       ph->getOtherNodeParam<int>("stereo", "i_height")));
 
             ptDepthPub = image_transport::create_camera_publisher(getROSNode(), "~/" + getName() + "/passthrough_depth/image_raw");
             ptDepthQ->addCallback(

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 
 namespace dai {
 class Pipeline;
@@ -26,7 +27,7 @@ namespace dai_nodes {
 
 class SpatialNNWrapper : public BaseNode {
    public:
-    explicit SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    explicit SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~SpatialNNWrapper();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai-shared/common/CameraBoardSocket.hpp"
+#include "depthai_ros_driver/dai_nodes/base_node.hpp"
 
 namespace dai {
 class Pipeline;
@@ -27,7 +27,10 @@ namespace dai_nodes {
 
 class SpatialNNWrapper : public BaseNode {
    public:
-    explicit SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
+    explicit SpatialNNWrapper(const std::string& daiNodeName,
+                              rclcpp::Node* node,
+                              std::shared_ptr<dai::Pipeline> pipeline,
+                              const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~SpatialNNWrapper();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -53,7 +53,7 @@ class SensorWrapper : public BaseNode {
 
    private:
     void subCB(const sensor_msgs::msg::Image& img);
-    std::unique_ptr<BaseNode> sensorNode, featureTrackerNode;
+    std::unique_ptr<BaseNode> sensorNode, featureTrackerNode, nnNode;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
     std::unique_ptr<dai::ros::ImageConverter> converter;
     rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr sub;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -93,7 +93,7 @@ class Stereo : public BaseNode {
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;
     std::unique_ptr<SensorWrapper> left;
     std::unique_ptr<SensorWrapper> right;
-    std::unique_ptr<BaseNode> featureTrackerLeftR, featureTrackerRightR;
+    std::unique_ptr<BaseNode> featureTrackerLeftR, featureTrackerRightR, nnNode;
     std::unique_ptr<param_handlers::StereoParamHandler> ph;
     std::shared_ptr<dai::DataOutputQueue> stereoQ, leftRectQ, rightRectQ;
     std::shared_ptr<dai::node::XLinkOut> xoutStereo, xoutLeftRect, xoutRightRect;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai-shared/properties/IMUProperties.hpp"
+#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai_bridge/ImuConverter.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -6,9 +6,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
-#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 
 namespace dai {

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -8,6 +8,7 @@
 
 #include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 
 namespace dai {
@@ -33,7 +34,7 @@ enum class NNFamily { Segmentation, Mobilenet, Yolo };
 }
 class NNParamHandler : public BaseParamHandler {
    public:
-    explicit NNParamHandler(rclcpp::Node* node, const std::string& name);
+    explicit NNParamHandler(rclcpp::Node* node, const std::string& name, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNParamHandler();
     nn::NNFamily getNNFamily();
     template <typename T>

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -26,13 +26,14 @@ class StereoParamHandler : public BaseParamHandler {
     ~StereoParamHandler();
     void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
-    void updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right);
+    void updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right, dai::CameraBoardSocket& align);
 
    private:
     std::unordered_map<std::string, dai::node::StereoDepth::PresetMode> depthPresetMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::CostMatching::DisparityWidth> disparityWidthMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode> decimationModeMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode> temporalPersistencyMap;
+    dai::CameraBoardSocket alignSocket;
 };
 }  // namespace param_handlers
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -33,11 +33,11 @@ def launch_setup(context, *args, **kwargs):
     cam_yaw      = LaunchConfiguration('cam_yaw',       default = '0.0')
     use_composition = LaunchConfiguration('rsp_use_composition', default='true')
     imu_from_descr = LaunchConfiguration('imu_from_descr', default='false')
-    pass_tf_args_as_params = LaunchConfiguration('pass_tf_args_as_params', default='false')
+    publish_tf_from_calibration = LaunchConfiguration('publish_tf_from_calibration', default='false')
     override_cam_model = LaunchConfiguration('override_cam_model', default='false')
 
     tf_params = {}
-    if(pass_tf_args_as_params.perform(context) == 'true'):
+    if(publish_tf_from_calibration.perform(context) == 'true'):
         cam_model = ''
         if override_cam_model.perform(context) == 'true':
             cam_model = camera_model.perform(context)
@@ -92,7 +92,7 @@ def launch_setup(context, *args, **kwargs):
                               'cam_pitch': cam_pitch,
                               'cam_yaw': cam_yaw,
                               'use_composition': use_composition,
-                              'use_base_descr': pass_tf_args_as_params}.items()),
+                              'use_base_descr': publish_tf_from_calibration}.items()),
 
         ComposableNodeContainer(
             name=name+"_container",
@@ -132,7 +132,7 @@ def generate_launch_description():
         DeclareLaunchArgument("use_rviz", default_value='false'),
         DeclareLaunchArgument("rviz_config", default_value=os.path.join(depthai_prefix, "config", "rviz", "rgbd.rviz")),
         DeclareLaunchArgument("rsp_use_composition", default_value='true'),
-        DeclareLaunchArgument("pass_tf_args_as_params", default_value='false', description='Enables TF publishing from camera calibration file.'),
+        DeclareLaunchArgument("publish_tf_from_calibration", default_value='false', description='Enables TF publishing from camera calibration file.'),
         DeclareLaunchArgument("imu_from_descr", default_value='false', description='Enables IMU publishing from URDF.'),
         DeclareLaunchArgument("override_cam_model", default_value='false', description='Overrides camera model from calibration file.'),
         DeclareLaunchArgument("use_gdb", default_value='false'),

--- a/depthai_ros_driver/launch/rgbd_pcl.launch.py
+++ b/depthai_ros_driver/launch/rgbd_pcl.launch.py
@@ -71,6 +71,7 @@ def generate_launch_description():
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     declared_arguments = [
         DeclareLaunchArgument("name", default_value="oak"),
+        DeclareLaunchArgument("camera_model", default_value="OAK-D"),
         DeclareLaunchArgument("parent_frame", default_value="oak-d-base-frame"),
         DeclareLaunchArgument("cam_pos_x", default_value="0.0"),
         DeclareLaunchArgument("cam_pos_y", default_value="0.0"),

--- a/depthai_ros_driver/launch/sr_rgbd_pcl.launch.py
+++ b/depthai_ros_driver/launch/sr_rgbd_pcl.launch.py
@@ -1,0 +1,89 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import LoadComposableNodes, Node
+from launch_ros.descriptions import ComposableNode
+from launch.conditions import IfCondition
+
+
+def launch_setup(context, *args, **kwargs):
+    params_file = LaunchConfiguration("params_file")
+    depthai_prefix = get_package_share_directory("depthai_ros_driver")
+
+    name = LaunchConfiguration('name').perform(context)
+    rgb_topic_name = name+'/right/image_raw'
+    if LaunchConfiguration('rectify_rgb').perform(context)=='true':
+        rgb_topic_name = name +'/right/image_rect'
+    return [
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
+            launch_arguments={"name": name,
+                              "params_file": params_file,
+                              "parent_frame": LaunchConfiguration("parent_frame"),
+                               "cam_pos_x": LaunchConfiguration("cam_pos_x"),
+                               "cam_pos_y": LaunchConfiguration("cam_pos_y"),
+                               "cam_pos_z": LaunchConfiguration("cam_pos_z"),
+                               "cam_roll": LaunchConfiguration("cam_roll"),
+                               "cam_pitch": LaunchConfiguration("cam_pitch"),
+                               "cam_yaw": LaunchConfiguration("cam_yaw"),
+                               "use_rviz": LaunchConfiguration("use_rviz")
+                               }.items()),
+
+        LoadComposableNodes(
+            condition=IfCondition(LaunchConfiguration("rectify_rgb")),
+            target_container=name+"_container",
+            composable_node_descriptions=[
+                    ComposableNode(
+                        package="image_proc",
+                        plugin="image_proc::RectifyNode",
+                        name="rectify_color_node",
+                        remappings=[('image', name+'/right/image_raw'),
+                                    ('camera_info', name+'/right/camera_info'),
+                                    ('image_rect', name+'/right/image_rect'),
+                                    ('image_rect/compressed', name+'/right/image_rect/compressed'),
+                                    ('image_rect/compressedDepth', name+'/right/image_rect/compressedDepth'),
+                                    ('image_rect/theora', name+'/right/image_rect/theora')]
+                    )
+            ]),
+        LoadComposableNodes(
+            target_container=name+"_container",
+            composable_node_descriptions=[
+                    ComposableNode(
+                    package='depth_image_proc',
+                    plugin='depth_image_proc::PointCloudXyzrgbNode',
+                    name='point_cloud_xyzrgb_node',
+                    remappings=[('depth_registered/image_rect', name+'/stereo/image_raw'),
+                                ('rgb/image_rect_color', rgb_topic_name),
+                                ('rgb/camera_info', name+'/right/camera_info'),
+                                ('points', name+'/points')]
+                    ),
+            ],
+        ),
+    ]
+
+
+def generate_launch_description():
+    depthai_prefix = get_package_share_directory("depthai_ros_driver")
+    declared_arguments = [
+        DeclareLaunchArgument("name", default_value="oak"),
+        DeclareLaunchArgument("camera_model", default_value="OAK-D-SR"),
+        DeclareLaunchArgument("parent_frame", default_value="oak-d-base-frame"),
+        DeclareLaunchArgument("cam_pos_x", default_value="0.0"),
+        DeclareLaunchArgument("cam_pos_y", default_value="0.0"),
+        DeclareLaunchArgument("cam_pos_z", default_value="0.0"),
+        DeclareLaunchArgument("cam_roll", default_value="0.0"),
+        DeclareLaunchArgument("cam_pitch", default_value="0.0"),
+        DeclareLaunchArgument("cam_yaw", default_value="0.0"),
+        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'sr_rgbd.yaml')),
+        DeclareLaunchArgument("use_rviz", default_value="False"),
+        DeclareLaunchArgument("rectify_rgb", default_value="False"),
+    ]
+
+    return LaunchDescription(
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -62,7 +62,9 @@ void Camera::diagCB(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) 
         if(status.name == get_name() + std::string(": sys_logger")) {
             if(status.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
                 RCLCPP_ERROR(this->get_logger(), "Camera diagnostics error: %s", status.message.c_str());
-                restart();
+                if (ph->getParam<bool>("i_restart_on_diagnostics_error")){
+                    restart();
+                };
             }
         }
     }

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -62,7 +62,7 @@ void Camera::diagCB(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) 
         if(status.name == get_name() + std::string(": sys_logger")) {
             if(status.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
                 RCLCPP_ERROR(this->get_logger(), "Camera diagnostics error: %s", status.message.c_str());
-                if (ph->getParam<bool>("i_restart_on_diagnostics_error")){
+                if(ph->getParam<bool>("i_restart_on_diagnostics_error")) {
                     restart();
                 };
             }

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,9 +10,9 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+NNWrapper::NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket) : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
-    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();
     switch(family) {
         case param_handlers::nn::NNFamily::Yolo: {

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,7 +10,8 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket) : BaseNode(daiNodeName, node, pipeline) {
+NNWrapper::NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+    : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();

--- a/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
@@ -17,18 +17,19 @@
 #include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "depthai_ros_driver/utils.hpp"
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
 namespace nn {
 
-Segmentation::Segmentation(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline)
+Segmentation::Segmentation(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     segNode = pipeline->create<dai::node::NeuralNetwork>();
     imageManip = pipeline->create<dai::node::ImageManip>();
-    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     ph->declareParams(segNode, imageManip);
     RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
     imageManip->out.link(segNode->input);
@@ -58,7 +59,7 @@ void Segmentation::setupQueues(std::shared_ptr<dai::Device> device) {
     nnPub = image_transport::create_camera_publisher(getROSNode(), "~/" + getName() + "/image_raw");
     nnQ->addCallback(std::bind(&Segmentation::segmentationCB, this, std::placeholders::_1, std::placeholders::_2));
     if(ph->getParam<bool>("i_enable_passthrough")) {
-        auto tfPrefix = getTFPrefix("rgb");
+        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         ptQ = device->getOutputQueue(ptQName, ph->getParam<int>("i_max_q_size"), false);
         imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(

--- a/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
@@ -12,12 +12,12 @@
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/param_handlers/nn_param_handler.hpp"
+#include "depthai_ros_driver/utils.hpp"
 #include "image_transport/camera_publisher.hpp"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
-#include "depthai_ros_driver/utils.hpp"
 
 namespace depthai_ros_driver {
 namespace dai_nodes {

--- a/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
@@ -9,10 +9,10 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline)
+SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
-    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();
     switch(family) {
         case param_handlers::nn::NNFamily::Yolo: {

--- a/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
@@ -9,7 +9,10 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName,
+                                   rclcpp::Node* node,
+                                   std::shared_ptr<dai::Pipeline> pipeline,
+                                   const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -125,7 +125,7 @@ sensor_msgs::msg::CameraInfo getCalibInfo(const rclcpp::Logger& logger,
     try {
         info = converter.calibrationToCameraInfo(calibHandler, socket, width, height);
     } catch(std::runtime_error& e) {
-        RCLCPP_ERROR(logger, "No calibration! Publishing empty camera_info.");
+        RCLCPP_ERROR(logger, "No calibration for socket %d! Publishing empty camera_info.", static_cast<int>(socket));
     }
     return info;
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -8,6 +8,7 @@
 #include "depthai_ros_driver/dai_nodes/sensors/mono.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/rgb.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/param_handlers/sensor_param_handler.hpp"
 #include "rclcpp/node.hpp"
 
@@ -53,6 +54,9 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
         }
         RCLCPP_DEBUG(node->get_logger(), "Node %s has sensor %s", daiNodeName.c_str(), sensorName.c_str());
         sensorData = *sensorIt;
+        if (device->getDeviceName() == "OAK-D-SR") {
+            (*sensorIt).color = true; // ov9282 is color sensor in this case
+        }
         if((*sensorIt).color) {
             sensorNode = std::make_unique<RGB>(daiNodeName, node, pipeline, socket, (*sensorIt), publish);
         } else {
@@ -62,6 +66,10 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode = std::make_unique<FeatureTracker>(daiNodeName + std::string("_feature_tracker"), node, pipeline);
         sensorNode->link(featureTrackerNode->getInput());
+    }
+    if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode = std::make_unique<NNWrapper>(daiNodeName + std::string("_nn"), node, pipeline, static_cast<dai::CameraBoardSocket>(socketID));
+        sensorNode->link(nnNode->getInput(), static_cast<int>(link_types::RGBLinkType::preview));
     }
     RCLCPP_DEBUG(node->get_logger(), "Base node %s created", daiNodeName.c_str());
 }
@@ -96,6 +104,9 @@ void SensorWrapper::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode->setupQueues(device);
     }
+    if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode->setupQueues(device);
+    }
 }
 void SensorWrapper::closeQueues() {
     if(ph->getParam<bool>("i_simulate_from_topic")) {
@@ -106,6 +117,9 @@ void SensorWrapper::closeQueues() {
     }
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode->closeQueues();
+    }
+    if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode->closeQueues();
     }
 }
 

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -4,11 +4,11 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/XLinkIn.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/feature_tracker.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/mono.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/rgb.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
-#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/param_handlers/sensor_param_handler.hpp"
 #include "rclcpp/node.hpp"
 
@@ -54,8 +54,8 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
         }
         RCLCPP_DEBUG(node->get_logger(), "Node %s has sensor %s", daiNodeName.c_str(), sensorName.c_str());
         sensorData = *sensorIt;
-        if (device->getDeviceName() == "OAK-D-SR") {
-            (*sensorIt).color = true; // ov9282 is color sensor in this case
+        if(device->getDeviceName() == "OAK-D-SR") {
+            (*sensorIt).color = true;  // ov9282 is color sensor in this case
         }
         if((*sensorIt).color) {
             sensorNode = std::make_unique<RGB>(daiNodeName, node, pipeline, socket, (*sensorIt), publish);

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -35,6 +35,7 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<std::string>("i_external_calibration_path", "");
     declareAndLogParam<int>("i_laser_dot_brightness", 800, getRangedIntDescriptor(0, 1200));
     declareAndLogParam<int>("i_floodlight_brightness", 0, getRangedIntDescriptor(0, 1500));
+    declareAndLogParam<bool>("i_restart_on_diagnostics_error", false);
 
     declareAndLogParam<bool>("i_publish_tf_from_calibration", false);
     declareAndLogParam<std::string>("i_tf_camera_name", getROSNode()->get_name());

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -8,6 +8,7 @@
 #include "depthai/pipeline/node/NeuralNetwork.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai_ros_driver/utils.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node.hpp"
@@ -15,12 +16,13 @@
 namespace depthai_ros_driver {
 namespace param_handlers {
 
-NNParamHandler::NNParamHandler(rclcpp::Node* node, const std::string& name) : BaseParamHandler(node, name) {
+NNParamHandler::NNParamHandler(rclcpp::Node* node, const std::string& name, const dai::CameraBoardSocket& socket) : BaseParamHandler(node, name) {
     nnFamilyMap = {
         {"segmentation", nn::NNFamily::Segmentation},
         {"mobilenet", nn::NNFamily::Mobilenet},
         {"YOLO", nn::NNFamily::Yolo},
     };
+    declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket));
 }
 NNParamHandler::~NNParamHandler() = default;
 nn::NNFamily NNParamHandler::getNNFamily() {

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -3,12 +3,12 @@
 #include <fstream>
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/pipeline/node/DetectionNetwork.hpp"
 #include "depthai/pipeline/node/ImageManip.hpp"
 #include "depthai/pipeline/node/NeuralNetwork.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai_ros_driver/utils.hpp"
-#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node.hpp"

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -28,6 +28,7 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     socketID = static_cast<dai::CameraBoardSocket>(declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket), 0));
     declareAndLogParam<bool>("i_update_ros_base_time_on_ros_msg", false);
     declareAndLogParam<bool>("i_enable_feature_tracker", false);
+    declareAndLogParam<bool>("i_enable_nn", false);
     declareAndLogParam<bool>("i_enable_lazy_publisher", true);
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
@@ -99,9 +100,19 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     int height = colorCam->getResolutionHeight();
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
-    if(declareAndLogParam<bool>("i_set_isp_scale", true)) {
-        int num = declareAndLogParam<int>("i_isp_num", 2);
-        int den = declareAndLogParam<int>("i_isp_den", 3);
+
+    bool setIspScale = true;
+    if (sensor.defaultResolution!="1080P" && sensor.defaultResolution!="1200P"){ // default disable ISP scaling since default resolution is not 1080P or 1200P
+        setIspScale = false;
+    }
+    if(declareAndLogParam<bool>("i_set_isp_scale", setIspScale)) {
+        int num = 2;
+        int den = 3;
+        if(sensor.defaultResolution == "1200P") {
+            den = 5; // for improved performance
+        }
+        num = declareAndLogParam<int>("i_isp_num", num);
+        den = declareAndLogParam<int>("i_isp_den", den);
         width = (width * num + den - 1) / den;
         height = (height * num + den - 1) / den;
         colorCam->setIspScale(num, den);

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -102,14 +102,15 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
 
     bool setIspScale = true;
-    if (sensor.defaultResolution!="1080P" && sensor.defaultResolution!="1200P"){ // default disable ISP scaling since default resolution is not 1080P or 1200P
+    if(sensor.defaultResolution != "1080P"
+       && sensor.defaultResolution != "1200P") {  // default disable ISP scaling since default resolution is not 1080P or 1200P
         setIspScale = false;
     }
     if(declareAndLogParam<bool>("i_set_isp_scale", setIspScale)) {
         int num = 2;
         int den = 3;
         if(sensor.defaultResolution == "1200P") {
-            den = 5; // for improved performance
+            den = 5;  // for improved performance
         }
         num = declareAndLogParam<int>("i_isp_num", num);
         den = declareAndLogParam<int>("i_isp_den", den);

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -55,12 +55,12 @@ std::string PipelineGenerator::validatePipeline(rclcpp::Node* node, const std::s
     auto pType = utils::getValFromMap(typeStr, pipelineTypeMap);
     if(sensorNum == 1) {
         if(pType != PipelineType::RGB) {
-            RCLCPP_ERROR(node->get_logger(), "Wrong pipeline chosen for camera as it has only one sensor. Switching to RGB.");
+            RCLCPP_ERROR(node->get_logger(), "Invalid pipeline chosen for camera as it has only one sensor. Switching to RGB.");
             return "RGB";
         }
     } else if(sensorNum == 2) {
         if(pType != PipelineType::Stereo && pType != PipelineType::Depth) {
-            RCLCPP_ERROR(node->get_logger(), "Wrong pipeline chosen for camera as it has only stereo pair. Switching to Depth.");
+            RCLCPP_ERROR(node->get_logger(), "Invalid pipeline chosen for camera as it has only stereo pair. Switching to Depth.");
             return "DEPTH";
         }
     }

--- a/depthai_ros_driver/src/utils.cpp
+++ b/depthai_ros_driver/src/utils.cpp
@@ -11,7 +11,6 @@ std::string getUpperCaseStr(const std::string& string) {
     return upper;
 }
 std::string getSocketName(dai::CameraBoardSocket socket) {
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "socket: %d", socket);
     return dai_nodes::sensor_helpers::socketNameMap.at(socket);
 }
 }  // namespace utils

--- a/depthai_ros_driver/src/utils.cpp
+++ b/depthai_ros_driver/src/utils.cpp
@@ -11,6 +11,7 @@ std::string getUpperCaseStr(const std::string& string) {
     return upper;
 }
 std::string getSocketName(dai::CameraBoardSocket socket) {
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "socket: %d", socket);
     return dai_nodes::sensor_helpers::socketNameMap.at(socket);
 }
 }  // namespace utils


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/471 https://github.com/luxonis/depthai-ros/issues/470
Issue description: Update out-of-the box experience for LR/SR/Wide users. Additionally add an options to attach NNs to sensor/stereo nodes
Related PRs

## Changes
ROS distro: Humble
List of changes:
- Add URDF setup for LR and SR
- Automatically change ISP scaling parameter based on camera model to prevent unusable configurations
- Custom ISP num/den for LR for better output syncing
- Add NN enabling for individual sensors
- Add Spatial NN to a stereo setup
- Add parameter to enable/disable camera restart on lack of diagnostic data
- Update NN publishers to provide correct frame ID based on set socket
- Replace `pass_tf_args_as_params` with `publish_tf_from_calibration` argument for clarity
- RSP's robot description param is now namespaced to be consistent with TF publisher

## Testing
Hardware used: OAK-D-SR, OAK-D-LR, OAK-D-PRO-W (OV9872)
Depthai library version: 2.23


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
