### PR TITLE
Sr lr update noetic

### DIFF
--- a/depthai_descriptions/launch/urdf.launch
+++ b/depthai_descriptions/launch/urdf.launch
@@ -15,7 +15,7 @@
     <arg name="cam_yaw"               default="0.0" /> <!-- Orientation respect to base frame (i.e. "base_link) -->
 
 
-    <param name="robot_description"
+    <param name="$(arg tf_prefix)/robot_description"
                command="$(find xacro)/xacro '$(find depthai_descriptions)/urdf/depthai_descr.urdf.xacro'
                         camera_name:=$(arg tf_prefix)
                         camera_model:=$(arg camera_model)
@@ -29,5 +29,7 @@
                         cam_yaw:=$(arg cam_yaw)"/>
 
 
-    <node name="$(arg tf_prefix)_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen" required="true"/>
+    <node name="$(arg tf_prefix)_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen" required="true">
+        <remap from="robot_description" to="$(arg tf_prefix)/robot_description"/>
+    </node>
 </launch>

--- a/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
@@ -12,28 +12,36 @@
         <xacro:property name="has_imu" value="false" />
         <xacro:property name="baseline" value="0.075" />
 
+        <xacro:if value="${model in ['OAK-D-SR']}">
+            <xacro:property name="baseline" value="0.02" />
+        </xacro:if>
+
         <xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
             <xacro:property name="has_imu" value="true" />
         </xacro:if>
 
         <xacro:base camera_name="${camera_name}" parent="${parent}" camera_model="${camera_model}" base_frame="${base_frame}" cam_pos_x="${cam_pos_x}" cam_pos_y="${cam_pos_y}" cam_pos_z="${cam_pos_z}" cam_roll="${cam_roll}" cam_pitch="${cam_pitch}" cam_yaw="${cam_yaw}" has_imu="${has_imu}"/>
+
         <!-- RGB Camera -->
-        <link name="${camera_name}_rgb_camera_frame" />
+        <xacro:unless value="${model in ['OAK-D-SR']}">
+            <link name="${camera_name}_rgb_camera_frame" />
 
-        <joint name="${camera_name}_rgb_camera_joint" type="fixed">
-            <parent link="${base_frame}"/>
-            <child link="${camera_name}_rgb_camera_frame"/>
-            <origin xyz="0 0 0" rpy="0 0 0" />
-        </joint>
+            <joint name="${camera_name}_rgb_camera_joint" type="fixed">
+                <parent link="${base_frame}"/>
+                <child link="${camera_name}_rgb_camera_frame"/>
+                <origin xyz="0 0 0" rpy="0 0 0" />
+            </joint>
 
-        <link name="${camera_name}_rgb_camera_optical_frame"/>
+            <link name="${camera_name}_rgb_camera_optical_frame"/>
 
-        <joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
-            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-            <parent link="${camera_name}_rgb_camera_frame"/>
-            <child link="${camera_name}_rgb_camera_optical_frame"/>
-        </joint>
-
+            <joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
+                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+                <parent link="${camera_name}_rgb_camera_frame"/>
+                <child link="${camera_name}_rgb_camera_optical_frame"/>
+            </joint>
+        </xacro:unless>
+        <xacro:unless value="${model in ['OAK-D-LR']}">
+            
         <!-- Left Camera -->
         <link name="${camera_name}_left_camera_frame" />
 
@@ -69,7 +77,44 @@
             <child link="${camera_name}_right_camera_optical_frame"/>
         </joint>
 
+        </xacro:unless>
 
+        <xacro:if value="${model in ['OAK-D-LR']}">
+
+        <!-- left Camera -->
+        <link name="${camera_name}_left_camera_frame" />
+
+        <joint name="${camera_name}_left_camera_joint" type="fixed">
+            <parent link="${base_frame}"/>
+            <child link="${camera_name}_left_camera_frame"/>
+            <origin xyz="0 0.1 0" rpy="0 0 0" />
+        </joint>
+
+        <link name="${camera_name}_left_camera_optical_frame"/>
+
+        <joint name="${camera_name}_left_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+            <parent link="${camera_name}_left_camera_frame"/>
+            <child link="${camera_name}_left_camera_optical_frame"/>
+        </joint>
+
+         <!-- right Camera -->
+        <link name="${camera_name}_right_camera_frame" />
+
+        <joint name="${camera_name}_right_camera_joint" type="fixed">
+            <parent link="${base_frame}"/>
+            <child link="${camera_name}_right_camera_frame"/>
+            <origin xyz="0 -0.05 0" rpy="0 0 0" />
+        </joint>
+
+        <link name="${camera_name}_right_camera_optical_frame"/>
+
+        <joint name="${camera_name}_right_camera_optical_joint" type="fixed">
+            <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
+            <parent link="${camera_name}_right_camera_frame"/>
+            <child link="${camera_name}_right_camera_optical_frame"/>
+        </joint>
+    </xacro:if>
     </xacro:macro>
 
 </robot>

--- a/depthai_ros_driver/config/sr_rgbd.yaml
+++ b/depthai_ros_driver/config/sr_rgbd.yaml
@@ -1,0 +1,5 @@
+/oak:
+    camera_i_nn_type: none
+    camera_i_pipeline_type: 'Depth'
+    right_i_publish_topic: true
+    stereo_i_extended_disp: true

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -38,7 +38,11 @@ class Detection : public BaseNode {
      * @param      node         The node
      * @param      pipeline     The pipeline
      */
-    Detection(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline,const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A) : BaseNode(daiNodeName, node, pipeline), it(node) {
+    Detection(const std::string& daiNodeName,
+              ros::NodeHandle node,
+              std::shared_ptr<dai::Pipeline> pipeline,
+              const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A)
+        : BaseNode(daiNodeName, node, pipeline), it(node) {
         ROS_DEBUG("Creating node %s", daiNodeName.c_str());
         setNames();
         detectionNode = pipeline->create<T>();

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "camera_info_manager/camera_info_manager.h"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/DataQueue.hpp"
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
@@ -17,6 +18,7 @@
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/param_handlers/nn_param_handler.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
+#include "depthai_ros_driver/utils.hpp"
 #include "image_transport/camera_publisher.h"
 #include "image_transport/image_transport.h"
 #include "ros/node_handle.h"
@@ -36,12 +38,12 @@ class Detection : public BaseNode {
      * @param      node         The node
      * @param      pipeline     The pipeline
      */
-    Detection(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline), it(node) {
+    Detection(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline,const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A) : BaseNode(daiNodeName, node, pipeline), it(node) {
         ROS_DEBUG("Creating node %s", daiNodeName.c_str());
         setNames();
         detectionNode = pipeline->create<T>();
         imageManip = pipeline->create<dai::node::ImageManip>();
-        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
         ph->declareParams(detectionNode, imageManip);
         ROS_DEBUG("Node %s created", daiNodeName.c_str());
         imageManip->out.link(detectionNode->input);
@@ -56,12 +58,13 @@ class Detection : public BaseNode {
      */
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        auto tfPrefix = getTFPrefix("rgb");
+        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
+        auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
-            width = ph->getOtherNodeParam<int>("rgb", "i_preview_size");
-            height = ph->getOtherNodeParam<int>("rgb", "i_preview_size");
+            width = ph->getOtherNodeParam<int>(socketName, "i_preview_width");
+            height = ph->getOtherNodeParam<int>(socketName, "i_preview_height");
         } else {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
 
@@ -25,7 +26,10 @@ namespace dai_nodes {
 
 class NNWrapper : public BaseNode {
    public:
-    explicit NNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline);
+    explicit NNWrapper(const std::string& daiNodeName,
+                       ros::NodeHandle node,
+                       std::shared_ptr<dai::Pipeline> pipeline,
+                       const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNWrapper();
     void updateParams(parametersConfig& config) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "cv_bridge/cv_bridge.h"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
 #include "image_transport/camera_publisher.h"
@@ -39,7 +40,10 @@ namespace dai_nodes {
 namespace nn {
 class Segmentation : public BaseNode {
    public:
-    Segmentation(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline);
+    Segmentation(const std::string& daiNodeName,
+                 ros::NodeHandle node,
+                 std::shared_ptr<dai::Pipeline> pipeline,
+                 const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~Segmentation();
     void updateParams(parametersConfig& config) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "camera_info_manager/camera_info_manager.h"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/DataQueue.hpp"
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
@@ -18,6 +19,7 @@
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/param_handlers/nn_param_handler.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
+#include "depthai_ros_driver/utils.hpp"
 #include "image_transport/camera_publisher.h"
 #include "image_transport/image_transport.h"
 #include "ros/node_handle.h"
@@ -28,13 +30,16 @@ namespace nn {
 template <typename T>
 class SpatialDetection : public BaseNode {
    public:
-    SpatialDetection(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline)
+    SpatialDetection(const std::string& daiNodeName,
+                     ros::NodeHandle node,
+                     std::shared_ptr<dai::Pipeline> pipeline,
+                     const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A)
         : BaseNode(daiNodeName, node, pipeline), it(node) {
         ROS_DEBUG("Creating node %s", daiNodeName.c_str());
         setNames();
         spatialNode = pipeline->create<T>();
         imageManip = pipeline->create<dai::node::ImageManip>();
-        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+        ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
         ph->declareParams(spatialNode, imageManip);
         ROS_DEBUG("Node %s created", daiNodeName.c_str());
         imageManip->out.link(spatialNode->input);
@@ -46,12 +51,14 @@ class SpatialDetection : public BaseNode {
     };
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        auto tfPrefix = getTFPrefix("rgb");
+        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
+
+        auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
-            width = ph->getOtherNodeParam<int>("rgb", "i_preview_size");
-            height = ph->getOtherNodeParam<int>("rgb", "i_preview_size");
+            width = ph->getOtherNodeParam<int>(socketName, "i_preview_width");
+            height = ph->getOtherNodeParam<int>(socketName, "i_preview_height");
         } else {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;
@@ -74,10 +81,8 @@ class SpatialDetection : public BaseNode {
         }
 
         if(ph->getParam<bool>("i_enable_passthrough_depth")) {
-            dai::CameraBoardSocket socket = dai::CameraBoardSocket::CAM_A;
-            bool align;
-            getROSNode().getParam("stereo_i_align_depth", align);
-            if(!align) {
+            dai::CameraBoardSocket socket = static_cast<dai::CameraBoardSocket>(ph->getOtherNodeParam<int>("stereo", "i_board_socket_id"));
+            if(!ph->getOtherNodeParam<bool>("stereo", "i_align_depth")) {
                 tfPrefix = getTFPrefix("right");
                 socket = dai::CameraBoardSocket::CAM_C;
             };

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
 
 namespace dai {
@@ -26,7 +27,7 @@ namespace dai_nodes {
 
 class SpatialNNWrapper : public BaseNode {
    public:
-    explicit SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline);
+    explicit SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~SpatialNNWrapper();
     void updateParams(parametersConfig& config) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai-shared/common/CameraBoardSocket.hpp"
+#include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/parametersConfig.h"
 
 namespace dai {
@@ -27,7 +27,10 @@ namespace dai_nodes {
 
 class SpatialNNWrapper : public BaseNode {
    public:
-    explicit SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
+    explicit SpatialNNWrapper(const std::string& daiNodeName,
+                              ros::NodeHandle node,
+                              std::shared_ptr<dai::Pipeline> pipeline,
+                              const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~SpatialNNWrapper();
     void updateParams(parametersConfig& config) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -52,7 +52,7 @@ class SensorWrapper : public BaseNode {
 
    private:
     void subCB(const sensor_msgs::Image::ConstPtr& img);
-    std::unique_ptr<BaseNode> sensorNode, featureTrackerNode;
+    std::unique_ptr<BaseNode> sensorNode, featureTrackerNode, nnNode;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
     std::unique_ptr<dai::ros::ImageConverter> converter;
     ros::Subscriber sub;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -84,7 +84,7 @@ class Stereo : public BaseNode {
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;
     std::unique_ptr<SensorWrapper> left;
     std::unique_ptr<SensorWrapper> right;
-    std::unique_ptr<BaseNode> featureTrackerLeftR, featureTrackerRightR;
+    std::unique_ptr<BaseNode> featureTrackerLeftR, featureTrackerRightR, nnNode;
     std::unique_ptr<param_handlers::StereoParamHandler> ph;
     std::shared_ptr<dai::DataOutputQueue> stereoQ, leftRectQ, rightRectQ;
     std::shared_ptr<dai::node::XLinkOut> xoutStereo, xoutLeftRect, xoutRightRect;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -6,8 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai-shared/common/CameraBoardSocket.hpp"
+#include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 #include "nlohmann/json.hpp"
 

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
 #include "nlohmann/json.hpp"
 
@@ -32,7 +33,7 @@ enum class NNFamily { Segmentation, Mobilenet, Yolo };
 }
 class NNParamHandler : public BaseParamHandler {
    public:
-    explicit NNParamHandler(ros::NodeHandle node, const std::string& name);
+    explicit NNParamHandler(ros::NodeHandle node, const std::string& name, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNParamHandler();
     nn::NNFamily getNNFamily();
     std::string getConfigPath();

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -25,13 +25,14 @@ class StereoParamHandler : public BaseParamHandler {
     ~StereoParamHandler();
     void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo);
     dai::CameraControl setRuntimeParams(parametersConfig& config) override;
-    void updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right);
+    void updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right, dai::CameraBoardSocket& align);
 
    private:
     std::unordered_map<std::string, dai::node::StereoDepth::PresetMode> depthPresetMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::CostMatching::DisparityWidth> disparityWidthMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::DecimationFilter::DecimationMode> decimationModeMap;
     std::unordered_map<std::string, dai::StereoDepthConfig::PostProcessing::TemporalFilter::PersistencyMode> temporalPersistencyMap;
+    dai::CameraBoardSocket alignSocket;
 };
 }  // namespace param_handlers
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/launch/camera.launch
+++ b/depthai_ros_driver/launch/camera.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="pass_tf_args_as_params" default="false" /> 
+    <arg name="publish_tf_from_calibration" default="false" />
     <arg name="imu_from_descr" default="false" />
     <arg name="override_cam_model" default="false" />
 
@@ -35,7 +35,7 @@
     <param name="$(arg name)/camera_i_cam_pitch" value="$(arg cam_pitch)"/>
     <param name="$(arg name)/camera_i_cam_yaw" value="$(arg cam_yaw)"/>
     <param name="$(arg name)/camera_i_imu_from_descr" value="$(arg imu_from_descr)"/>
-    <param name="$(arg name)/camera_i_publish_tf_from_calibration" value="$(arg pass_tf_args_as_params)"/>
+    <param name="$(arg name)/camera_i_publish_tf_from_calibration" value="$(arg publish_tf_from_calibration)"/>
 
     <arg name="launch_prefix" default=""/>
 
@@ -43,7 +43,7 @@
     <rosparam file="$(arg params_file)" />
     <node pkg="rosservice" if="$(optenv DEPTHAI_DEBUG 0)" type="rosservice" name="set_log_level" args="call --wait /oak_nodelet_manager/set_logger_level 'ros.depthai_ros_driver' 'debug'" />
     
-    <include unless="$(arg pass_tf_args_as_params)" file="$(find depthai_descriptions)/launch/urdf.launch">
+    <include unless="$(arg publish_tf_from_calibration)" file="$(find depthai_descriptions)/launch/urdf.launch">
         <arg name="base_frame" value="$(arg  name)" />
         <arg name="parent_frame" value="$(arg  parent_frame)"/>
         <arg name="camera_model" value="$(arg  camera_model)"/>

--- a/depthai_ros_driver/launch/camera.launch
+++ b/depthai_ros_driver/launch/camera.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="pass_tf_args_as_params" default="false" />
+    <arg name="pass_tf_args_as_params" default="false" /> 
     <arg name="imu_from_descr" default="false" />
     <arg name="override_cam_model" default="false" />
 
@@ -42,20 +42,20 @@
 
     <rosparam file="$(arg params_file)" />
     <node pkg="rosservice" if="$(optenv DEPTHAI_DEBUG 0)" type="rosservice" name="set_log_level" args="call --wait /oak_nodelet_manager/set_logger_level 'ros.depthai_ros_driver' 'debug'" />
-    <group if="$(arg pass_tf_args_as_params)">
-        <include file="$(find depthai_descriptions)/launch/urdf.launch">
-            <arg name="base_frame" value="$(arg  name)" />
-            <arg name="parent_frame" value="$(arg  parent_frame)"/>
-            <arg name="camera_model" value="$(arg  camera_model)"/>
-            <arg name="tf_prefix" value="$(arg  name)" />
-            <arg name="cam_pos_x" value="$(arg  cam_pos_x)" />
-            <arg name="cam_pos_y" value="$(arg  cam_pos_y)" />
-            <arg name="cam_pos_z" value="$(arg  cam_pos_z)" />
-            <arg name="cam_roll" value="$(arg  cam_roll)" />
-            <arg name="cam_pitch" value="$(arg  cam_pitch)" />
-            <arg name="cam_yaw" value="$(arg  cam_yaw)" />
-        </include>
-    </group>
+    
+    <include unless="$(arg pass_tf_args_as_params)" file="$(find depthai_descriptions)/launch/urdf.launch">
+        <arg name="base_frame" value="$(arg  name)" />
+        <arg name="parent_frame" value="$(arg  parent_frame)"/>
+        <arg name="camera_model" value="$(arg  camera_model)"/>
+        <arg name="tf_prefix" value="$(arg  name)" />
+        <arg name="cam_pos_x" value="$(arg  cam_pos_x)" />
+        <arg name="cam_pos_y" value="$(arg  cam_pos_y)" />
+        <arg name="cam_pos_z" value="$(arg  cam_pos_z)" />
+        <arg name="cam_roll" value="$(arg  cam_roll)" />
+        <arg name="cam_pitch" value="$(arg  cam_pitch)" />
+        <arg name="cam_yaw" value="$(arg  cam_yaw)" />
+    </include>
+
 
     <node pkg="nodelet" type="nodelet" name="$(arg  name)_nodelet_manager"  launch-prefix="$(arg launch_prefix)" args="manager" output="screen">
         <remap from="/nodelet_manager/load_nodelet" to="$(arg name)/nodelet_manager/load_nodelet"/>

--- a/depthai_ros_driver/launch/sr_rgbd_pcl.launch
+++ b/depthai_ros_driver/launch/sr_rgbd_pcl.launch
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="params_file" default="$(find depthai_ros_driver)/config/sr_rgbd.yaml"/>
+
+    <arg name="name" default="oak" />
+    <arg name="rectify_rgb" default="false"/>
+    <arg name="camera_model" default="OAK-D-SR" />
+
+    <arg name="base_frame" default="oak-d_frame" />
+    <arg name="parent_frame" default="oak-d-base-frame" />
+
+    <arg name="cam_pos_x" default="0.0" />
+    <!-- Position respect to base frame (i.e. "base_link) -->
+    <arg name="cam_pos_y" default="0.0" />
+    <!-- Position respect to base frame (i.e. "base_link) -->
+    <arg name="cam_pos_z" default="0.0" />
+    <!-- Position respect to base frame (i.e. "base_link) -->
+    <arg name="cam_roll" default="0.0" />
+    <!-- Orientation respect to base frame (i.e. "base_link) -->
+    <arg name="cam_pitch" default="0.0" />
+    <!-- Orientation respect to base frame (i.e. "base_link) -->
+    <arg name="cam_yaw" default="0.0" />
+    <!-- Orientation respect to base frame (i.e. "base_link) -->
+
+    <rosparam file="$(arg params_file)" />
+    <include file="$(find depthai_ros_driver)/launch/camera.launch">
+        <arg name="name" value="$(arg name)"/>
+        <arg name="params_file" value="$(arg params_file)"/>
+        <arg name="base_frame" value="$(arg  name)" />
+        <arg name="parent_frame" value="$(arg  parent_frame)"/>
+        <arg name="camera_model" value="$(arg  camera_model)"/>
+        <arg name="cam_pos_x" value="$(arg  cam_pos_x)" />
+        <arg name="cam_pos_y" value="$(arg  cam_pos_y)" />
+        <arg name="cam_pos_z" value="$(arg  cam_pos_z)" />
+        <arg name="cam_roll" value="$(arg  cam_roll)" />
+        <arg name="cam_pitch" value="$(arg  cam_pitch)" />
+        <arg name="cam_yaw" value="$(arg  cam_yaw)" />
+    </include>
+
+
+
+    <node pkg="nodelet" type="nodelet" name="rectify_color"
+            args="load image_proc/rectify $(arg  name)_nodelet_manager" if="$(arg rectify_rgb)">
+            <remap from="image_mono" to="$(arg name)/right/image_raw"/>
+        <remap from="image_rect" to="$(arg name)/right/image_rect"/>
+    </node>  
+
+    <node pkg="nodelet" type="nodelet" name="depth_image_to_rgb_pointcloud"
+        args="load depth_image_proc/point_cloud_xyzrgb $(arg  name)_nodelet_manager">
+        <param name="queue_size"          value="10"/>
+
+        <remap from="rgb/camera_info" to="$(arg name)/right/camera_info"/>
+        <remap from="rgb/image_rect_color" to="$(arg name)/right/image_rect" if="$(arg rectify_rgb)"/>
+        <remap from="rgb/image_rect_color" to="$(arg name)/right/image_raw" unless="$(arg rectify_rgb)"/>
+        <remap from="depth_registered/image_rect" to="$(arg name)/stereo/image_raw"/>    
+        <remap from="depth_registered/points" to="$(arg name)/points"/>
+    </node>
+
+
+</launch>

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -59,7 +59,9 @@ void Camera::diagCB(const diagnostic_msgs::DiagnosticArray::ConstPtr& msg) {
         if(status.name == nodeletName + std::string(": sys_logger")) {
             if(status.level == diagnostic_msgs::DiagnosticStatus::ERROR) {
                 ROS_ERROR("Camera diagnostics error: %s", status.message.c_str());
-                restart();
+                if(ph->getParam<bool>("i_restart_on_diagnostics_error")){
+                    restart();
+                }
             }
         }
     }

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -59,7 +59,7 @@ void Camera::diagCB(const diagnostic_msgs::DiagnosticArray::ConstPtr& msg) {
         if(status.name == nodeletName + std::string(": sys_logger")) {
             if(status.level == diagnostic_msgs::DiagnosticStatus::ERROR) {
                 ROS_ERROR("Camera diagnostics error: %s", status.message.c_str());
-                if(ph->getParam<bool>("i_restart_on_diagnostics_error")){
+                if(ph->getParam<bool>("i_restart_on_diagnostics_error")) {
                     restart();
                 }
             }

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,7 +10,8 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket) : BaseNode(daiNodeName, node, pipeline) {
+NNWrapper::NNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+    : BaseNode(daiNodeName, node, pipeline) {
     ROS_DEBUG("Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,9 +10,9 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+NNWrapper::NNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket) : BaseNode(daiNodeName, node, pipeline) {
     ROS_DEBUG("Creating node %s base", daiNodeName.c_str());
-    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();
     switch(family) {
         case param_handlers::nn::NNFamily::Yolo: {

--- a/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
@@ -9,10 +9,10 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline)
+SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     ROS_DEBUG("Creating node %s base", daiNodeName.c_str());
-    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName);
+    ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);
     auto family = ph->getNNFamily();
     switch(family) {
         case param_handlers::nn::NNFamily::Yolo: {

--- a/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
@@ -9,7 +9,10 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName, ros::NodeHandle node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName,
+                                   ros::NodeHandle node,
+                                   std::shared_ptr<dai::Pipeline> pipeline,
+                                   const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     ROS_DEBUG("Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -100,7 +100,7 @@ sensor_msgs::CameraInfo getCalibInfo(
     try {
         info = converter.calibrationToCameraInfo(calibHandler, socket, width, height);
     } catch(std::runtime_error& e) {
-        ROS_ERROR("No calibration! Publishing empty camera_info.");
+        ROS_ERROR("No calibration for socket %d! Publishing empty camera_info.", static_cast<int>(socket));
     }
     return info;
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -4,11 +4,11 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/XLinkIn.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/feature_tracker.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/mono.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/rgb.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
-#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/param_handlers/sensor_param_handler.hpp"
 #include "ros/node_handle.h"
 
@@ -53,8 +53,8 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
         }
         ROS_DEBUG("Node %s has sensor %s", daiNodeName.c_str(), sensorName.c_str());
         sensorData = *sensorIt;
-        if (device->getDeviceName() == "OAK-D-SR") {
-            (*sensorIt).color = true; // ov9282 is color sensor in this case
+        if(device->getDeviceName() == "OAK-D-SR") {
+            (*sensorIt).color = true;  // ov9282 is color sensor in this case
         }
         if((*sensorIt).color) {
             sensorNode = std::make_unique<RGB>(daiNodeName, node, pipeline, socket, (*sensorIt), publish);
@@ -118,7 +118,7 @@ void SensorWrapper::closeQueues() {
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode->closeQueues();
     }
-        if(ph->getParam<bool>("i_enable_nn")) {
+    if(ph->getParam<bool>("i_enable_nn")) {
         nnNode->closeQueues();
     }
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -8,6 +8,7 @@
 #include "depthai_ros_driver/dai_nodes/sensors/mono.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/rgb.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp"
 #include "depthai_ros_driver/param_handlers/sensor_param_handler.hpp"
 #include "ros/node_handle.h"
 
@@ -52,6 +53,9 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
         }
         ROS_DEBUG("Node %s has sensor %s", daiNodeName.c_str(), sensorName.c_str());
         sensorData = *sensorIt;
+        if (device->getDeviceName() == "OAK-D-SR") {
+            (*sensorIt).color = true; // ov9282 is color sensor in this case
+        }
         if((*sensorIt).color) {
             sensorNode = std::make_unique<RGB>(daiNodeName, node, pipeline, socket, (*sensorIt), publish);
         } else {
@@ -61,6 +65,10 @@ SensorWrapper::SensorWrapper(const std::string& daiNodeName,
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode = std::make_unique<FeatureTracker>(daiNodeName + std::string("_feature_tracker"), node, pipeline);
         sensorNode->link(featureTrackerNode->getInput());
+    }
+    if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode = std::make_unique<NNWrapper>(daiNodeName + std::string("_nn"), node, pipeline, static_cast<dai::CameraBoardSocket>(socketID));
+        sensorNode->link(nnNode->getInput(), static_cast<int>(link_types::RGBLinkType::preview));
     }
     ROS_DEBUG("Base node %s created", daiNodeName.c_str());
 }
@@ -96,6 +104,9 @@ void SensorWrapper::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode->setupQueues(device);
     }
+    if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode->setupQueues(device);
+    }
 }
 void SensorWrapper::closeQueues() {
     if(ph->getParam<bool>("i_simulate_from_topic")) {
@@ -106,6 +117,9 @@ void SensorWrapper::closeQueues() {
     }
     if(ph->getParam<bool>("i_enable_feature_tracker")) {
         featureTrackerNode->closeQueues();
+    }
+        if(ph->getParam<bool>("i_enable_nn")) {
+        nnNode->closeQueues();
     }
 }
 

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -9,6 +9,8 @@
 #include "depthai/pipeline/node/VideoEncoder.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/nn_helpers.hpp"
+#include "depthai_ros_driver/dai_nodes/nn/spatial_nn_wrapper.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/feature_tracker.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp"
@@ -30,7 +32,11 @@ Stereo::Stereo(const std::string& daiNodeName,
     ROS_DEBUG("Creating node %s", daiNodeName.c_str());
     setNames();
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
-    ph->updateSocketsFromParams(leftSocket, rightSocket);
+    auto alignSocket = dai::CameraBoardSocket::CAM_A;
+    if(device->getDeviceName() == "OAK-D-SR") {
+        alignSocket = dai::CameraBoardSocket::CAM_C;
+    }
+    ph->updateSocketsFromParams(leftSocket, rightSocket, alignSocket);
     auto features = device->getConnectedCameraFeatures();
     for(auto f : features) {
         if(f.socket == leftSocket) {
@@ -51,6 +57,18 @@ Stereo::Stereo(const std::string& daiNodeName,
     setXinXout(pipeline);
     left->link(stereoCamNode->left);
     right->link(stereoCamNode->right);
+    if(ph->getParam<bool>("i_enable_spatial_nn")) {
+        if(ph->getParam<std::string>("i_spatial_nn_source") == "left") {
+            nnNode = std::make_unique<SpatialNNWrapper>(getName() + "_spatial_nn", getROSNode(), pipeline, leftSensInfo.socket);
+            left->link(nnNode->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::input)),
+                       static_cast<int>(dai_nodes::link_types::RGBLinkType::preview));
+        } else {
+            nnNode = std::make_unique<SpatialNNWrapper>(getName() + "_spatial_nn", getROSNode(), pipeline, rightSensInfo.socket);
+            right->link(nnNode->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::input)),
+                        static_cast<int>(dai_nodes::link_types::RGBLinkType::preview));
+        }
+        stereoCamNode->depth.link(nnNode->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::inputDepth)));
+    }
     ROS_DEBUG("Node %s created", daiNodeName.c_str());
 }
 Stereo::~Stereo() = default;
@@ -276,6 +294,9 @@ void Stereo::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_right_rect_enable_feature_tracker")) {
         featureTrackerRightR->setupQueues(device);
     }
+    if(ph->getParam<bool>("i_enable_spatial_nn")) {
+        nnNode->setupQueues(device);
+    }
 }
 void Stereo::closeQueues() {
     left->closeQueues();
@@ -299,6 +320,9 @@ void Stereo::closeQueues() {
     }
     if(ph->getParam<bool>("i_right_rect_enable_feature_tracker")) {
         featureTrackerRightR->closeQueues();
+    }
+    if(ph->getParam<bool>("i_enable_spatial_nn")) {
+        nnNode->closeQueues();
     }
 }
 

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -35,6 +35,7 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<std::string>("i_external_calibration_path", "");
     declareAndLogParam("i_laser_dot_brightness", 800, getRangedIntDescriptor(0, 1200));
     declareAndLogParam("i_floodlight_brightness", 0, getRangedIntDescriptor(0, 1500));
+    declareAndLogParam<bool>("i_restart_on_diagnostics_error", false);
     declareAndLogParam<bool>("i_publish_tf_from_calibration", false);
     declareAndLogParam<std::string>("i_tf_camera_name", "oak");
     declareAndLogParam<std::string>("i_tf_camera_model", "");

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -7,6 +7,7 @@
 #include "depthai/pipeline/node/NeuralNetwork.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai_ros_driver/utils.hpp"
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 #include "ros/node_handle.h"
 #include "ros/package.h"
@@ -14,12 +15,13 @@
 namespace depthai_ros_driver {
 namespace param_handlers {
 
-NNParamHandler::NNParamHandler(ros::NodeHandle node, const std::string& name) : BaseParamHandler(node, name) {
+NNParamHandler::NNParamHandler(ros::NodeHandle node, const std::string& name, const dai::CameraBoardSocket& socket) : BaseParamHandler(node, name) {
     nnFamilyMap = {
         {"segmentation", nn::NNFamily::Segmentation},
         {"mobilenet", nn::NNFamily::Mobilenet},
         {"YOLO", nn::NNFamily::Yolo},
     };
+    declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket));
 }
 NNParamHandler::~NNParamHandler() = default;
 std::string NNParamHandler::getConfigPath() {

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -2,12 +2,12 @@
 
 #include <fstream>
 
+#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/pipeline/node/DetectionNetwork.hpp"
 #include "depthai/pipeline/node/ImageManip.hpp"
 #include "depthai/pipeline/node/NeuralNetwork.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai_ros_driver/utils.hpp"
-#include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "nlohmann/json.hpp"
 #include "ros/node_handle.h"
 #include "ros/package.h"

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -27,6 +27,7 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     socketID = static_cast<dai::CameraBoardSocket>(declareAndLogParam<int>("i_board_socket_id", static_cast<int>(socket), 0));
     declareAndLogParam<bool>("i_update_ros_base_time_on_ros_msg", false);
     declareAndLogParam<bool>("i_enable_feature_tracker", false);
+    declareAndLogParam<bool>("i_enable_nn", false);
     declareAndLogParam<bool>("i_enable_lazy_publisher", true);
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
@@ -94,9 +95,20 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     int height = colorCam->getResolutionHeight();
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
-    if(declareAndLogParam<bool>("i_set_isp_scale", true)) {
-        int num = declareAndLogParam<int>("i_isp_num", 2);
-        int den = declareAndLogParam<int>("i_isp_den", 3);
+
+    bool setIspScale = true;
+    if(sensor.defaultResolution != "1080P"
+       && sensor.defaultResolution != "1200P") {  // default disable ISP scaling since default resolution is not 1080P or 1200P
+        setIspScale = false;
+    }
+    if(declareAndLogParam<bool>("i_set_isp_scale", setIspScale)) {
+        int num = 2;
+        int den = 3;
+        if(sensor.defaultResolution == "1200P") {
+            den = 5;  // for improved performance
+        }
+        num = declareAndLogParam<int>("i_isp_num", num);
+        den = declareAndLogParam<int>("i_isp_den", den);
         width = (width * num + den - 1) / den;
         height = (height * num + den - 1) / den;
         colorCam->setIspScale(num, den);

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -34,9 +34,10 @@ StereoParamHandler::StereoParamHandler(ros::NodeHandle node, const std::string& 
     };
 }
 
-void StereoParamHandler::updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right) {
+void StereoParamHandler::updateSocketsFromParams(dai::CameraBoardSocket& left, dai::CameraBoardSocket& right, dai::CameraBoardSocket& align) {
     int newLeftS = getParam<int>("i_left_socket_id", static_cast<int>(left));
     int newRightS = getParam<int>("i_right_socket_id", static_cast<int>(right));
+    alignSocket = static_cast<dai::CameraBoardSocket>(declareAndLogParam<int>("i_board_socket_id", static_cast<int>(align)));
     if(newLeftS != static_cast<int>(left) || newRightS != static_cast<int>(right)) {
         ROS_WARN("Left or right socket changed, updating stereo node");
         ROS_WARN("Old left socket: %d, new left socket: %d", static_cast<int>(left), newLeftS);
@@ -75,17 +76,19 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_right_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_right_rect_exposure_offset", 0);
 
+    declareAndLogParam<bool>("i_enable_spatial_nn", false);
+    declareAndLogParam<std::string>("i_spatial_nn_source", "right");
+
     stereo->setLeftRightCheck(declareAndLogParam<bool>("i_lr_check", true));
     int width = 1280;
     int height = 720;
-    auto socket = static_cast<dai::CameraBoardSocket>(declareAndLogParam<int>("i_board_socket_id", static_cast<int>(dai::CameraBoardSocket::CAM_A)));
     std::string socketName;
     if(declareAndLogParam<bool>("i_align_depth", true)) {
-        socketName = utils::getSocketName(socket);
+        socketName = utils::getSocketName(alignSocket);
         width = getOtherNodeParam<int>(socketName, "i_width");
         height = getOtherNodeParam<int>(socketName, "i_height");
         declareAndLogParam<std::string>("i_socket_name", socketName);
-        stereo->setDepthAlign(socket);
+        stereo->setDepthAlign(alignSocket);
     }
 
     if(declareAndLogParam<bool>("i_set_input_size", false)) {

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -55,12 +55,12 @@ std::string PipelineGenerator::validatePipeline(const std::string& typeStr, int 
     auto pType = utils::getValFromMap(typeStr, pipelineTypeMap);
     if(sensorNum == 1) {
         if(pType != PipelineType::RGB) {
-            ROS_ERROR("Wrong pipeline chosen for camera as it has only one sensor. Switching to RGB.");
+            ROS_ERROR("Invalid pipeline chosen for camera as it has only one sensor. Switching to RGB.");
             return "RGB";
         }
     } else if(sensorNum == 2) {
         if(pType != PipelineType::Stereo || pType != PipelineType::Depth) {
-            ROS_ERROR("Wrong pipeline chosen for camera as it has only stereo pair. Switching to DEPTH.");
+            ROS_ERROR("Invalid pipeline chosen for camera as it has only stereo pair. Switching to DEPTH.");
             return "DEPTH";
         }
     }

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -59,7 +59,7 @@ std::string PipelineGenerator::validatePipeline(const std::string& typeStr, int 
             return "RGB";
         }
     } else if(sensorNum == 2) {
-        if(pType != PipelineType::Stereo || pType != PipelineType::Depth) {
+        if(pType != PipelineType::Stereo && pType != PipelineType::Depth) {
             ROS_ERROR("Invalid pipeline chosen for camera as it has only stereo pair. Switching to DEPTH.");
             return "DEPTH";
         }


### PR DESCRIPTION
## Overview
Author:  @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/471 https://github.com/luxonis/depthai-ros/issues/470
Issue description: Update out-of-the box experience for LR/SR/Wide users. Additionally add an options to attach NNs to sensor/stereo nodes
Related PRs

## Changes
ROS distro: Noetic
List of changes:
- Add URDF setup for LR and SR
- Automatically change ISP scaling parameter based on camera model to prevent unusable configurations
- Custom ISP num/den for LR for better output syncing
- Add NN enabling for individual sensors
- Add Spatial NN to a stereo setup
- Add parameter to enable/disable camera restart on lack of diagnostic data
- Update NN publishers to provide correct frame ID based on set socket
- Replace `pass_tf_args_as_params` with `publish_tf_from_calibration` argument for clarity
- RSP's robot description param is now namespaced to be consistent with TF publisher

## Testing
Hardware used: OAK-D-SR, OAK-D-LR, OAK-D-PRO-W (OV9872)
Depthai library version: 2.23


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
