### PR TITLE
Tracking converter for ROS2 Foxy

### DIFF
--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB LIB_SRC
 "src/SpatialDetection2DConverter.cpp"
 "src/ImuConverter.cpp"
 "src/TrackDetectionConverter.cpp"
+"src/TrackSpatialDetectionConverter.cpp"
 )
 
 add_library(${PROJECT_NAME} SHARED ${LIB_SRC})

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -61,6 +61,7 @@ file(GLOB LIB_SRC
 "src/ImageConverter.cpp"
 "src/ImgDetectionConverter.cpp"
 "src/SpatialDetectionConverter.cpp"
+"src/SpatialDetection2DConverter.cpp"
 "src/ImuConverter.cpp"
 "src/TrackDetectionConverter.cpp"
 )

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -62,6 +62,7 @@ file(GLOB LIB_SRC
 "src/ImgDetectionConverter.cpp"
 "src/SpatialDetectionConverter.cpp"
 "src/ImuConverter.cpp"
+"src/TrackDetectionConverter.cpp"
 )
 
 add_library(${PROJECT_NAME} SHARED ${LIB_SRC})

--- a/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+
+#include <rclcpp/time.hpp>
+#include <vision_msgs/msg/detection2_d_array.hpp>
+#include "depthai/pipeline/datatype/SpatialImgDetections.hpp"
+
+namespace dai {
+
+namespace ros {
+
+namespace VisionMsgs = vision_msgs::msg;
+using SpatialDetection2DArrayPtr = VisionMsgs::Detection2DArray;
+
+class SpatialDetection2DConverter {
+	public:
+		SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+		~SpatialDetection2DConverter();
+		void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsg);
+
+	private:
+		int _width, _height;
+		const std::string _frameName;
+		bool _normalized;
+		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+
+		rclcpp::Time _rosBaseTime;
+		bool _getBaseDeviceTimestamp;
+};
+
+/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
+ * is there any situation where we would need to have xlinkin to take bounding
+ * box as input. One scenario would to take this as input and use ImageManip
+ * node to crop the roi of the image. Since it is not available yet. Leaving
+ * it out for now to speed up on other tasks feel free to raise a issue if you
+ * feel that feature is good to have...
+ */
+
+}  // namespace ros
+
+namespace rosBridge = ros;
+
+}  // namespace dai

--- a/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
@@ -16,19 +16,19 @@ namespace VisionMsgs = vision_msgs::msg;
 using SpatialDetection2DArrayPtr = VisionMsgs::Detection2DArray;
 
 class SpatialDetection2DConverter {
-	public:
-		SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
-		~SpatialDetection2DConverter();
-		void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsg);
+   public:
+    SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+    ~SpatialDetection2DConverter();
+    void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsg);
 
-	private:
-		int _width, _height;
-		const std::string _frameName;
-		bool _normalized;
-		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+   private:
+    int _width, _height;
+    const std::string _frameName;
+    bool _normalized;
+    std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
 
-		rclcpp::Time _rosBaseTime;
-		bool _getBaseDeviceTimestamp;
+    rclcpp::Time _rosBaseTime;
+    bool _getBaseDeviceTimestamp;
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
@@ -4,9 +4,9 @@
 #include <memory>
 #include <string>
 
+#include "depthai/pipeline/datatype/SpatialImgDetections.hpp"
 #include "rclcpp/time.hpp"
 #include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai/pipeline/datatype/SpatialImgDetections.hpp"
 
 namespace dai {
 

--- a/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetection2DConverter.hpp
@@ -4,8 +4,8 @@
 #include <memory>
 #include <string>
 
-#include <rclcpp/time.hpp>
-#include <vision_msgs/msg/detection2_d_array.hpp>
+#include "rclcpp/time.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 #include "depthai/pipeline/datatype/SpatialImgDetections.hpp"
 
 namespace dai {
@@ -30,14 +30,6 @@ class SpatialDetection2DConverter {
     rclcpp::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
 };
-
-/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
- * is there any situation where we would need to have xlinkin to take bounding
- * box as input. One scenario would to take this as input and use ImageManip
- * node to crop the roi of the image. Since it is not available yet. Leaving
- * it out for now to speed up on other tasks feel free to raise a issue if you
- * feel that feature is good to have...
- */
 
 }  // namespace ros
 

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -21,7 +21,7 @@ using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 class TrackDetectionConverter {
 	public:
 		// DetectionConverter() = default;
-		TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+		TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
 		~TrackDetectionConverter();
 		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 
@@ -31,6 +31,7 @@ class TrackDetectionConverter {
 		int _width, _height;
 		const std::string _frameName;
 		bool _normalized;
+		float _thresh;
 		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
 		rclcpp::Time _rosBaseTime;
 		bool _getBaseDeviceTimestamp;

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vision_msgs/msg/detection2_d_array.hpp>
+
+#include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "rclcpp/time.hpp"
+
+namespace dai {
+
+namespace ros {
+
+namespace VisionMsgs = vision_msgs::msg;
+using Detection2DArrayPtr = VisionMsgs::Detection2DArray::SharedPtr;
+
+class TrackDetectionConverter {
+	public:
+		// DetectionConverter() = default;
+		TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+		~TrackDetectionConverter();
+		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs);
+
+		Detection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+
+	private:
+		int _width, _height;
+		const std::string _frameName;
+		bool _normalized;
+		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+		rclcpp::Time _rosBaseTime;
+		bool _getBaseDeviceTimestamp;
+};
+
+/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
+ * is there any situation where we would need to have xlinkin to take bounding
+ * box as input. One scenario would to take this as input and use ImageManip
+ * node to crop the roi of the image. Since it is not available yet. Leaving
+ * it out for now to speed up on other tasks feel free to raise a issue if you
+ * feel that feature is good to have...
+ */
+
+}  // namespace ros
+
+namespace rosBridge = ros;
+
+}  // namespace dai

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <vision_msgs/msg/detection2_d_array.hpp>
+#include <depthai_ros_msgs/msg/track_detection2_d_array.hpp>
 
 #include "depthai/pipeline/datatype/Tracklets.hpp"
 #include "rclcpp/time.hpp"
@@ -13,16 +14,18 @@ namespace dai {
 namespace ros {
 
 namespace VisionMsgs = vision_msgs::msg;
+namespace DepthaiMsgs = depthai_ros_msgs::msg;
 using Detection2DArrayPtr = VisionMsgs::Detection2DArray::SharedPtr;
+using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 
 class TrackDetectionConverter {
 	public:
 		// DetectionConverter() = default;
 		TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
 		~TrackDetectionConverter();
-		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs);
+		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 
-		Detection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+		TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
 
 	private:
 		int _width, _height;

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -19,22 +19,21 @@ using Detection2DArrayPtr = VisionMsgs::Detection2DArray::SharedPtr;
 using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 
 class TrackDetectionConverter {
-	public:
-		// DetectionConverter() = default;
-		TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
-		~TrackDetectionConverter();
-		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
+   public:
+    TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    ~TrackDetectionConverter();
+    void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 
-		TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+    TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
 
-	private:
-		int _width, _height;
-		const std::string _frameName;
-		bool _normalized;
-		float _thresh;
-		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
-		rclcpp::Time _rosBaseTime;
-		bool _getBaseDeviceTimestamp;
+   private:
+    int _width, _height;
+    const std::string _frameName;
+    bool _normalized;
+    float _thresh;
+    std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+    rclcpp::Time _rosBaseTime;
+    bool _getBaseDeviceTimestamp;
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -3,11 +3,11 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 
 #include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 #include "rclcpp/time.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 
 namespace dai {
 

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -3,8 +3,8 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <vision_msgs/msg/detection2_d_array.hpp>
-#include <depthai_ros_msgs/msg/track_detection2_d_array.hpp>
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 
 #include "depthai/pipeline/datatype/Tracklets.hpp"
 #include "rclcpp/time.hpp"
@@ -35,14 +35,6 @@ class TrackDetectionConverter {
     rclcpp::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
 };
-
-/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
- * is there any situation where we would need to have xlinkin to take bounding
- * box as input. One scenario would to take this as input and use ImageManip
- * node to crop the roi of the image. Since it is not available yet. Leaving
- * it out for now to speed up on other tasks feel free to raise a issue if you
- * feel that feature is good to have...
- */
 
 }  // namespace ros
 

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -3,8 +3,8 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <vision_msgs/msg/detection2_d_array.hpp>
-#include <depthai_ros_msgs/msg/track_detection2_d_array.hpp>
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 
 #include "depthai/pipeline/datatype/Tracklets.hpp"
 #include "rclcpp/time.hpp"
@@ -35,14 +35,6 @@ class TrackSpatialDetectionConverter {
     rclcpp::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
 };
-
-/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
- * is there any situation where we would need to have xlinkin to take bounding
- * box as input. One scenario would to take this as input and use ImageManip
- * node to crop the roi of the image. Since it is not available yet. Leaving
- * it out for now to speed up on other tasks feel free to raise a issue if you
- * feel that feature is good to have...
- */
 
 }  // namespace ros
 

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -19,22 +19,21 @@ using Detection2DArrayPtr = VisionMsgs::Detection2DArray::SharedPtr;
 using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 
 class TrackSpatialDetectionConverter {
-	public:
-		// DetectionConverter() = default;
-		TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
-		~TrackSpatialDetectionConverter();
-		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
+   public:
+    TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    ~TrackSpatialDetectionConverter();
+    void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 
-		TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+    TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
 
-	private:
-		int _width, _height;
-		const std::string _frameName;
-		bool _normalized;
-		float _thresh;
-		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
-		rclcpp::Time _rosBaseTime;
-		bool _getBaseDeviceTimestamp;
+   private:
+    int _width, _height;
+    const std::string _frameName;
+    bool _normalized;
+    float _thresh;
+    std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+    rclcpp::Time _rosBaseTime;
+    bool _getBaseDeviceTimestamp;
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -21,7 +21,7 @@ using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 class TrackSpatialDetectionConverter {
 	public:
 		// DetectionConverter() = default;
-		TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+		TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
 		~TrackSpatialDetectionConverter();
 		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 
@@ -31,6 +31,7 @@ class TrackSpatialDetectionConverter {
 		int _width, _height;
 		const std::string _frameName;
 		bool _normalized;
+		float _thresh;
 		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
 		rclcpp::Time _rosBaseTime;
 		bool _getBaseDeviceTimestamp;

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -20,7 +20,8 @@ using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
 
 class TrackSpatialDetectionConverter {
    public:
-    TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    TrackSpatialDetectionConverter(
+        std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
     ~TrackSpatialDetectionConverter();
     void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
 

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vision_msgs/msg/detection2_d_array.hpp>
+#include <depthai_ros_msgs/msg/track_detection2_d_array.hpp>
+
+#include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "rclcpp/time.hpp"
+
+namespace dai {
+
+namespace ros {
+
+namespace VisionMsgs = vision_msgs::msg;
+namespace DepthaiMsgs = depthai_ros_msgs::msg;
+using Detection2DArrayPtr = VisionMsgs::Detection2DArray::SharedPtr;
+using TrackDetection2DArrayPtr = DepthaiMsgs::TrackDetection2DArray::SharedPtr;
+
+class TrackSpatialDetectionConverter {
+	public:
+		// DetectionConverter() = default;
+		TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
+		~TrackSpatialDetectionConverter();
+		void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs);
+
+		TrackDetection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+
+	private:
+		int _width, _height;
+		const std::string _frameName;
+		bool _normalized;
+		std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+		rclcpp::Time _rosBaseTime;
+		bool _getBaseDeviceTimestamp;
+};
+
+/** TODO(sachin): Do we need to have ros msg -> dai bounding box ?
+ * is there any situation where we would need to have xlinkin to take bounding
+ * box as input. One scenario would to take this as input and use ImageManip
+ * node to crop the roi of the image. Since it is not available yet. Leaving
+ * it out for now to speed up on other tasks feel free to raise a issue if you
+ * feel that feature is good to have...
+ */
+
+}  // namespace ros
+
+namespace rosBridge = ros;
+
+}  // namespace dai

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -3,11 +3,11 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 
 #include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
 #include "rclcpp/time.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 
 namespace dai {
 

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -34,14 +34,18 @@ void ImgDetectionConverter::toRosMsg(std::shared_ptr<dai::ImgDetections> inNetDa
 
     // TODO(Sachin): check if this works fine for normalized detection
     // publishing
-    for(int i = 0; i < inNetData->detections.size(); ++i) {
-        int xMin, yMin, xMax, yMax;
-        if(_normalized) {
+    for (int i = 0; i < inNetData->detections.size(); ++i)
+	{
+        float xMin, yMin, xMax, yMax;
+        if(_normalized)
+		{
             xMin = inNetData->detections[i].xmin;
             yMin = inNetData->detections[i].ymin;
             xMax = inNetData->detections[i].xmax;
             yMax = inNetData->detections[i].ymax;
-        } else {
+        }
+		else
+		{
             xMin = inNetData->detections[i].xmin * _width;
             yMin = inNetData->detections[i].ymin * _height;
             xMax = inNetData->detections[i].xmax * _width;

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -32,20 +32,15 @@ void ImgDetectionConverter::toRosMsg(std::shared_ptr<dai::ImgDetections> inNetDa
     opDetectionMsg.header.frame_id = _frameName;
     opDetectionMsg.detections.resize(inNetData->detections.size());
 
-    // TODO(Sachin): check if this works fine for normalized detection
     // publishing
-    for (int i = 0; i < inNetData->detections.size(); ++i)
-	{
+    for(int i = 0; i < inNetData->detections.size(); ++i) {
         float xMin, yMin, xMax, yMax;
-        if(_normalized)
-		{
+        if(_normalized) {
             xMin = inNetData->detections[i].xmin;
             yMin = inNetData->detections[i].ymin;
             xMax = inNetData->detections[i].xmax;
             yMax = inNetData->detections[i].ymax;
-        }
-		else
-		{
+        } else {
             xMin = inNetData->detections[i].xmin * _width;
             yMin = inNetData->detections[i].ymin * _height;
             xMax = inNetData->detections[i].xmax * _width;

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -1,0 +1,79 @@
+#include "depthai_bridge/SpatialDetection2DConverter.hpp"
+
+#include "depthai_bridge/depthaiUtility.hpp"
+#include "depthai/depthai.hpp"
+
+namespace dai {
+
+namespace ros {
+
+SpatialDetection2DConverter::SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
+	:	_frameName(frameName),
+		_width(width),
+		_height(height),
+		_normalized(normalized),
+		_steadyBaseTime(std::chrono::steady_clock::now()),
+		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+		_rosBaseTime = rclcpp::Clock().now();
+}
+
+SpatialDetection2DConverter::~SpatialDetection2DConverter() = default;
+
+void SpatialDetection2DConverter::toRosVisionMsg(
+	std::shared_ptr<dai::SpatialImgDetections> inNetData,
+	std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+
+	std::chrono::_V2::steady_clock::time_point tstamp;
+	if(_getBaseDeviceTimestamp)
+		tstamp = inNetData->getTimestampDevice();
+	else
+		tstamp = inNetData->getTimestamp();
+
+	VisionMsgs::Detection2DArray opDetectionMsg;
+	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+	opDetectionMsg.header.frame_id = _frameName;
+	opDetectionMsg.detections.resize(inNetData->detections.size());
+
+	// TODO(Sachin): check if this works fine for normalized detection
+	// publishing
+	for (int i = 0; i < inNetData->detections.size(); ++i)
+	{
+		int xMin, yMin, xMax, yMax;
+		if(_normalized)
+		{
+			xMin = inNetData->detections[i].xmin;
+			yMin = inNetData->detections[i].ymin;
+			xMax = inNetData->detections[i].xmax;
+			yMax = inNetData->detections[i].ymax;
+		} else {
+			xMin = inNetData->detections[i].xmin * _width;
+			yMin = inNetData->detections[i].ymin * _height;
+			xMax = inNetData->detections[i].xmax * _width;
+			yMax = inNetData->detections[i].ymax * _height;
+		}
+
+		float xSize = xMax - xMin;
+		float ySize = yMax - yMin;
+		float xCenter = xMin + xSize / 2;
+		float yCenter = yMin + ySize / 2;
+		opDetectionMsg.detections[i].results.resize(1);
+
+		opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
+		opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
+		opDetectionMsg.detections[i].bbox.center.x = xCenter;
+		opDetectionMsg.detections[i].bbox.center.y = yCenter;
+		opDetectionMsg.detections[i].bbox.size_x = xSize;
+		opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+		// converting mm to meters since per ros rep-103 lenght should always be in meters
+		opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
+		opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
+		opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
+	}
+
+	opDetectionMsgs.push_back(opDetectionMsg);
+}
+
+}  // namespace ros
+
+}  // namespace dai

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -8,67 +8,66 @@ namespace dai {
 namespace ros {
 
 SpatialDetection2DConverter::SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
-  :	_frameName(frameName),
-    _width(width),
-    _height(height),
-    _normalized(normalized),
-    _steadyBaseTime(std::chrono::steady_clock::now()),
-    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-  _rosBaseTime = rclcpp::Clock().now();
+    : _frameName(frameName),
+      _width(width),
+      _height(height),
+      _normalized(normalized),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+    _rosBaseTime = rclcpp::Clock().now();
 }
 
 SpatialDetection2DConverter::~SpatialDetection2DConverter() = default;
 
-void SpatialDetection2DConverter::toRosVisionMsg(
-  std::shared_ptr<dai::SpatialImgDetections> inNetData,
-  std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
-  // setting the header
-  std::chrono::_V2::steady_clock::time_point tstamp;
-  if(_getBaseDeviceTimestamp)
-    tstamp = inNetData->getTimestampDevice();
-  else
-    tstamp = inNetData->getTimestamp();
+void SpatialDetection2DConverter::toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,
+                                                 std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = inNetData->getTimestampDevice();
+    else
+        tstamp = inNetData->getTimestamp();
 
-  VisionMsgs::Detection2DArray opDetectionMsg;
-  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-  opDetectionMsg.header.frame_id = _frameName;
-  opDetectionMsg.detections.resize(inNetData->detections.size());
+    VisionMsgs::Detection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(inNetData->detections.size());
 
-  // publishing
-  for(int i = 0; i < inNetData->detections.size(); ++i) {
-    float xMin, yMin, xMax, yMax;
-    if(_normalized) {
-      xMin = inNetData->detections[i].xmin;
-      yMin = inNetData->detections[i].ymin;
-      xMax = inNetData->detections[i].xmax;
-      yMax = inNetData->detections[i].ymax;
-    } else {
-      xMin = inNetData->detections[i].xmin * _width;
-      yMin = inNetData->detections[i].ymin * _height;
-      xMax = inNetData->detections[i].xmax * _width;
-      yMax = inNetData->detections[i].ymax * _height;
+    // publishing
+    for(int i = 0; i < inNetData->detections.size(); ++i) {
+        float xMin, yMin, xMax, yMax;
+        if(_normalized) {
+            xMin = inNetData->detections[i].xmin;
+            yMin = inNetData->detections[i].ymin;
+            xMax = inNetData->detections[i].xmax;
+            yMax = inNetData->detections[i].ymax;
+        } else {
+            xMin = inNetData->detections[i].xmin * _width;
+            yMin = inNetData->detections[i].ymin * _height;
+            xMax = inNetData->detections[i].xmax * _width;
+            yMax = inNetData->detections[i].ymax * _height;
+        }
+
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2;
+        float yCenter = yMin + ySize / 2;
+        opDetectionMsg.detections[i].results.resize(1);
+
+        opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
+        opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
     }
 
-    float xSize = xMax - xMin;
-    float ySize = yMax - yMin;
-    float xCenter = xMin + xSize / 2;
-    float yCenter = yMin + ySize / 2;
-    opDetectionMsg.detections[i].results.resize(1);
-
-    opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
-    opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
-    opDetectionMsg.detections[i].bbox.center.x = xCenter;
-    opDetectionMsg.detections[i].bbox.center.y = yCenter;
-    opDetectionMsg.detections[i].bbox.size_x = xSize;
-    opDetectionMsg.detections[i].bbox.size_y = ySize;
-
-    // converting mm to meters since per ros rep-103 lenght should always be in meters
-    opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
-  }
-
-  opDetectionMsgs.push_back(opDetectionMsg);
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -8,72 +8,72 @@ namespace dai {
 namespace ros {
 
 SpatialDetection2DConverter::SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
-	:	_frameName(frameName),
-		_width(width),
-		_height(height),
-		_normalized(normalized),
-		_steadyBaseTime(std::chrono::steady_clock::now()),
-		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-		_rosBaseTime = rclcpp::Clock().now();
+    :	_frameName(frameName),
+        _width(width),
+        _height(height),
+        _normalized(normalized),
+        _steadyBaseTime(std::chrono::steady_clock::now()),
+        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+        _rosBaseTime = rclcpp::Clock().now();
 }
 
 SpatialDetection2DConverter::~SpatialDetection2DConverter() = default;
 
 void SpatialDetection2DConverter::toRosVisionMsg(
-	std::shared_ptr<dai::SpatialImgDetections> inNetData,
-	std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+    std::shared_ptr<dai::SpatialImgDetections> inNetData,
+    std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
 
-	std::chrono::_V2::steady_clock::time_point tstamp;
-	if(_getBaseDeviceTimestamp)
-		tstamp = inNetData->getTimestampDevice();
-	else
-		tstamp = inNetData->getTimestamp();
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = inNetData->getTimestampDevice();
+    else
+        tstamp = inNetData->getTimestamp();
 
-	VisionMsgs::Detection2DArray opDetectionMsg;
-	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-	opDetectionMsg.header.frame_id = _frameName;
-	opDetectionMsg.detections.resize(inNetData->detections.size());
+    VisionMsgs::Detection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(inNetData->detections.size());
 
-	// TODO(Sachin): check if this works fine for normalized detection
-	// publishing
-	for (int i = 0; i < inNetData->detections.size(); ++i)
-	{
-		float xMin, yMin, xMax, yMax;
-		if(_normalized)
-		{
-			xMin = inNetData->detections[i].xmin;
-			yMin = inNetData->detections[i].ymin;
-			xMax = inNetData->detections[i].xmax;
-			yMax = inNetData->detections[i].ymax;
-		}
-		else
-		{
-			xMin = inNetData->detections[i].xmin * _width;
-			yMin = inNetData->detections[i].ymin * _height;
-			xMax = inNetData->detections[i].xmax * _width;
-			yMax = inNetData->detections[i].ymax * _height;
-		}
+    // TODO(Sachin): check if this works fine for normalized detection
+    // publishing
+    for (int i = 0; i < inNetData->detections.size(); ++i)
+    {
+        float xMin, yMin, xMax, yMax;
+        if(_normalized)
+        {
+            xMin = inNetData->detections[i].xmin;
+            yMin = inNetData->detections[i].ymin;
+            xMax = inNetData->detections[i].xmax;
+            yMax = inNetData->detections[i].ymax;
+        }
+        else
+        {
+            xMin = inNetData->detections[i].xmin * _width;
+            yMin = inNetData->detections[i].ymin * _height;
+            xMax = inNetData->detections[i].xmax * _width;
+            yMax = inNetData->detections[i].ymax * _height;
+        }
 
-		float xSize = xMax - xMin;
-		float ySize = yMax - yMin;
-		float xCenter = xMin + xSize / 2;
-		float yCenter = yMin + ySize / 2;
-		opDetectionMsg.detections[i].results.resize(1);
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2;
+        float yCenter = yMin + ySize / 2;
+        opDetectionMsg.detections[i].results.resize(1);
 
-		opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
-		opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
-		opDetectionMsg.detections[i].bbox.center.x = xCenter;
-		opDetectionMsg.detections[i].bbox.center.y = yCenter;
-		opDetectionMsg.detections[i].bbox.size_x = xSize;
-		opDetectionMsg.detections[i].bbox.size_y = ySize;
+        opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
+        opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
 
-		// converting mm to meters since per ros rep-103 lenght should always be in meters
-		opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
-		opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
-		opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
-	}
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
+    }
 
-	opDetectionMsgs.push_back(opDetectionMsg);
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -1,78 +1,74 @@
 #include "depthai_bridge/SpatialDetection2DConverter.hpp"
 
-#include "depthai_bridge/depthaiUtility.hpp"
 #include "depthai/depthai.hpp"
+#include "depthai_bridge/depthaiUtility.hpp"
 
 namespace dai {
 
 namespace ros {
 
 SpatialDetection2DConverter::SpatialDetection2DConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
-    :	_frameName(frameName),
-        _width(width),
-        _height(height),
-        _normalized(normalized),
-        _steadyBaseTime(std::chrono::steady_clock::now()),
-        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-        _rosBaseTime = rclcpp::Clock().now();
+  :	_frameName(frameName),
+    _width(width),
+    _height(height),
+    _normalized(normalized),
+    _steadyBaseTime(std::chrono::steady_clock::now()),
+    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+  _rosBaseTime = rclcpp::Clock().now();
 }
 
 SpatialDetection2DConverter::~SpatialDetection2DConverter() = default;
 
 void SpatialDetection2DConverter::toRosVisionMsg(
-    std::shared_ptr<dai::SpatialImgDetections> inNetData,
-    std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+  std::shared_ptr<dai::SpatialImgDetections> inNetData,
+  std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+  // setting the header
+  std::chrono::_V2::steady_clock::time_point tstamp;
+  if(_getBaseDeviceTimestamp)
+    tstamp = inNetData->getTimestampDevice();
+  else
+    tstamp = inNetData->getTimestamp();
 
-    std::chrono::_V2::steady_clock::time_point tstamp;
-    if(_getBaseDeviceTimestamp)
-        tstamp = inNetData->getTimestampDevice();
-    else
-        tstamp = inNetData->getTimestamp();
+  VisionMsgs::Detection2DArray opDetectionMsg;
+  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+  opDetectionMsg.header.frame_id = _frameName;
+  opDetectionMsg.detections.resize(inNetData->detections.size());
 
-    VisionMsgs::Detection2DArray opDetectionMsg;
-    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-    opDetectionMsg.header.frame_id = _frameName;
-    opDetectionMsg.detections.resize(inNetData->detections.size());
-
-    // publishing
-    for (int i = 0; i < inNetData->detections.size(); ++i)
-    {
-        float xMin, yMin, xMax, yMax;
-        if(_normalized)
-        {
-            xMin = inNetData->detections[i].xmin;
-            yMin = inNetData->detections[i].ymin;
-            xMax = inNetData->detections[i].xmax;
-            yMax = inNetData->detections[i].ymax;
-        }
-        else
-        {
-            xMin = inNetData->detections[i].xmin * _width;
-            yMin = inNetData->detections[i].ymin * _height;
-            xMax = inNetData->detections[i].xmax * _width;
-            yMax = inNetData->detections[i].ymax * _height;
-        }
-
-        float xSize = xMax - xMin;
-        float ySize = yMax - yMin;
-        float xCenter = xMin + xSize / 2;
-        float yCenter = yMin + ySize / 2;
-        opDetectionMsg.detections[i].results.resize(1);
-
-        opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
-        opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
-        opDetectionMsg.detections[i].bbox.center.x = xCenter;
-        opDetectionMsg.detections[i].bbox.center.y = yCenter;
-        opDetectionMsg.detections[i].bbox.size_x = xSize;
-        opDetectionMsg.detections[i].bbox.size_y = ySize;
-
-        // converting mm to meters since per ros rep-103 lenght should always be in meters
-        opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
-        opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
-        opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
+  // publishing
+  for(int i = 0; i < inNetData->detections.size(); ++i) {
+    float xMin, yMin, xMax, yMax;
+    if(_normalized) {
+      xMin = inNetData->detections[i].xmin;
+      yMin = inNetData->detections[i].ymin;
+      xMax = inNetData->detections[i].xmax;
+      yMax = inNetData->detections[i].ymax;
+    } else {
+      xMin = inNetData->detections[i].xmin * _width;
+      yMin = inNetData->detections[i].ymin * _height;
+      xMax = inNetData->detections[i].xmax * _width;
+      yMax = inNetData->detections[i].ymax * _height;
     }
 
-    opDetectionMsgs.push_back(opDetectionMsg);
+    float xSize = xMax - xMin;
+    float ySize = yMax - yMin;
+    float xCenter = xMin + xSize / 2;
+    float yCenter = yMin + ySize / 2;
+    opDetectionMsg.detections[i].results.resize(1);
+
+    opDetectionMsg.detections[i].results[0].id = std::to_string(inNetData->detections[i].label);
+    opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
+    opDetectionMsg.detections[i].bbox.center.x = xCenter;
+    opDetectionMsg.detections[i].bbox.center.y = yCenter;
+    opDetectionMsg.detections[i].bbox.size_x = xSize;
+    opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+    // converting mm to meters since per ros rep-103 lenght should always be in meters
+    opDetectionMsg.detections[i].results[0].pose.pose.position.x = inNetData->detections[i].spatialCoordinates.x / 1000.;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.y = inNetData->detections[i].spatialCoordinates.y / 1000.;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.z = inNetData->detections[i].spatialCoordinates.z / 1000.;
+  }
+
+  opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -38,14 +38,16 @@ void SpatialDetection2DConverter::toRosVisionMsg(
 	// publishing
 	for (int i = 0; i < inNetData->detections.size(); ++i)
 	{
-		int xMin, yMin, xMax, yMax;
+		float xMin, yMin, xMax, yMax;
 		if(_normalized)
 		{
 			xMin = inNetData->detections[i].xmin;
 			yMin = inNetData->detections[i].ymin;
 			xMax = inNetData->detections[i].xmax;
 			yMax = inNetData->detections[i].ymax;
-		} else {
+		}
+		else
+		{
 			xMin = inNetData->detections[i].xmin * _width;
 			yMin = inNetData->detections[i].ymin * _height;
 			xMax = inNetData->detections[i].xmax * _width;

--- a/depthai_bridge/src/SpatialDetection2DConverter.cpp
+++ b/depthai_bridge/src/SpatialDetection2DConverter.cpp
@@ -34,7 +34,6 @@ void SpatialDetection2DConverter::toRosVisionMsg(
     opDetectionMsg.header.frame_id = _frameName;
     opDetectionMsg.detections.resize(inNetData->detections.size());
 
-    // TODO(Sachin): check if this works fine for normalized detection
     // publishing
     for (int i = 0; i < inNetData->detections.size(); ++i)
     {

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -32,8 +32,8 @@ void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetectio
 
     // TODO(Sachin): check if this works fine for normalized detection
     // publishing
-    for(int i = 0; i < inNetData->detections.size(); ++i) {
-        int xMin, yMin, xMax, yMax;
+    for (int i = 0; i < inNetData->detections.size(); ++i) {
+        float xMin, yMin, xMax, yMax;
         if(_normalized) {
             xMin = inNetData->detections[i].xmin;
             yMin = inNetData->detections[i].ymin;

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -30,9 +30,8 @@ void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetectio
     opDetectionMsg.header.frame_id = _frameName;
     opDetectionMsg.detections.resize(inNetData->detections.size());
 
-    // TODO(Sachin): check if this works fine for normalized detection
     // publishing
-    for (int i = 0; i < inNetData->detections.size(); ++i) {
+    for(int i = 0; i < inNetData->detections.size(); ++i) {
         float xMin, yMin, xMax, yMax;
         if(_normalized) {
             xMin = inNetData->detections[i].xmin;

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -8,98 +8,98 @@ namespace dai {
 namespace ros {
 
 TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-	:	_frameName(frameName),
-		_width(width),
-		_height(height),
-		_normalized(normalized),
-		_thresh(thresh),
-		_steadyBaseTime(std::chrono::steady_clock::now()),
-		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-		_rosBaseTime = rclcpp::Clock().now();
+    :	_frameName(frameName),
+        _width(width),
+        _height(height),
+        _normalized(normalized),
+        _thresh(thresh),
+        _steadyBaseTime(std::chrono::steady_clock::now()),
+        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+        _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackDetectionConverter::~TrackDetectionConverter() = default;
 
 void TrackDetectionConverter::toRosMsg(
-	std::shared_ptr<dai::Tracklets> trackData, 
-	std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+    std::shared_ptr<dai::Tracklets> trackData, 
+    std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
 
-	// setting the header
-	std::chrono::_V2::steady_clock::time_point tstamp;
-	if(_getBaseDeviceTimestamp)
-		tstamp = trackData->getTimestampDevice();
-	else
-		tstamp = trackData->getTimestamp();
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
+    else
+        tstamp = trackData->getTimestamp();
 
-	DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-	opDetectionMsg.header.frame_id = _frameName;
-	opDetectionMsg.detections.resize(trackData->tracklets.size());
+    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-	// publishing
-	for (int i = 0; i < trackData->tracklets.size(); ++i)
-	{
-		dai::Tracklet t = trackData->tracklets[i];
-		dai::Rect roi;
-		float xMin, yMin, xMax, yMax;
+    // publishing
+    for (int i = 0; i < trackData->tracklets.size(); ++i)
+    {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-		if (_normalized)
-			roi = t.roi;
-		else
-			roi = t.roi.denormalize(_width, _height);
+        if (_normalized)
+            roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-		xMin = roi.topLeft().x;
-		yMin = roi.topLeft().y;
-		xMax = roi.bottomRight().x;
-		yMax = roi.bottomRight().y;
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-		float xSize = xMax - xMin;
-		float ySize = yMax - yMin;
-		float xCenter = xMin + xSize / 2.;
-		float yCenter = yMin + ySize / 2.;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-		opDetectionMsg.detections[i].results.resize(1);
+        opDetectionMsg.detections[i].results.resize(1);
 
 #if defined(IS_GALACTIC) || defined(IS_HUMBLE)
-		opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
 #elif IS_ROS2
-		opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 #else
-		opDetectionMsg.detections[i].results[0].id = t.label;
+        opDetectionMsg.detections[i].results[0].id = t.label;
 #endif
 
-		opDetectionMsg.detections[i].results[0].score = _thresh;
+        opDetectionMsg.detections[i].results[0].score = _thresh;
 
 #ifdef IS_HUMBLE
-		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-		opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
 #else
-		opDetectionMsg.detections[i].bbox.center.x = xCenter;
-		opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
 #endif
 
-		opDetectionMsg.detections[i].bbox.size_x = xSize;
-		opDetectionMsg.detections[i].bbox.size_y = ySize;
-		opDetectionMsg.detections[i].is_tracking = true;
-		std::stringstream track_id_str;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
         track_id_str << "" << t.id;
-		opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-		opDetectionMsg.detections[i].tracking_age = t.age;
-		opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
 
-		// converting mm to meters since per ros rep-103 lenght should always be in meters
-		// opDetectionMsg.detections[i].position.x = 0;
-		// opDetectionMsg.detections[i].position.y = 0;
-		// opDetectionMsg.detections[i].position.z = 0;
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        // opDetectionMsg.detections[i].position.x = 0;
+        // opDetectionMsg.detections[i].position.y = 0;
+        // opDetectionMsg.detections[i].position.z = 0;
     }
 
     opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 TrackDetection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(
-	std::shared_ptr<dai::Tracklets> trackData) {
+    std::shared_ptr<dai::Tracklets> trackData) {
 
-	std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
     toRosMsg(trackData, msgQueue);
     auto msg = msgQueue.front();
 

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -1,95 +1,91 @@
 #include "depthai_bridge/TrackDetectionConverter.hpp"
 
-#include "depthai_bridge/depthaiUtility.hpp"
 #include "depthai/depthai.hpp"
+#include "depthai_bridge/depthaiUtility.hpp"
 
 namespace dai {
 
 namespace ros {
 
 TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-    :	_frameName(frameName),
-        _width(width),
-        _height(height),
-        _normalized(normalized),
-        _thresh(thresh),
-        _steadyBaseTime(std::chrono::steady_clock::now()),
-        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-        _rosBaseTime = rclcpp::Clock().now();
+  :	_frameName(frameName),
+    _width(width),
+    _height(height),
+    _normalized(normalized),
+    _thresh(thresh),
+    _steadyBaseTime(std::chrono::steady_clock::now()),
+    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+  _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackDetectionConverter::~TrackDetectionConverter() = default;
 
 void TrackDetectionConverter::toRosMsg(
-    std::shared_ptr<dai::Tracklets> trackData, 
-    std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+  std::shared_ptr<dai::Tracklets> trackData, 
+  std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+  // setting the header
+  std::chrono::_V2::steady_clock::time_point tstamp;
+  if(_getBaseDeviceTimestamp)
+    tstamp = trackData->getTimestampDevice();
+  else
+    tstamp = trackData->getTimestamp();
 
-    // setting the header
-    std::chrono::_V2::steady_clock::time_point tstamp;
-    if(_getBaseDeviceTimestamp)
-        tstamp = trackData->getTimestampDevice();
+  DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+  opDetectionMsg.header.frame_id = _frameName;
+  opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+  // publishing
+  for(int i = 0; i < trackData->tracklets.size(); ++i) {
+    dai::Tracklet t = trackData->tracklets[i];
+    dai::Rect roi;
+    float xMin, yMin, xMax, yMax;
+
+    if(_normalized)
+      roi = t.roi;
     else
-        tstamp = trackData->getTimestamp();
+      roi = t.roi.denormalize(_width, _height);
 
-    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-    opDetectionMsg.header.frame_id = _frameName;
-    opDetectionMsg.detections.resize(trackData->tracklets.size());
+    xMin = roi.topLeft().x;
+    yMin = roi.topLeft().y;
+    xMax = roi.bottomRight().x;
+    yMax = roi.bottomRight().y;
 
-    // publishing
-    for (int i = 0; i < trackData->tracklets.size(); ++i)
-    {
-        dai::Tracklet t = trackData->tracklets[i];
-        dai::Rect roi;
-        float xMin, yMin, xMax, yMax;
+    float xSize = xMax - xMin;
+    float ySize = yMax - yMin;
+    float xCenter = xMin + xSize / 2.;
+    float yCenter = yMin + ySize / 2.;
 
-        if (_normalized)
-            roi = t.roi;
-        else
-            roi = t.roi.denormalize(_width, _height);
+    opDetectionMsg.detections[i].results.resize(1);
 
-        xMin = roi.topLeft().x;
-        yMin = roi.topLeft().y;
-        xMax = roi.bottomRight().x;
-        yMax = roi.bottomRight().y;
+    opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 
-        float xSize = xMax - xMin;
-        float ySize = yMax - yMin;
-        float xCenter = xMin + xSize / 2.;
-        float yCenter = yMin + ySize / 2.;
+    opDetectionMsg.detections[i].results[0].score = _thresh;
 
-        opDetectionMsg.detections[i].results.resize(1);
+    opDetectionMsg.detections[i].bbox.center.x = xCenter;
+    opDetectionMsg.detections[i].bbox.center.y = yCenter;
+    opDetectionMsg.detections[i].bbox.size_x = xSize;
+    opDetectionMsg.detections[i].bbox.size_y = ySize;
 
-        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+    opDetectionMsg.detections[i].is_tracking = true;
+    std::stringstream track_id_str;
+    track_id_str << "" << t.id;
+    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+    opDetectionMsg.detections[i].tracking_age = t.age;
+    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+  }
 
-        opDetectionMsg.detections[i].results[0].score = _thresh;
-
-        opDetectionMsg.detections[i].bbox.center.x = xCenter;
-        opDetectionMsg.detections[i].bbox.center.y = yCenter;
-        opDetectionMsg.detections[i].bbox.size_x = xSize;
-        opDetectionMsg.detections[i].bbox.size_y = ySize;
-
-        opDetectionMsg.detections[i].is_tracking = true;
-        std::stringstream track_id_str;
-        track_id_str << "" << t.id;
-        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-        opDetectionMsg.detections[i].tracking_age = t.age;
-        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
-    }
-
-    opDetectionMsgs.push_back(opDetectionMsg);
+  opDetectionMsgs.push_back(opDetectionMsg);
 }
 
-TrackDetection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(
-    std::shared_ptr<dai::Tracklets> trackData) {
+TrackDetection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
+  std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+  toRosMsg(trackData, msgQueue);
+  auto msg = msgQueue.front();
 
-    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
-    toRosMsg(trackData, msgQueue);
-    auto msg = msgQueue.front();
+  TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
 
-    TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-
-    return ptr;
+  return ptr;
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -1,4 +1,4 @@
-#include <depthai_bridge/TrackDetectionConverter.hpp>
+#include "depthai_bridge/TrackDetectionConverter.hpp"
 
 #include "depthai_bridge/depthaiUtility.hpp"
 #include "depthai/depthai.hpp"
@@ -60,37 +60,21 @@ void TrackDetectionConverter::toRosMsg(
 
         opDetectionMsg.detections[i].results.resize(1);
 
-#if defined(IS_GALACTIC) || defined(IS_HUMBLE)
-        opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
-#elif IS_ROS2
         opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
-#else
-        opDetectionMsg.detections[i].results[0].id = t.label;
-#endif
 
         opDetectionMsg.detections[i].results[0].score = _thresh;
 
-#ifdef IS_HUMBLE
-        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
-#else
         opDetectionMsg.detections[i].bbox.center.x = xCenter;
         opDetectionMsg.detections[i].bbox.center.y = yCenter;
-#endif
-
         opDetectionMsg.detections[i].bbox.size_x = xSize;
         opDetectionMsg.detections[i].bbox.size_y = ySize;
+
         opDetectionMsg.detections[i].is_tracking = true;
         std::stringstream track_id_str;
         track_id_str << "" << t.id;
         opDetectionMsg.detections[i].tracking_id = track_id_str.str();
         opDetectionMsg.detections[i].tracking_age = t.age;
         opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
-
-        // converting mm to meters since per ros rep-103 lenght should always be in meters
-        // opDetectionMsg.detections[i].position.x = 0;
-        // opDetectionMsg.detections[i].position.y = 0;
-        // opDetectionMsg.detections[i].position.z = 0;
     }
 
     opDetectionMsgs.push_back(opDetectionMsg);
@@ -103,11 +87,8 @@ TrackDetection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(
     toRosMsg(trackData, msgQueue);
     auto msg = msgQueue.front();
 
-#ifdef IS_ROS2
     TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-#else
-    TrackDetection2DArrayPtr ptr = boost::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-#endif
+
     return ptr;
 }
 

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -8,84 +8,82 @@ namespace dai {
 namespace ros {
 
 TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-  :	_frameName(frameName),
-    _width(width),
-    _height(height),
-    _normalized(normalized),
-    _thresh(thresh),
-    _steadyBaseTime(std::chrono::steady_clock::now()),
-    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-  _rosBaseTime = rclcpp::Clock().now();
+    : _frameName(frameName),
+      _width(width),
+      _height(height),
+      _normalized(normalized),
+      _thresh(thresh),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+    _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackDetectionConverter::~TrackDetectionConverter() = default;
 
-void TrackDetectionConverter::toRosMsg(
-  std::shared_ptr<dai::Tracklets> trackData, 
-  std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
-  // setting the header
-  std::chrono::_V2::steady_clock::time_point tstamp;
-  if(_getBaseDeviceTimestamp)
-    tstamp = trackData->getTimestampDevice();
-  else
-    tstamp = trackData->getTimestamp();
-
-  DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-  opDetectionMsg.header.frame_id = _frameName;
-  opDetectionMsg.detections.resize(trackData->tracklets.size());
-
-  // publishing
-  for(int i = 0; i < trackData->tracklets.size(); ++i) {
-    dai::Tracklet t = trackData->tracklets[i];
-    dai::Rect roi;
-    float xMin, yMin, xMax, yMax;
-
-    if(_normalized)
-      roi = t.roi;
+void TrackDetectionConverter::toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
     else
-      roi = t.roi.denormalize(_width, _height);
+        tstamp = trackData->getTimestamp();
 
-    xMin = roi.topLeft().x;
-    yMin = roi.topLeft().y;
-    xMax = roi.bottomRight().x;
-    yMax = roi.bottomRight().y;
+    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-    float xSize = xMax - xMin;
-    float ySize = yMax - yMin;
-    float xCenter = xMin + xSize / 2.;
-    float yCenter = yMin + ySize / 2.;
+    // publishing
+    for(int i = 0; i < trackData->tracklets.size(); ++i) {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-    opDetectionMsg.detections[i].results.resize(1);
+        if(_normalized)
+            roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-    opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-    opDetectionMsg.detections[i].results[0].score = _thresh;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-    opDetectionMsg.detections[i].bbox.center.x = xCenter;
-    opDetectionMsg.detections[i].bbox.center.y = yCenter;
-    opDetectionMsg.detections[i].bbox.size_x = xSize;
-    opDetectionMsg.detections[i].bbox.size_y = ySize;
+        opDetectionMsg.detections[i].results.resize(1);
 
-    opDetectionMsg.detections[i].is_tracking = true;
-    std::stringstream track_id_str;
-    track_id_str << "" << t.id;
-    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-    opDetectionMsg.detections[i].tracking_age = t.age;
-    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
-  }
+        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 
-  opDetectionMsgs.push_back(opDetectionMsg);
+        opDetectionMsg.detections[i].results[0].score = _thresh;
+
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 TrackDetection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
-  std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
-  toRosMsg(trackData, msgQueue);
-  auto msg = msgQueue.front();
+    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
 
-  TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
+    TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
 
-  return ptr;
+    return ptr;
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -1,0 +1,113 @@
+#include <depthai_bridge/TrackDetectionConverter.hpp>
+
+#include "depthai_bridge/depthaiUtility.hpp"
+#include "depthai/depthai.hpp"
+
+namespace dai {
+
+namespace ros {
+
+TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
+	:	_frameName(frameName),
+		_width(width),
+		_height(height),
+		_normalized(normalized),
+		_steadyBaseTime(std::chrono::steady_clock::now()),
+		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+		_rosBaseTime = rclcpp::Clock().now();
+}
+
+TrackDetectionConverter::~TrackDetectionConverter() = default;
+
+void TrackDetectionConverter::toRosMsg(
+	std::shared_ptr<dai::Tracklets> trackData, 
+	std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs) {
+
+	// setting the header
+	std::chrono::_V2::steady_clock::time_point tstamp;
+	if(_getBaseDeviceTimestamp)
+		tstamp = trackData->getTimestampDevice();
+	else
+		tstamp = trackData->getTimestamp();
+
+	VisionMsgs::Detection2DArray opDetectionMsg;
+	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+	opDetectionMsg.header.frame_id = _frameName;
+	opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+	// publishing
+	for(int i = 0; i < trackData->tracklets.size(); ++i)
+	{
+		dai::Tracklet t = trackData->tracklets[i];
+		dai::Rect roi;
+		int xMin, yMin, xMax, yMax;
+
+		if (_normalized)
+			roi = t.roi;
+		else
+			roi = t.roi.denormalize(_width, _height);
+
+		xMin = t.roi.topLeft().x;
+		yMin = t.roi.topLeft().y;
+		xMax = t.roi.bottomRight().x;
+		yMax = t.roi.bottomRight().y;
+
+		float xSize = xMax - xMin;
+		float ySize = yMax - yMin;
+		float xCenter = xMin + xSize / 2.;
+		float yCenter = yMin + ySize / 2.;
+
+		opDetectionMsg.detections[i].results.resize(1);
+
+#if defined(IS_GALACTIC) || defined(IS_HUMBLE)
+		opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
+#elif IS_ROS2
+		opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+#else
+		opDetectionMsg.detections[i].results[0].id = t.label;
+#endif
+
+		opDetectionMsg.detections[i].results[0].score = -1.0;
+
+#ifdef IS_HUMBLE
+		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+		opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+#else
+		opDetectionMsg.detections[i].bbox.center.x = xCenter;
+		opDetectionMsg.detections[i].bbox.center.y = yCenter;
+#endif
+
+		opDetectionMsg.detections[i].bbox.size_x = xSize;
+		opDetectionMsg.detections[i].bbox.size_y = ySize;
+		opDetectionMsg.detections[i].is_tracking = true;
+		std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+		opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+
+		// converting mm to meters since per ros rep-103 lenght should always be in meters
+		// opDetectionMsg.detections[i].position.x = 0;
+		// opDetectionMsg.detections[i].position.y = 0;
+		// opDetectionMsg.detections[i].position.z = 0;
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
+}
+
+Detection2DArrayPtr TrackDetectionConverter::toRosMsgPtr(
+	std::shared_ptr<dai::Tracklets> trackData) {
+
+	std::deque<VisionMsgs::Detection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
+
+#ifdef IS_ROS2
+    Detection2DArrayPtr ptr = std::make_shared<VisionMsgs::Detection2DArray>(msg);
+#else
+    Detection2DArrayPtr ptr = boost::make_shared<VisionMsgs::Detection2DArray>(msg);
+#endif
+    return ptr;
+}
+
+}  // namespace ros
+
+}  // namespace dai

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -36,7 +36,7 @@ void TrackDetectionConverter::toRosMsg(
 	opDetectionMsg.detections.resize(trackData->tracklets.size());
 
 	// publishing
-	for(int i = 0; i < trackData->tracklets.size(); ++i)
+	for (int i = 0; i < trackData->tracklets.size(); ++i)
 	{
 		dai::Tracklet t = trackData->tracklets[i];
 		dai::Rect roi;

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -7,11 +7,12 @@ namespace dai {
 
 namespace ros {
 
-TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
+TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
 	:	_frameName(frameName),
 		_width(width),
 		_height(height),
 		_normalized(normalized),
+		_thresh(thresh),
 		_steadyBaseTime(std::chrono::steady_clock::now()),
 		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
 		_rosBaseTime = rclcpp::Clock().now();
@@ -40,11 +41,11 @@ void TrackDetectionConverter::toRosMsg(
 	{
 		dai::Tracklet t = trackData->tracklets[i];
 		dai::Rect roi;
-		int xMin, yMin, xMax, yMax;
+		float xMin, yMin, xMax, yMax;
 
-		// if (_normalized)
-		// 	roi = t.roi;
-		// else
+		if (_normalized)
+			roi = t.roi;
+		else
 			roi = t.roi.denormalize(_width, _height);
 
 		xMin = roi.topLeft().x;
@@ -67,7 +68,7 @@ void TrackDetectionConverter::toRosMsg(
 		opDetectionMsg.detections[i].results[0].id = t.label;
 #endif
 
-		opDetectionMsg.detections[i].results[0].score = -1.0;
+		opDetectionMsg.detections[i].results[0].score = _thresh;
 
 #ifdef IS_HUMBLE
 		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -7,90 +7,89 @@ namespace dai {
 
 namespace ros {
 
-TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-  :	_frameName(frameName),
-    _width(width),
-    _height(height),
-    _normalized(normalized),
-    _thresh(thresh),
-    _steadyBaseTime(std::chrono::steady_clock::now()),
-    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-  _rosBaseTime = rclcpp::Clock().now();
+TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(
+    std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
+    : _frameName(frameName),
+      _width(width),
+      _height(height),
+      _normalized(normalized),
+      _thresh(thresh),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+    _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
 
-void TrackSpatialDetectionConverter::toRosMsg(
-  std::shared_ptr<dai::Tracklets> trackData, 
-  std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
-  // setting the header
-  std::chrono::_V2::steady_clock::time_point tstamp;
-  if(_getBaseDeviceTimestamp)
-    tstamp = trackData->getTimestampDevice();
-  else
-    tstamp = trackData->getTimestamp();
-
-  DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-  opDetectionMsg.header.frame_id = _frameName;
-  opDetectionMsg.detections.resize(trackData->tracklets.size());
-
-  // publishing
-  for(int i = 0; i < trackData->tracklets.size(); ++i) {
-    dai::Tracklet t = trackData->tracklets[i];
-    dai::Rect roi;
-    float xMin, yMin, xMax, yMax;
-
-    if(_normalized)
-      roi = t.roi;
+void TrackSpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
     else
-      roi = t.roi.denormalize(_width, _height);
+        tstamp = trackData->getTimestamp();
 
-    xMin = roi.topLeft().x;
-    yMin = roi.topLeft().y;
-    xMax = roi.bottomRight().x;
-    yMax = roi.bottomRight().y;
+    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-    float xSize = xMax - xMin;
-    float ySize = yMax - yMin;
-    float xCenter = xMin + xSize / 2.;
-    float yCenter = yMin + ySize / 2.;
+    // publishing
+    for(int i = 0; i < trackData->tracklets.size(); ++i) {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-    opDetectionMsg.detections[i].results.resize(1);
+        if(_normalized)
+            roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-    opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-    opDetectionMsg.detections[i].results[0].score = _thresh;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-    opDetectionMsg.detections[i].bbox.center.x = xCenter;
-    opDetectionMsg.detections[i].bbox.center.y = yCenter;
-    opDetectionMsg.detections[i].bbox.size_x = xSize;
-    opDetectionMsg.detections[i].bbox.size_y = ySize;
+        opDetectionMsg.detections[i].results.resize(1);
 
-    opDetectionMsg.detections[i].is_tracking = true;
-    std::stringstream track_id_str;
-    track_id_str << "" << t.id;
-    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-    opDetectionMsg.detections[i].tracking_age = t.age;
-    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 
-    // converting mm to meters since per ros rep-103 lenght should always be in meters
-    opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
-  }
+        opDetectionMsg.detections[i].results[0].score = _thresh;
 
-  opDetectionMsgs.push_back(opDetectionMsg);
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
-  std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
-  toRosMsg(trackData, msgQueue);
-  auto msg = msgQueue.front();
+    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
 
-  TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
+    TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
 
-  return ptr;
+    return ptr;
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -1,0 +1,115 @@
+#include <depthai_bridge/TrackSpatialDetectionConverter.hpp>
+
+#include "depthai_bridge/depthaiUtility.hpp"
+#include "depthai/depthai.hpp"
+
+namespace dai {
+
+namespace ros {
+
+TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
+	:	_frameName(frameName),
+		_width(width),
+		_height(height),
+		_normalized(normalized),
+		_steadyBaseTime(std::chrono::steady_clock::now()),
+		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+		_rosBaseTime = rclcpp::Clock().now();
+}
+
+TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
+
+void TrackSpatialDetectionConverter::toRosMsg(
+	std::shared_ptr<dai::Tracklets> trackData, 
+	std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+
+	// setting the header
+	std::chrono::_V2::steady_clock::time_point tstamp;
+	if(_getBaseDeviceTimestamp)
+		tstamp = trackData->getTimestampDevice();
+	else
+		tstamp = trackData->getTimestamp();
+
+	DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+	opDetectionMsg.header.frame_id = _frameName;
+	opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+	// publishing
+	for (int i = 0; i < trackData->tracklets.size(); ++i)
+	{
+		dai::Tracklet t = trackData->tracklets[i];
+		dai::Rect roi;
+		int xMin, yMin, xMax, yMax;
+
+		// if (_normalized)
+		// 	roi = t.roi;
+		// else
+			roi = t.roi.denormalize(_width, _height);
+
+		xMin = roi.topLeft().x;
+		yMin = roi.topLeft().y;
+		xMax = roi.bottomRight().x;
+		yMax = roi.bottomRight().y;
+
+		float xSize = xMax - xMin;
+		float ySize = yMax - yMin;
+		float xCenter = xMin + xSize / 2.;
+		float yCenter = yMin + ySize / 2.;
+
+		opDetectionMsg.detections[i].results.resize(1);
+
+#if defined(IS_GALACTIC) || defined(IS_HUMBLE)
+		opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
+#elif IS_ROS2
+		opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+#else
+		opDetectionMsg.detections[i].results[0].id = t.label;
+#endif
+
+		opDetectionMsg.detections[i].results[0].score = -1.0;
+
+#ifdef IS_HUMBLE
+		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+		opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+#else
+		opDetectionMsg.detections[i].bbox.center.x = xCenter;
+		opDetectionMsg.detections[i].bbox.center.y = yCenter;
+#endif
+
+		opDetectionMsg.detections[i].bbox.size_x = xSize;
+		opDetectionMsg.detections[i].bbox.size_y = ySize;
+		opDetectionMsg.detections[i].is_tracking = true;
+		std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+		opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+		opDetectionMsg.detections[i].tracking_age = t.age;
+		opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+
+		// converting mm to meters since per ros rep-103 lenght should always be in meters
+		opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+		opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+		opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
+}
+
+TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(
+	std::shared_ptr<dai::Tracklets> trackData) {
+
+	std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
+
+#ifdef IS_ROS2
+    TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
+#else
+    TrackDetection2DArrayPtr ptr = boost::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
+#endif
+    return ptr;
+}
+
+}  // namespace ros
+
+}  // namespace dai

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -1,4 +1,4 @@
-#include <depthai_bridge/TrackSpatialDetectionConverter.hpp>
+#include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
 
 #include "depthai_bridge/depthaiUtility.hpp"
 #include "depthai/depthai.hpp"
@@ -60,26 +60,15 @@ void TrackSpatialDetectionConverter::toRosMsg(
 
         opDetectionMsg.detections[i].results.resize(1);
 
-#if defined(IS_GALACTIC) || defined(IS_HUMBLE)
-        opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
-#elif IS_ROS2
         opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
-#else
-        opDetectionMsg.detections[i].results[0].id = t.label;
-#endif
 
         opDetectionMsg.detections[i].results[0].score = _thresh;
 
-#ifdef IS_HUMBLE
-        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
-#else
         opDetectionMsg.detections[i].bbox.center.x = xCenter;
         opDetectionMsg.detections[i].bbox.center.y = yCenter;
-#endif
-
         opDetectionMsg.detections[i].bbox.size_x = xSize;
         opDetectionMsg.detections[i].bbox.size_y = ySize;
+
         opDetectionMsg.detections[i].is_tracking = true;
         std::stringstream track_id_str;
         track_id_str << "" << t.id;
@@ -103,11 +92,8 @@ TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(
     toRosMsg(trackData, msgQueue);
     auto msg = msgQueue.front();
 
-#ifdef IS_ROS2
     TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-#else
-    TrackDetection2DArrayPtr ptr = boost::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-#endif
+
     return ptr;
 }
 

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -7,11 +7,12 @@ namespace dai {
 
 namespace ros {
 
-TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, bool getBaseDeviceTimestamp)
+TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
 	:	_frameName(frameName),
 		_width(width),
 		_height(height),
 		_normalized(normalized),
+		_thresh(thresh),
 		_steadyBaseTime(std::chrono::steady_clock::now()),
 		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
 		_rosBaseTime = rclcpp::Clock().now();
@@ -40,11 +41,11 @@ void TrackSpatialDetectionConverter::toRosMsg(
 	{
 		dai::Tracklet t = trackData->tracklets[i];
 		dai::Rect roi;
-		int xMin, yMin, xMax, yMax;
+		float xMin, yMin, xMax, yMax;
 
-		// if (_normalized)
-		// 	roi = t.roi;
-		// else
+		 if (_normalized)
+		 	roi = t.roi;
+		else
 			roi = t.roi.denormalize(_width, _height);
 
 		xMin = roi.topLeft().x;
@@ -67,7 +68,7 @@ void TrackSpatialDetectionConverter::toRosMsg(
 		opDetectionMsg.detections[i].results[0].id = t.label;
 #endif
 
-		opDetectionMsg.detections[i].results[0].score = -1.0;
+		opDetectionMsg.detections[i].results[0].score = _thresh;
 
 #ifdef IS_HUMBLE
 		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -1,100 +1,96 @@
 #include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
 
-#include "depthai_bridge/depthaiUtility.hpp"
 #include "depthai/depthai.hpp"
+#include "depthai_bridge/depthaiUtility.hpp"
 
 namespace dai {
 
 namespace ros {
 
 TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-    :	_frameName(frameName),
-        _width(width),
-        _height(height),
-        _normalized(normalized),
-        _thresh(thresh),
-        _steadyBaseTime(std::chrono::steady_clock::now()),
-        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-        _rosBaseTime = rclcpp::Clock().now();
+  :	_frameName(frameName),
+    _width(width),
+    _height(height),
+    _normalized(normalized),
+    _thresh(thresh),
+    _steadyBaseTime(std::chrono::steady_clock::now()),
+    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+  _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
 
 void TrackSpatialDetectionConverter::toRosMsg(
-    std::shared_ptr<dai::Tracklets> trackData, 
-    std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+  std::shared_ptr<dai::Tracklets> trackData, 
+  std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+  // setting the header
+  std::chrono::_V2::steady_clock::time_point tstamp;
+  if(_getBaseDeviceTimestamp)
+    tstamp = trackData->getTimestampDevice();
+  else
+    tstamp = trackData->getTimestamp();
 
-    // setting the header
-    std::chrono::_V2::steady_clock::time_point tstamp;
-    if(_getBaseDeviceTimestamp)
-        tstamp = trackData->getTimestampDevice();
+  DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+  opDetectionMsg.header.frame_id = _frameName;
+  opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+  // publishing
+  for(int i = 0; i < trackData->tracklets.size(); ++i) {
+    dai::Tracklet t = trackData->tracklets[i];
+    dai::Rect roi;
+    float xMin, yMin, xMax, yMax;
+
+    if(_normalized)
+      roi = t.roi;
     else
-        tstamp = trackData->getTimestamp();
+      roi = t.roi.denormalize(_width, _height);
 
-    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-    opDetectionMsg.header.frame_id = _frameName;
-    opDetectionMsg.detections.resize(trackData->tracklets.size());
+    xMin = roi.topLeft().x;
+    yMin = roi.topLeft().y;
+    xMax = roi.bottomRight().x;
+    yMax = roi.bottomRight().y;
 
-    // publishing
-    for (int i = 0; i < trackData->tracklets.size(); ++i)
-    {
-        dai::Tracklet t = trackData->tracklets[i];
-        dai::Rect roi;
-        float xMin, yMin, xMax, yMax;
+    float xSize = xMax - xMin;
+    float ySize = yMax - yMin;
+    float xCenter = xMin + xSize / 2.;
+    float yCenter = yMin + ySize / 2.;
 
-         if (_normalized)
-             roi = t.roi;
-        else
-            roi = t.roi.denormalize(_width, _height);
+    opDetectionMsg.detections[i].results.resize(1);
 
-        xMin = roi.topLeft().x;
-        yMin = roi.topLeft().y;
-        xMax = roi.bottomRight().x;
-        yMax = roi.bottomRight().y;
+    opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 
-        float xSize = xMax - xMin;
-        float ySize = yMax - yMin;
-        float xCenter = xMin + xSize / 2.;
-        float yCenter = yMin + ySize / 2.;
+    opDetectionMsg.detections[i].results[0].score = _thresh;
 
-        opDetectionMsg.detections[i].results.resize(1);
+    opDetectionMsg.detections[i].bbox.center.x = xCenter;
+    opDetectionMsg.detections[i].bbox.center.y = yCenter;
+    opDetectionMsg.detections[i].bbox.size_x = xSize;
+    opDetectionMsg.detections[i].bbox.size_y = ySize;
 
-        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+    opDetectionMsg.detections[i].is_tracking = true;
+    std::stringstream track_id_str;
+    track_id_str << "" << t.id;
+    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+    opDetectionMsg.detections[i].tracking_age = t.age;
+    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
 
-        opDetectionMsg.detections[i].results[0].score = _thresh;
+    // converting mm to meters since per ros rep-103 lenght should always be in meters
+    opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+  }
 
-        opDetectionMsg.detections[i].bbox.center.x = xCenter;
-        opDetectionMsg.detections[i].bbox.center.y = yCenter;
-        opDetectionMsg.detections[i].bbox.size_x = xSize;
-        opDetectionMsg.detections[i].bbox.size_y = ySize;
-
-        opDetectionMsg.detections[i].is_tracking = true;
-        std::stringstream track_id_str;
-        track_id_str << "" << t.id;
-        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-        opDetectionMsg.detections[i].tracking_age = t.age;
-        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
-
-        // converting mm to meters since per ros rep-103 lenght should always be in meters
-        opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
-        opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
-        opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
-    }
-
-    opDetectionMsgs.push_back(opDetectionMsg);
+  opDetectionMsgs.push_back(opDetectionMsg);
 }
 
-TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(
-    std::shared_ptr<dai::Tracklets> trackData) {
+TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
+  std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+  toRosMsg(trackData, msgQueue);
+  auto msg = msgQueue.front();
 
-    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
-    toRosMsg(trackData, msgQueue);
-    auto msg = msgQueue.front();
+  TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
 
-    TrackDetection2DArrayPtr ptr = std::make_shared<DepthaiMsgs::TrackDetection2DArray>(msg);
-
-    return ptr;
+  return ptr;
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -8,98 +8,98 @@ namespace dai {
 namespace ros {
 
 TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-	:	_frameName(frameName),
-		_width(width),
-		_height(height),
-		_normalized(normalized),
-		_thresh(thresh),
-		_steadyBaseTime(std::chrono::steady_clock::now()),
-		_getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-		_rosBaseTime = rclcpp::Clock().now();
+    :	_frameName(frameName),
+        _width(width),
+        _height(height),
+        _normalized(normalized),
+        _thresh(thresh),
+        _steadyBaseTime(std::chrono::steady_clock::now()),
+        _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+        _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
 
 void TrackSpatialDetectionConverter::toRosMsg(
-	std::shared_ptr<dai::Tracklets> trackData, 
-	std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
+    std::shared_ptr<dai::Tracklets> trackData, 
+    std::deque<DepthaiMsgs::TrackDetection2DArray>& opDetectionMsgs) {
 
-	// setting the header
-	std::chrono::_V2::steady_clock::time_point tstamp;
-	if(_getBaseDeviceTimestamp)
-		tstamp = trackData->getTimestampDevice();
-	else
-		tstamp = trackData->getTimestamp();
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
+    else
+        tstamp = trackData->getTimestamp();
 
-	DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
-	opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-	opDetectionMsg.header.frame_id = _frameName;
-	opDetectionMsg.detections.resize(trackData->tracklets.size());
+    DepthaiMsgs::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-	// publishing
-	for (int i = 0; i < trackData->tracklets.size(); ++i)
-	{
-		dai::Tracklet t = trackData->tracklets[i];
-		dai::Rect roi;
-		float xMin, yMin, xMax, yMax;
+    // publishing
+    for (int i = 0; i < trackData->tracklets.size(); ++i)
+    {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-		 if (_normalized)
-		 	roi = t.roi;
-		else
-			roi = t.roi.denormalize(_width, _height);
+         if (_normalized)
+             roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-		xMin = roi.topLeft().x;
-		yMin = roi.topLeft().y;
-		xMax = roi.bottomRight().x;
-		yMax = roi.bottomRight().y;
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-		float xSize = xMax - xMin;
-		float ySize = yMax - yMin;
-		float xCenter = xMin + xSize / 2.;
-		float yCenter = yMin + ySize / 2.;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-		opDetectionMsg.detections[i].results.resize(1);
+        opDetectionMsg.detections[i].results.resize(1);
 
 #if defined(IS_GALACTIC) || defined(IS_HUMBLE)
-		opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].class_id = std::to_string(t.label);
 #elif IS_ROS2
-		opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].id = std::to_string(t.label);
 #else
-		opDetectionMsg.detections[i].results[0].id = t.label;
+        opDetectionMsg.detections[i].results[0].id = t.label;
 #endif
 
-		opDetectionMsg.detections[i].results[0].score = _thresh;
+        opDetectionMsg.detections[i].results[0].score = _thresh;
 
 #ifdef IS_HUMBLE
-		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-		opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
 #else
-		opDetectionMsg.detections[i].bbox.center.x = xCenter;
-		opDetectionMsg.detections[i].bbox.center.y = yCenter;
+        opDetectionMsg.detections[i].bbox.center.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.y = yCenter;
 #endif
 
-		opDetectionMsg.detections[i].bbox.size_x = xSize;
-		opDetectionMsg.detections[i].bbox.size_y = ySize;
-		opDetectionMsg.detections[i].is_tracking = true;
-		std::stringstream track_id_str;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
         track_id_str << "" << t.id;
-		opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-		opDetectionMsg.detections[i].tracking_age = t.age;
-		opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
 
-		// converting mm to meters since per ros rep-103 lenght should always be in meters
-		opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
-		opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
-		opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
     }
 
     opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 TrackDetection2DArrayPtr TrackSpatialDetectionConverter::toRosMsgPtr(
-	std::shared_ptr<dai::Tracklets> trackData) {
+    std::shared_ptr<dai::Tracklets> trackData) {
 
-	std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
+    std::deque<DepthaiMsgs::TrackDetection2DArray> msgQueue;
     toRosMsg(trackData, msgQueue);
     auto msg = msgQueue.front();
 

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -127,8 +127,8 @@ install(TARGETS
         stereo_inertial_node
         stereo_node
         yolov4_spatial_node
-				tracker_yolov4_node
-				tracker_yolov4_spatial_node
+        tracker_yolov4_node
+        tracker_yolov4_spatial_node
         DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -100,10 +100,14 @@ dai_add_node_ros2(rgb_stereo_node src/rgb_stereo_node.cpp)
 dai_add_node_ros2(stereo_inertial_node src/stereo_inertial_publisher.cpp)
 dai_add_node_ros2(stereo_node src/stereo_publisher.cpp)
 dai_add_node_ros2(yolov4_spatial_node src/yolov4_spatial_publisher.cpp)
+dai_add_node_ros2(tracker_yolov4_node src/tracker_yolov4_publisher.cpp)
+dai_add_node_ros2(tracker_yolov4_spatial_node src/tracker_yolov4_spatial_publisher.cpp)
 
 target_compile_definitions(mobilenet_node PRIVATE BLOB_NAME="${mobilenet_blob_name}")
 target_compile_definitions(yolov4_spatial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
 target_compile_definitions(stereo_inertial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
+target_compile_definitions(tracker_yolov4_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
+target_compile_definitions(tracker_yolov4_spatial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
 
 if($ENV{ROS_DISTRO} STREQUAL "galactic")
   target_compile_definitions(rgb_stereo_node PRIVATE IS_GALACTIC)
@@ -123,6 +127,8 @@ install(TARGETS
         stereo_inertial_node
         stereo_node
         yolov4_spatial_node
+				tracker_yolov4_node
+				tracker_yolov4_spatial_node
         DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/depthai_examples/launch/tracker_yolov4_node.launch.py
+++ b/depthai_examples/launch/tracker_yolov4_node.launch.py
@@ -1,0 +1,159 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, launch_description_sources
+from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+import launch_ros.actions
+import launch_ros.descriptions
+
+
+def generate_launch_description():
+    depthai_examples_path = get_package_share_directory('depthai_examples')
+
+    default_rviz = os.path.join(depthai_examples_path,
+                                'rviz', 'pointCloud.rviz')
+    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
+    default_resources_path = os.path.join(depthai_examples_path,
+                                'resources')
+    print('Default resources path..............')
+    print(default_resources_path)
+    camera_model = LaunchConfiguration('camera_model',  default = 'OAK-D')
+    tf_prefix    = LaunchConfiguration('tf_prefix',     default = 'oak')
+    base_frame   = LaunchConfiguration('base_frame',    default = 'oak-d_frame')
+    parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
+
+    cam_pos_x = LaunchConfiguration('cam_pos_x',     default = '0.0')
+    cam_pos_y = LaunchConfiguration('cam_pos_y',     default = '0.0')
+    cam_pos_z = LaunchConfiguration('cam_pos_z',     default = '0.0')
+    cam_roll  = LaunchConfiguration('cam_roll',      default = '0.0')
+    cam_pitch = LaunchConfiguration('cam_pitch',     default = '0.0')
+    cam_yaw   = LaunchConfiguration('cam_yaw',       default = '0.0')
+
+    camera_param_uri   = LaunchConfiguration('camera_param_uri',  default = 'package://depthai_examples/params/camera')
+    nnName             = LaunchConfiguration('nnName', default = "x")
+    resourceBaseFolder = LaunchConfiguration('resourceBaseFolder', default = default_resources_path)
+    fullFrameTracking  = LaunchConfiguration('fullFrameTracking',  default = False)
+
+    declare_camera_model_cmd = DeclareLaunchArgument(
+        'camera_model',
+        default_value=camera_model,
+        description='The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.')
+
+    declare_tf_prefix_cmd = DeclareLaunchArgument(
+        'tf_prefix',
+        default_value=tf_prefix,
+        description='The name of the camera. It can be different from the camera model and it will be used in naming TF.')
+
+    declare_base_frame_cmd = DeclareLaunchArgument(
+        'base_frame',
+        default_value=base_frame,
+        description='Name of the base link.')
+
+    declare_parent_frame_cmd = DeclareLaunchArgument(
+        'parent_frame',
+        default_value=parent_frame,
+        description='Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.')
+
+    declare_pos_x_cmd = DeclareLaunchArgument(
+        'cam_pos_x',
+        default_value=cam_pos_x,
+        description='Position X of the camera with respect to the base frame.')
+
+    declare_pos_y_cmd = DeclareLaunchArgument(
+        'cam_pos_y',
+        default_value=cam_pos_y,
+        description='Position Y of the camera with respect to the base frame.')
+
+    declare_pos_z_cmd = DeclareLaunchArgument(
+        'cam_pos_z',
+        default_value=cam_pos_z,
+        description='Position Z of the camera with respect to the base frame.')
+
+    declare_roll_cmd = DeclareLaunchArgument(
+        'cam_roll',
+        default_value=cam_roll,
+        description='Roll orientation of the camera with respect to the base frame.')
+
+    declare_pitch_cmd = DeclareLaunchArgument(
+        'cam_pitch',
+        default_value=cam_pitch,
+        description='Pitch orientation of the camera with respect to the base frame.')
+
+    declare_yaw_cmd = DeclareLaunchArgument(
+        'cam_yaw',
+        default_value=cam_yaw,
+        description='Yaw orientation of the camera with respect to the base frame.')
+
+    declare_camera_param_uri_cmd = DeclareLaunchArgument(
+        'camera_param_uri',
+        default_value=camera_param_uri,
+        description='Sending camera yaml path')
+
+    declare_nnName_cmd = DeclareLaunchArgument(
+        'nnName',
+        default_value=nnName,
+        description='Path to the object detection blob needed for detection')
+
+    declare_resourceBaseFolder_cmd = DeclareLaunchArgument(
+        'resourceBaseFolder',
+        default_value=resourceBaseFolder,
+        description='Path to the resources folder which contains the default blobs for the network')
+
+    declare_fullFrameTracking_cmd = DeclareLaunchArgument(
+        'fullFrameTracking',
+        default_value=fullFrameTracking,
+        description='Set to true for tracking in entire frame')
+
+    urdf_launch = IncludeLaunchDescription(
+                            launch_description_sources.PythonLaunchDescriptionSource(
+                                    os.path.join(urdf_launch_dir, 'urdf_launch.py')),
+                            launch_arguments={'tf_prefix'   : tf_prefix,
+                                              'camera_model': camera_model,
+                                              'base_frame'  : base_frame,
+                                              'parent_frame': parent_frame,
+                                              'cam_pos_x'   : cam_pos_x,
+                                              'cam_pos_y'   : cam_pos_y,
+                                              'cam_pos_z'   : cam_pos_z,
+                                              'cam_roll'    : cam_roll,
+                                              'cam_pitch'   : cam_pitch,
+                                              'cam_yaw'     : cam_yaw}.items())
+
+    tracker_yolov4_node = launch_ros.actions.Node(
+            package='depthai_examples', executable='tracker_yolov4_node',
+            output='screen',
+            parameters=[{'tf_prefix': tf_prefix},
+                        {'camera_param_uri': camera_param_uri},
+                        {'nnName': nnName},
+                        {'resourceBaseFolder': resourceBaseFolder},
+												{'fullFrameTracking': fullFrameTracking}])
+
+    rviz_node = launch_ros.actions.Node(
+            package='rviz2', executable='rviz2', output='screen',
+            arguments=['--display-config', default_rviz])
+
+    ld = LaunchDescription()
+    ld.add_action(declare_tf_prefix_cmd)
+    ld.add_action(declare_camera_model_cmd)
+
+    ld.add_action(declare_base_frame_cmd)
+    ld.add_action(declare_parent_frame_cmd)
+
+    ld.add_action(declare_pos_x_cmd)
+    ld.add_action(declare_pos_y_cmd)
+    ld.add_action(declare_pos_z_cmd)
+    ld.add_action(declare_roll_cmd)
+    ld.add_action(declare_pitch_cmd)
+    ld.add_action(declare_yaw_cmd)
+
+    ld.add_action(declare_camera_param_uri_cmd)
+    ld.add_action(declare_nnName_cmd)
+    ld.add_action(declare_resourceBaseFolder_cmd)
+    ld.add_action(declare_fullFrameTracking_cmd)
+
+    ld.add_action(tracker_yolov4_node)
+    #ld.add_action(urdf_launch)
+
+    return ld
+

--- a/depthai_examples/launch/tracker_yolov4_spatial_node.launch.py
+++ b/depthai_examples/launch/tracker_yolov4_spatial_node.launch.py
@@ -1,0 +1,196 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, launch_description_sources
+from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+import launch_ros.actions
+import launch_ros.descriptions
+
+
+def generate_launch_description():
+    depthai_examples_path = get_package_share_directory('depthai_examples')
+
+    default_rviz = os.path.join(depthai_examples_path,
+                                'rviz', 'pointCloud.rviz')
+    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
+    default_resources_path = os.path.join(depthai_examples_path,
+                                'resources')
+    print('Default resources path..............')
+    print(default_resources_path)
+    camera_model = LaunchConfiguration('camera_model',  default = 'OAK-D')
+    tf_prefix    = LaunchConfiguration('tf_prefix',     default = 'oak')
+    base_frame   = LaunchConfiguration('base_frame',    default = 'oak-d_frame')
+    parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
+
+    cam_pos_x = LaunchConfiguration('cam_pos_x',     default = '0.0')
+    cam_pos_y = LaunchConfiguration('cam_pos_y',     default = '0.0')
+    cam_pos_z = LaunchConfiguration('cam_pos_z',     default = '0.0')
+    cam_roll  = LaunchConfiguration('cam_roll',      default = '0.0')
+    cam_pitch = LaunchConfiguration('cam_pitch',     default = '0.0')
+    cam_yaw   = LaunchConfiguration('cam_yaw',       default = '0.0')
+
+    camera_param_uri   = LaunchConfiguration('camera_param_uri',  default = 'package://depthai_examples/params/camera')
+    sync_nn            = LaunchConfiguration('sync_nn',           default = True)
+    subpixel           = LaunchConfiguration('subpixel',          default = True)
+    nnName             = LaunchConfiguration('nnName', default = "x")
+    resourceBaseFolder = LaunchConfiguration('resourceBaseFolder', default = default_resources_path)
+    confidence         = LaunchConfiguration('confidence',         default = 200)
+    lrCheckTresh       = LaunchConfiguration('lrCheckTresh',       default = 5)
+    monoResolution     = LaunchConfiguration('monoResolution',     default = '400p')
+    fullFrameTracking  = LaunchConfiguration('fullFrameTracking',  default = False)
+
+    declare_camera_model_cmd = DeclareLaunchArgument(
+        'camera_model',
+        default_value=camera_model,
+        description='The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.')
+
+    declare_tf_prefix_cmd = DeclareLaunchArgument(
+        'tf_prefix',
+        default_value=tf_prefix,
+        description='The name of the camera. It can be different from the camera model and it will be used in naming TF.')
+
+    declare_base_frame_cmd = DeclareLaunchArgument(
+        'base_frame',
+        default_value=base_frame,
+        description='Name of the base link.')
+
+    declare_parent_frame_cmd = DeclareLaunchArgument(
+        'parent_frame',
+        default_value=parent_frame,
+        description='Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.')
+
+    declare_pos_x_cmd = DeclareLaunchArgument(
+        'cam_pos_x',
+        default_value=cam_pos_x,
+        description='Position X of the camera with respect to the base frame.')
+
+    declare_pos_y_cmd = DeclareLaunchArgument(
+        'cam_pos_y',
+        default_value=cam_pos_y,
+        description='Position Y of the camera with respect to the base frame.')
+
+    declare_pos_z_cmd = DeclareLaunchArgument(
+        'cam_pos_z',
+        default_value=cam_pos_z,
+        description='Position Z of the camera with respect to the base frame.')
+
+    declare_roll_cmd = DeclareLaunchArgument(
+        'cam_roll',
+        default_value=cam_roll,
+        description='Roll orientation of the camera with respect to the base frame.')
+
+    declare_pitch_cmd = DeclareLaunchArgument(
+        'cam_pitch',
+        default_value=cam_pitch,
+        description='Pitch orientation of the camera with respect to the base frame.')
+
+    declare_yaw_cmd = DeclareLaunchArgument(
+        'cam_yaw',
+        default_value=cam_yaw,
+        description='Yaw orientation of the camera with respect to the base frame.')
+
+    declare_camera_param_uri_cmd = DeclareLaunchArgument(
+        'camera_param_uri',
+        default_value=camera_param_uri,
+        description='Sending camera yaml path')
+
+    declare_sync_nn_cmd = DeclareLaunchArgument(
+        'sync_nn',
+        default_value=sync_nn,
+        description='Syncs the image output with the Detection.')
+
+    declare_subpixel_cmd = DeclareLaunchArgument(
+        'subpixel',
+        default_value=subpixel,
+        description='Enables subpixel stereo detection.')
+
+    declare_nnName_cmd = DeclareLaunchArgument(
+        'nnName',
+        default_value=nnName,
+        description='Path to the object detection blob needed for detection')
+
+    declare_resourceBaseFolder_cmd = DeclareLaunchArgument(
+        'resourceBaseFolder',
+        default_value=resourceBaseFolder,
+        description='Path to the resources folder which contains the default blobs for the network')
+
+    declare_confidence_cmd = DeclareLaunchArgument(
+        'confidence',
+        default_value=confidence,
+        description='Confidence that the disparity from the feature matching was good. 0-255. 255 being the lowest confidence.')
+
+    declare_lrCheckTresh_cmd = DeclareLaunchArgument(
+        'lrCheckTresh',
+        default_value=lrCheckTresh,
+        description='LR Threshold is the threshod of how much off the disparity on the l->r and r->l  ')
+
+    declare_monoResolution_cmd = DeclareLaunchArgument(
+        'monoResolution',
+        default_value=monoResolution,
+        description='Contains the resolution of the Mono Cameras. Available resolutions are 800p, 720p & 400p for OAK-D & 480p for OAK-D-Lite.')
+
+    declare_fullFrameTracking_cmd = DeclareLaunchArgument(
+        'fullFrameTracking',
+        default_value=fullFrameTracking,
+        description='Set to true for tracking in entire frame')
+
+    urdf_launch = IncludeLaunchDescription(
+                            launch_description_sources.PythonLaunchDescriptionSource(
+                                    os.path.join(urdf_launch_dir, 'urdf_launch.py')),
+                            launch_arguments={'tf_prefix'   : tf_prefix,
+                                              'camera_model': camera_model,
+                                              'base_frame'  : base_frame,
+                                              'parent_frame': parent_frame,
+                                              'cam_pos_x'   : cam_pos_x,
+                                              'cam_pos_y'   : cam_pos_y,
+                                              'cam_pos_z'   : cam_pos_z,
+                                              'cam_roll'    : cam_roll,
+                                              'cam_pitch'   : cam_pitch,
+                                              'cam_yaw'     : cam_yaw}.items())
+
+    tracker_yolov4_spatial_node = launch_ros.actions.Node(
+            package='depthai_examples', executable='tracker_yolov4_spatial_node',
+            output='screen',
+            parameters=[{'tf_prefix': tf_prefix},
+                        {'camera_param_uri': camera_param_uri},
+                        {'sync_nn': sync_nn},
+                        {'nnName': nnName},
+                        {'resourceBaseFolder': resourceBaseFolder},
+                        {'monoResolution': monoResolution},
+												{'fullFrameTracking': fullFrameTracking}])
+
+    rviz_node = launch_ros.actions.Node(
+            package='rviz2', executable='rviz2', output='screen',
+            arguments=['--display-config', default_rviz])
+
+    ld = LaunchDescription()
+    ld.add_action(declare_tf_prefix_cmd)
+    ld.add_action(declare_camera_model_cmd)
+
+    ld.add_action(declare_base_frame_cmd)
+    ld.add_action(declare_parent_frame_cmd)
+
+    ld.add_action(declare_pos_x_cmd)
+    ld.add_action(declare_pos_y_cmd)
+    ld.add_action(declare_pos_z_cmd)
+    ld.add_action(declare_roll_cmd)
+    ld.add_action(declare_pitch_cmd)
+    ld.add_action(declare_yaw_cmd)
+
+    ld.add_action(declare_camera_param_uri_cmd)
+    ld.add_action(declare_sync_nn_cmd)
+    ld.add_action(declare_subpixel_cmd)
+    ld.add_action(declare_nnName_cmd)
+    ld.add_action(declare_resourceBaseFolder_cmd)
+    ld.add_action(declare_confidence_cmd)
+    ld.add_action(declare_lrCheckTresh_cmd)
+    ld.add_action(declare_monoResolution_cmd)
+    ld.add_action(declare_fullFrameTracking_cmd)
+
+    ld.add_action(tracker_yolov4_spatial_node)
+    #ld.add_action(urdf_launch)
+
+    return ld
+

--- a/depthai_examples/src/tracker_yolov4_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_publisher.cpp
@@ -1,0 +1,173 @@
+#include <cstdio>
+#include <iostream>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "camera_info_manager/camera_info_manager.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+
+#include "depthai_bridge/BridgePublisher.hpp"
+#include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_bridge/TrackDetectionConverter.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/device/DataQueue.hpp"
+#include "depthai/device/Device.hpp"
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/node/ColorCamera.hpp"
+#include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
+#include "depthai/pipeline/node/StereoDepth.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
+
+const std::vector<std::string> label_map = {
+    "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+    "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+    "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+    "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+    "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+    "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+    "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+    "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+    "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+
+dai::Pipeline createPipeline(std::string nnPath, bool fullFrameTracking) {
+    dai::Pipeline pipeline;
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto detectionNetwork = pipeline.create<dai::node::YoloDetectionNetwork>();
+    auto tracker = pipeline.create<dai::node::ObjectTracker>();
+
+    // create xlink connections
+    auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+    auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+
+    xoutRgb->setStreamName("preview");
+    xoutTracker->setStreamName("tracklets");
+
+    colorCam->setPreviewSize(416, 416);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+
+    // setting node configs
+    detectionNetwork->setBlobPath(nnPath);
+    detectionNetwork->setConfidenceThreshold(0.3f);
+    detectionNetwork->input.setBlocking(false);
+
+    // yolo specific parameters
+    detectionNetwork->setNumClasses(80);
+    detectionNetwork->setCoordinateSize(4);
+    detectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+    detectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+    detectionNetwork->setIouThreshold(0.5f);
+
+    // object tracker settings
+    tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+    tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+
+    // Link plugins CAM -> NN -> XLINK
+    colorCam->preview.link(detectionNetwork->input);
+    tracker->passthroughTrackerFrame.link(xoutRgb->input);
+
+    if (fullFrameTracking)
+    {
+      colorCam->setPreviewKeepAspectRatio(false);
+      colorCam->video.link(tracker->inputTrackerFrame);
+      //tracker->inputTrackerFrame.setBlocking(false);
+      // do not block the pipeline if it's too slow on full frame
+      //tracker->inputTrackerFrame.setQueueSize(2);
+    }
+    else
+    {
+      detectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+    }
+
+    detectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+    detectionNetwork->out.link(tracker->inputDetections);
+    tracker->out.link(xoutTracker->input);
+
+    return pipeline;
+}
+
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+    auto node = rclcpp::Node::make_shared("tracker_yolov4_node");
+
+    std::string tfPrefix, resourceBaseFolder, nnPath;
+    std::string camera_param_uri;
+    bool fullFrameTracking;
+    std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+
+    node->declare_parameter("tf_prefix", "oak");
+    node->declare_parameter("camera_param_uri", camera_param_uri);
+    node->declare_parameter("nnName", "");
+    node->declare_parameter("resourceBaseFolder", "");
+    node->declare_parameter("fullFrameTracking", false);
+
+    node->get_parameter("tf_prefix", tfPrefix);
+    node->get_parameter("camera_param_uri", camera_param_uri);
+    node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+    node->get_parameter("fullFrameTracking", fullFrameTracking);
+
+    if(resourceBaseFolder.empty()) {
+        throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+    }
+
+    std::string nnParam;
+    node->get_parameter("nnName", nnParam);
+    if(nnParam != "x") {
+        node->get_parameter("nnName", nnName);
+    }
+
+    nnPath = resourceBaseFolder + "/" + nnName;
+    dai::Pipeline pipeline = createPipeline(nnPath, fullFrameTracking);
+    dai::Device device(pipeline);
+
+    auto colorQueue = device.getOutputQueue("preview", 30, false);
+    auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+    auto calibrationHandler = device.readCalibration();
+
+    int width, height;
+    auto boardName = calibrationHandler.getEepromData().boardName;
+    if(height > 480 && boardName == "OAK-D-LITE") {
+        width = 640;
+        height = 480;
+    }
+
+    dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+    auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::RGB, -1, -1);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(
+        colorQueue,
+        node,
+        std::string("color/image"),
+        std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+                  &rgbConverter,  // since the converter has the same frame name
+                                  // and image type is also same we can reuse it
+                  std::placeholders::_1,
+                  std::placeholders::_2),
+        30,
+        rgbCameraInfo,
+        "color");
+
+    dai::rosBridge::TrackDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.01);
+    dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+        trackQueue,
+        node,
+        std::string("color/yolov4_tracklets"),
+        std::bind(&dai::rosBridge::TrackDetectionConverter::toRosMsg,
+                  &trackConverter,
+                  std::placeholders::_1,
+                  std::placeholders::_2),
+        30);
+
+    rgbPublish.addPublisherCallback();
+    trackPublish.addPublisherCallback();
+
+    rclcpp::spin(node);
+
+    return 0;
+}

--- a/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
@@ -1,17 +1,16 @@
 #include <cstdio>
 #include <iostream>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/executors.hpp"
-#include "sensor_msgs/msg/image.hpp"
 #include "camera_info_manager/camera_info_manager.hpp"
-#include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
-
 #include "depthai_bridge/BridgePublisher.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+#include "rclcpp/executors.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 
 // Inludes common necessary includes for development using depthai library
 #include "depthai/device/DataQueue.hpp"
@@ -19,9 +18,9 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/ColorCamera.hpp"
 #include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai/pipeline/node/StereoDepth.hpp"
-#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
 
 const std::vector<std::string> label_map = {
@@ -110,17 +109,14 @@ dai::Pipeline createPipeline(bool syncNN, bool subpixel, std::string nnPath, int
     colorCam->preview.link(spatialDetectionNetwork->input);
     tracker->passthroughTrackerFrame.link(xoutRgb->input);
 
-    if (fullFrameTracking)
-    {
-      colorCam->setPreviewKeepAspectRatio(false);
-      colorCam->video.link(tracker->inputTrackerFrame);
-      //tracker->inputTrackerFrame.setBlocking(false);
-      // do not block the pipeline if it's too slow on full frame
-      //tracker->inputTrackerFrame.setQueueSize(2);
-    }
-    else
-    {
-      spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+    if(fullFrameTracking) {
+        colorCam->setPreviewKeepAspectRatio(false);
+        colorCam->video.link(tracker->inputTrackerFrame);
+        // tracker->inputTrackerFrame.setBlocking(false);
+        // do not block the pipeline if it's too slow on full frame
+        // tracker->inputTrackerFrame.setQueueSize(2);
+    } else {
+        spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
     }
 
     spatialDetectionNetwork->passthrough.link(tracker->inputDetectionFrame);
@@ -210,25 +206,23 @@ int main(int argc, char** argv) {
     dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
     auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::RGB, -1, -1);
     dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
-        node,
-        std::string("color/image"),
-        std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
-                  &rgbConverter,  // since the converter has the same frame name
-                                  // and image type is also same we can reuse it
-                  std::placeholders::_1,
-                  std::placeholders::_2),
-        30,
-        rgbCameraInfo,
-        "color");
+                                                                                       node,
+                                                                                       std::string("color/image"),
+                                                                                       std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+                                                                                                 &rgbConverter,  // since the converter has the same frame name
+                                                                                                                 // and image type is also same we can reuse it
+                                                                                                 std::placeholders::_1,
+                                                                                                 std::placeholders::_2),
+                                                                                       30,
+                                                                                       rgbCameraInfo,
+                                                                                       "color");
 
     dai::rosBridge::TrackSpatialDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.01);
     dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
         trackQueue,
-        node, std::string("color/yolov4_Spatial_tracklets"),
-        std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg,
-                  &trackConverter,
-                  std::placeholders::_1,
-                  std::placeholders::_2),
+        node,
+        std::string("color/yolov4_Spatial_tracklets"),
+        std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg, &trackConverter, std::placeholders::_1, std::placeholders::_2),
         30);
 
     dai::rosBridge::ImageConverter depthConverter(tfPrefix + "_right_camera_optical_frame", true);

--- a/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
@@ -1,0 +1,252 @@
+#include <cstdio>
+#include <iostream>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "camera_info_manager/camera_info_manager.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+
+#include "depthai_bridge/BridgePublisher.hpp"
+#include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/device/DataQueue.hpp"
+#include "depthai/device/Device.hpp"
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/node/ColorCamera.hpp"
+#include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
+#include "depthai/pipeline/node/StereoDepth.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
+
+const std::vector<std::string> label_map = {
+    "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+    "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+    "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+    "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+    "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+    "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+    "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+    "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+    "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+
+dai::Pipeline createPipeline(bool syncNN, bool subpixel, std::string nnPath, int confidence, int LRchecktresh, std::string resolution, bool fullFrameTracking) {
+    dai::Pipeline pipeline;
+    dai::node::MonoCamera::Properties::SensorResolution monoResolution;
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto spatialDetectionNetwork = pipeline.create<dai::node::YoloSpatialDetectionNetwork>();
+    auto monoLeft = pipeline.create<dai::node::MonoCamera>();
+    auto monoRight = pipeline.create<dai::node::MonoCamera>();
+    auto stereo = pipeline.create<dai::node::StereoDepth>();
+    auto tracker = pipeline.create<dai::node::ObjectTracker>();
+
+    // create xlink connections
+    auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+    auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
+    auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+
+    xoutRgb->setStreamName("preview");
+    xoutDepth->setStreamName("depth");
+    xoutTracker->setStreamName("tracklets");
+
+    colorCam->setPreviewSize(416, 416);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+
+    if(resolution == "720p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_720_P;
+    } else if(resolution == "400p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_400_P;
+    } else if(resolution == "800p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_800_P;
+    } else if(resolution == "480p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_480_P;
+    } else {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", resolution.c_str());
+        throw std::runtime_error("Invalid mono camera resolution.");
+    }
+
+    monoLeft->setResolution(monoResolution);
+    monoLeft->setBoardSocket(dai::CameraBoardSocket::LEFT);
+    monoRight->setResolution(monoResolution);
+    monoRight->setBoardSocket(dai::CameraBoardSocket::RIGHT);
+
+    /// setting node configs
+    stereo->initialConfig.setConfidenceThreshold(confidence);
+    stereo->setRectifyEdgeFillColor(0);  // black, to better see the cutout
+    stereo->initialConfig.setLeftRightCheckThreshold(LRchecktresh);
+    stereo->setSubpixel(subpixel);
+    stereo->setDepthAlign(dai::CameraBoardSocket::RGB);
+
+    spatialDetectionNetwork->setBlobPath(nnPath);
+    spatialDetectionNetwork->setConfidenceThreshold(0.3f);
+    spatialDetectionNetwork->input.setBlocking(false);
+    spatialDetectionNetwork->setBoundingBoxScaleFactor(0.5);
+    spatialDetectionNetwork->setDepthLowerThreshold(100);
+    spatialDetectionNetwork->setDepthUpperThreshold(5000);
+
+    // yolo specific parameters
+    spatialDetectionNetwork->setNumClasses(80);
+    spatialDetectionNetwork->setCoordinateSize(4);
+    spatialDetectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+    spatialDetectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+    spatialDetectionNetwork->setIouThreshold(0.5f);
+
+    // object tracker settings
+    tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+    tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+
+    // Link plugins CAM -> STEREO -> XLINK
+    monoLeft->out.link(stereo->left);
+    monoRight->out.link(stereo->right);
+
+    // Link plugins CAM -> NN -> XLINK
+    colorCam->preview.link(spatialDetectionNetwork->input);
+    tracker->passthroughTrackerFrame.link(xoutRgb->input);
+
+    if (fullFrameTracking)
+    {
+      colorCam->setPreviewKeepAspectRatio(false);
+      colorCam->video.link(tracker->inputTrackerFrame);
+      //tracker->inputTrackerFrame.setBlocking(false);
+      // do not block the pipeline if it's too slow on full frame
+      //tracker->inputTrackerFrame.setQueueSize(2);
+    }
+    else
+    {
+      spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+    }
+
+    spatialDetectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+    spatialDetectionNetwork->out.link(tracker->inputDetections);
+    tracker->out.link(xoutTracker->input);
+    stereo->depth.link(spatialDetectionNetwork->inputDepth);
+    spatialDetectionNetwork->passthroughDepth.link(xoutDepth->input);
+
+    return pipeline;
+}
+
+int main(int argc, char** argv) {
+    rclcpp::init(argc, argv);
+    auto node = rclcpp::Node::make_shared("tracker_yolov4_spatial_node");
+
+    std::string tfPrefix, resourceBaseFolder, nnPath;
+    std::string camera_param_uri;
+    std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+    bool syncNN, subpixel, fullFrameTracking;
+    int confidence = 200, LRchecktresh = 5;
+    std::string monoResolution = "400p";
+
+    node->declare_parameter("tf_prefix", "oak");
+    node->declare_parameter("camera_param_uri", camera_param_uri);
+    node->declare_parameter("sync_nn", true);
+    node->declare_parameter("subpixel", true);
+    node->declare_parameter("nnName", "");
+    node->declare_parameter("confidence", confidence);
+    node->declare_parameter("LRchecktresh", LRchecktresh);
+    node->declare_parameter("monoResolution", monoResolution);
+    node->declare_parameter("resourceBaseFolder", "");
+    node->declare_parameter("fullFrameTracking", false);
+
+    node->get_parameter("tf_prefix", tfPrefix);
+    node->get_parameter("camera_param_uri", camera_param_uri);
+    node->get_parameter("sync_nn", syncNN);
+    node->get_parameter("subpixel", subpixel);
+    node->get_parameter("confidence", confidence);
+    node->get_parameter("LRchecktresh", LRchecktresh);
+    node->get_parameter("monoResolution", monoResolution);
+    node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+    node->get_parameter("fullFrameTracking", fullFrameTracking);
+
+    if(resourceBaseFolder.empty()) {
+        throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+    }
+
+    std::string nnParam;
+    node->get_parameter("nnName", nnParam);
+    if(nnParam != "x") {
+        node->get_parameter("nnName", nnName);
+    }
+
+    nnPath = resourceBaseFolder + "/" + nnName;
+    dai::Pipeline pipeline = createPipeline(syncNN, subpixel, nnPath, confidence, LRchecktresh, monoResolution, fullFrameTracking);
+    dai::Device device(pipeline);
+
+    auto colorQueue = device.getOutputQueue("preview", 30, false);
+    auto depthQueue = device.getOutputQueue("depth", 30, false);
+    auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+    auto calibrationHandler = device.readCalibration();
+
+    int width, height;
+    if(monoResolution == "720p") {
+        width = 1280;
+        height = 720;
+    } else if(monoResolution == "400p") {
+        width = 640;
+        height = 400;
+    } else if(monoResolution == "800p") {
+        width = 1280;
+        height = 800;
+    } else if(monoResolution == "480p") {
+        width = 640;
+        height = 480;
+    } else {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", monoResolution.c_str());
+        throw std::runtime_error("Invalid mono camera resolution.");
+    }
+
+    auto boardName = calibrationHandler.getEepromData().boardName;
+    if(height > 480 && boardName == "OAK-D-LITE") {
+        width = 640;
+        height = 480;
+    }
+
+    dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+    auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::RGB, -1, -1);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
+        node,
+        std::string("color/image"),
+        std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+                  &rgbConverter,  // since the converter has the same frame name
+                                  // and image type is also same we can reuse it
+                  std::placeholders::_1,
+                  std::placeholders::_2),
+        30,
+        rgbCameraInfo,
+        "color");
+
+    dai::rosBridge::TrackSpatialDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.01);
+    dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+        trackQueue,
+        node, std::string("color/yolov4_Spatial_tracklets"),
+        std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg,
+                  &trackConverter,
+                  std::placeholders::_1,
+                  std::placeholders::_2),
+        30);
+
+    dai::rosBridge::ImageConverter depthConverter(tfPrefix + "_right_camera_optical_frame", true);
+    auto rightCameraInfo = depthConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::RIGHT, width, height);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> depthPublish(
+        depthQueue,
+        node,
+        std::string("stereo/depth"),
+        std::bind(&dai::rosBridge::ImageConverter::toRosMsg, &depthConverter, std::placeholders::_1, std::placeholders::_2),
+        30,
+        rightCameraInfo,
+        "stereo");
+
+    depthPublish.addPublisherCallback();
+    trackPublish.addPublisherCallback();
+    rgbPublish.addPublisherCallback();  // addPublisherCallback works only when the dataqueue is non blocking.
+
+    rclcpp::spin(node);
+
+    return 0;
+}

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -27,6 +27,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   # "msg/ImageMarkerArray.msg"
   "msg/SpatialDetection.msg"
   "msg/SpatialDetectionArray.msg"
+  "msg/TrackDetection2D.msg"
+  "msg/TrackDetection2DArray.msg"
   "srv/TriggerNamed.srv"
   "srv/NormalizedImageCrop.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs vision_msgs

--- a/depthai_ros_msgs/msg/TrackDetection2D.msg
+++ b/depthai_ros_msgs/msg/TrackDetection2D.msg
@@ -1,0 +1,25 @@
+
+# Class probabilities
+vision_msgs/ObjectHypothesisWithPose[] results
+
+# 2D bounding box surrounding the object.
+vision_msgs/BoundingBox2D bbox
+
+# If true, this message contains object tracking information.
+bool is_tracking
+
+# ID used for consistency across multiple detection messages. This value will
+# likely differ from the id field set in each individual ObjectHypothesis.
+# If you set this field, be sure to also set is_tracking to True.
+string tracking_id
+
+# Age: number of frames the object is being tracked
+int32 tracking_age
+
+# Status of the tracking:
+# 0 = NEW -> the object is newly added.
+# 1 = TRACKED -> the object is being tracked.
+# 2 = LOST -> the object gets lost now. The object can be tracked again automatically (long term tracking) 
+#			  or by specifying detected object manually (short term and zero term tracking).
+# 3 = REMOVED -> the object is removed.
+int32 tracking_status

--- a/depthai_ros_msgs/msg/TrackDetection2DArray.msg
+++ b/depthai_ros_msgs/msg/TrackDetection2DArray.msg
@@ -1,0 +1,7 @@
+# A list of 2D tracklets, for a multi-object 2D tracker.
+
+std_msgs/Header header
+# A list of the tracking proposals.
+TrackDetection2D[] detections
+
+## These messages are created as close as possible to the official vision_msgs(http://wiki.ros.org/vision_msgs)


### PR DESCRIPTION
## Overview
Author: [@daniqsilva25](https://github.com/daniqsilva25)

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/146
Issue description: Absence of a tracking converter. This PR adds a tracking converter to enable object tracking with ROS.
Related PRs

## Changes
ROS distro: Foxy
List of changes:
* Added other spatial detection converter that uses standard ROS2 vision msgs for more compatibility with other ROS2 code
* Added a track detection converter and track spatial detection converter for tracking purposes with 2D or 3D detections, respectively
* Added new ROS2 messages for tracking: TrackDetection2D and TrackDetection2DArray. The first message adds two important fields for tracking tasks: tracking age and tracking status, both available in the depthai pipeline. The second message is just an array of the first one.

## Testing
Hardware used: OAK-1, OAK-D
Depthai library version: 2.21.2.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
