### PR TITLE
No imu fix Noetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Depthai ROS Repository
 Hi and welcome to the main depthai-ros respository! Here you can find ROS related code for OAK cameras from Luxonis. Don't have one? You can get them [here!](https://shop.luxonis.com/)
 
-You can find the newest documentation [here](https://docs-beta.luxonis.com/develop/ros/depthai-ros/intro/).
+You can find the newest documentation [here](https://docs-beta.luxonis.com/software/ros/depthai-ros/intro/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Depthai ROS Repository
 Hi and welcome to the main depthai-ros respository! Here you can find ROS related code for OAK cameras from Luxonis. Don't have one? You can get them [here!](https://shop.luxonis.com/)
 
-You can find the newest documentation [here](https://docs-beta.luxonis.com/develop/ros/depthai-ros-intro/).
+You can find the newest documentation [here](https://docs-beta.luxonis.com/develop/ros/depthai-ros/intro/).

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -38,7 +38,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
     }
 
     if(enableImu) {
-        if(device->getConnectedIMU() == "NONE") {
+        if(device->getConnectedIMU() == "NONE" || device->getConnectedIMU().empty()){
             ROS_WARN("IMU enabled but not available!");
         } else {
             auto imu = std::make_unique<dai_nodes::Imu>("imu", node, pipeline, device);

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -38,7 +38,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
     }
 
     if(enableImu) {
-        if(device->getConnectedIMU() == "NONE" || device->getConnectedIMU().empty()){
+        if(device->getConnectedIMU() == "NONE" || device->getConnectedIMU().empty()) {
             ROS_WARN("IMU enabled but not available!");
         } else {
             auto imu = std::make_unique<dai_nodes::Imu>("imu", node, pipeline, device);


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/495
Issue description: It seems that `getConnectedIMU()` can return empty string now instead of NONE which can break driver for cameras without IMU.
Related PRs: N/A

## Changes
ROS distro: Noetic
List of changes: 
- Modify IMU checking method

## Testing
Hardware used: OAK-D-Lite (non IMU version)
Depthai library version: 2.23


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
