### PR TITLE
Tracking converter for ROS2 Humble

### DIFF
--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -72,6 +72,8 @@ file(GLOB LIB_SRC
 "src/ImuConverter.cpp"
 "src/TFPublisher.cpp"
 "src/TrackedFeaturesConverter.cpp"
+"src/TrackDetectionConverter.cpp"
+"src/TrackSpatialDetectionConverter.cpp"
 )
 
 add_library(${PROJECT_NAME} SHARED ${LIB_SRC})

--- a/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackDetectionConverter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+#include "rclcpp/time.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+
+namespace dai {
+
+namespace ros {
+
+class TrackDetectionConverter {
+   public:
+    TrackDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    ~TrackDetectionConverter();
+
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     *
+     */
+    void updateRosBaseTime();
+
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     *
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
+    void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs);
+
+    depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+
+   private:
+    int _width, _height;
+    const std::string _frameName;
+    bool _normalized;
+    float _thresh;
+    std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+    rclcpp::Time _rosBaseTime;
+    bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
+};
+
+}  // namespace ros
+
+namespace rosBridge = ros;
+
+}  // namespace dai

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+
+#include "depthai/pipeline/datatype/Tracklets.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+#include "rclcpp/time.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+
+namespace dai {
+
+namespace ros {
+
+class TrackSpatialDetectionConverter {
+   public:
+    TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    ~TrackSpatialDetectionConverter();
+
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     *
+     */
+    void updateRosBaseTime();
+
+    /**
+     * @brief Commands the converter to automatically update the ROS base time on message conversion based on variable
+     *
+     * @param update: bool whether to automatically update the ROS base time on message conversion
+     */
+    void setUpdateRosBaseTimeOnToRosMsg(bool update = true) {
+        _updateRosBaseTimeOnToRosMsg = update;
+    }
+
+    void toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs);
+
+    depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData);
+
+   private:
+    int _width, _height;
+    const std::string _frameName;
+    bool _normalized;
+    float _thresh;
+    std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
+    rclcpp::Time _rosBaseTime;
+    bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{0};
+    // Whether to update the ROS base time on each message conversion
+    bool _updateRosBaseTimeOnToRosMsg{false};
+};
+
+}  // namespace ros
+
+namespace rosBridge = ros;
+
+}  // namespace dai

--- a/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/TrackSpatialDetectionConverter.hpp
@@ -15,7 +15,8 @@ namespace ros {
 
 class TrackSpatialDetectionConverter {
    public:
-    TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
+    TrackSpatialDetectionConverter(
+        std::string frameName, int width, int height, bool normalized = false, float thresh = 0.0, bool getBaseDeviceTimestamp = false);
     ~TrackSpatialDetectionConverter();
 
     /**

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -1,0 +1,96 @@
+#include "depthai_bridge/TrackDetectionConverter.hpp"
+
+#include "depthai/depthai.hpp"
+#include "depthai_bridge/depthaiUtility.hpp"
+
+namespace dai {
+
+namespace ros {
+
+TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
+  : _frameName(frameName),
+    _width(width),
+    _height(height),
+    _normalized(normalized),
+    _thresh(thresh),
+    _steadyBaseTime(std::chrono::steady_clock::now()),
+    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+  _rosBaseTime = rclcpp::Clock().now();
+}
+
+TrackDetectionConverter::~TrackDetectionConverter() = default;
+
+void TrackDetectionConverter::updateRosBaseTime() {
+  updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
+}
+
+void TrackDetectionConverter::toRosMsg(
+  std::shared_ptr<dai::Tracklets> trackData, 
+  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
+  // setting the header
+  std::chrono::_V2::steady_clock::time_point tstamp;
+  if(_getBaseDeviceTimestamp)
+    tstamp = trackData->getTimestampDevice();
+  else
+    tstamp = trackData->getTimestamp();
+
+  depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
+  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+  opDetectionMsg.header.frame_id = _frameName;
+  opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+  // publishing
+  for(int i = 0; i < trackData->tracklets.size(); ++i) {
+    dai::Tracklet t = trackData->tracklets[i];
+    dai::Rect roi;
+    float xMin, yMin, xMax, yMax;
+
+    if(_normalized)
+      roi = t.roi;
+    else
+      roi = t.roi.denormalize(_width, _height);
+
+    xMin = roi.topLeft().x;
+    yMin = roi.topLeft().y;
+    xMax = roi.bottomRight().x;
+    yMax = roi.bottomRight().y;
+
+    float xSize = xMax - xMin;
+    float ySize = yMax - yMin;
+    float xCenter = xMin + xSize / 2.;
+    float yCenter = yMin + ySize / 2.;
+
+    opDetectionMsg.detections[i].results.resize(1);
+
+    opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
+    opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
+
+    opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+    opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+    opDetectionMsg.detections[i].bbox.size_x = xSize;
+    opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+    opDetectionMsg.detections[i].is_tracking = true;
+    std::stringstream track_id_str;
+    track_id_str << "" << t.id;
+    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+    opDetectionMsg.detections[i].tracking_age = t.age;
+    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+  }
+
+  opDetectionMsgs.push_back(opDetectionMsg);
+}
+
+depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr TrackDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
+  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
+  toRosMsg(trackData, msgQueue);
+  auto msg = msgQueue.front();
+
+  depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
+
+  return ptr;
+}
+
+}  // namespace ros
+
+}  // namespace dai

--- a/depthai_bridge/src/TrackDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackDetectionConverter.cpp
@@ -8,87 +8,85 @@ namespace dai {
 namespace ros {
 
 TrackDetectionConverter::TrackDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-  : _frameName(frameName),
-    _width(width),
-    _height(height),
-    _normalized(normalized),
-    _thresh(thresh),
-    _steadyBaseTime(std::chrono::steady_clock::now()),
-    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-  _rosBaseTime = rclcpp::Clock().now();
+    : _frameName(frameName),
+      _width(width),
+      _height(height),
+      _normalized(normalized),
+      _thresh(thresh),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+    _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackDetectionConverter::~TrackDetectionConverter() = default;
 
 void TrackDetectionConverter::updateRosBaseTime() {
-  updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
-void TrackDetectionConverter::toRosMsg(
-  std::shared_ptr<dai::Tracklets> trackData, 
-  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
-  // setting the header
-  std::chrono::_V2::steady_clock::time_point tstamp;
-  if(_getBaseDeviceTimestamp)
-    tstamp = trackData->getTimestampDevice();
-  else
-    tstamp = trackData->getTimestamp();
-
-  depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
-  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-  opDetectionMsg.header.frame_id = _frameName;
-  opDetectionMsg.detections.resize(trackData->tracklets.size());
-
-  // publishing
-  for(int i = 0; i < trackData->tracklets.size(); ++i) {
-    dai::Tracklet t = trackData->tracklets[i];
-    dai::Rect roi;
-    float xMin, yMin, xMax, yMax;
-
-    if(_normalized)
-      roi = t.roi;
+void TrackDetectionConverter::toRosMsg(std::shared_ptr<dai::Tracklets> trackData, std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
     else
-      roi = t.roi.denormalize(_width, _height);
+        tstamp = trackData->getTimestamp();
 
-    xMin = roi.topLeft().x;
-    yMin = roi.topLeft().y;
-    xMax = roi.bottomRight().x;
-    yMax = roi.bottomRight().y;
+    depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-    float xSize = xMax - xMin;
-    float ySize = yMax - yMin;
-    float xCenter = xMin + xSize / 2.;
-    float yCenter = yMin + ySize / 2.;
+    // publishing
+    for(int i = 0; i < trackData->tracklets.size(); ++i) {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-    opDetectionMsg.detections[i].results.resize(1);
+        if(_normalized)
+            roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-    opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
-    opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-    opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-    opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
-    opDetectionMsg.detections[i].bbox.size_x = xSize;
-    opDetectionMsg.detections[i].bbox.size_y = ySize;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-    opDetectionMsg.detections[i].is_tracking = true;
-    std::stringstream track_id_str;
-    track_id_str << "" << t.id;
-    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-    opDetectionMsg.detections[i].tracking_age = t.age;
-    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
-  }
+        opDetectionMsg.detections[i].results.resize(1);
 
-  opDetectionMsgs.push_back(opDetectionMsg);
+        opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
+
+        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr TrackDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
-  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
-  toRosMsg(trackData, msgQueue);
-  auto msg = msgQueue.front();
+    std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
 
-  depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
+    depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
 
-  return ptr;
+    return ptr;
 }
 
 }  // namespace ros

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -1,0 +1,101 @@
+#include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
+
+#include "depthai/depthai.hpp"
+#include "depthai_bridge/depthaiUtility.hpp"
+
+namespace dai {
+
+namespace ros {
+
+TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
+  : _frameName(frameName),
+    _width(width),
+    _height(height),
+    _normalized(normalized),
+    _thresh(thresh),
+    _steadyBaseTime(std::chrono::steady_clock::now()),
+    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+  _rosBaseTime = rclcpp::Clock().now();
+}
+
+TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
+
+void TrackSpatialDetectionConverter::updateRosBaseTime() {
+  updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
+}
+
+void TrackSpatialDetectionConverter::toRosMsg(
+  std::shared_ptr<dai::Tracklets> trackData, 
+  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
+  // setting the header
+  std::chrono::_V2::steady_clock::time_point tstamp;
+  if(_getBaseDeviceTimestamp)
+      tstamp = trackData->getTimestampDevice();
+  else
+      tstamp = trackData->getTimestamp();
+
+  depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
+  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+  opDetectionMsg.header.frame_id = _frameName;
+  opDetectionMsg.detections.resize(trackData->tracklets.size());
+
+  // publishing
+  for(int i = 0; i < trackData->tracklets.size(); ++i) {
+    dai::Tracklet t = trackData->tracklets[i];
+    dai::Rect roi;
+    float xMin, yMin, xMax, yMax;
+
+    if(_normalized)
+          roi = t.roi;
+    else
+        roi = t.roi.denormalize(_width, _height);
+
+    xMin = roi.topLeft().x;
+    yMin = roi.topLeft().y;
+    xMax = roi.bottomRight().x;
+    yMax = roi.bottomRight().y;
+
+    float xSize = xMax - xMin;
+    float ySize = yMax - yMin;
+    float xCenter = xMin + xSize / 2.;
+    float yCenter = yMin + ySize / 2.;
+
+    opDetectionMsg.detections[i].results.resize(1);
+
+    opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
+    opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
+
+    opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+    opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+    opDetectionMsg.detections[i].bbox.size_x = xSize;
+    opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+    opDetectionMsg.detections[i].is_tracking = true;
+    std::stringstream track_id_str;
+    track_id_str << "" << t.id;
+    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+    opDetectionMsg.detections[i].tracking_age = t.age;
+    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+
+    // converting mm to meters since per ros rep-103 lenght should always be in meters
+    opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+    opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+  }
+
+  opDetectionMsgs.push_back(opDetectionMsg);
+}
+
+depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr TrackSpatialDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
+  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
+  toRosMsg(trackData, msgQueue);
+  auto msg = msgQueue.front();
+
+  depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
+
+  return ptr;
+}
+
+}  // namespace ros
+
+}  // namespace dai

--- a/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/TrackSpatialDetectionConverter.cpp
@@ -7,93 +7,93 @@ namespace dai {
 
 namespace ros {
 
-TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
-  : _frameName(frameName),
-    _width(width),
-    _height(height),
-    _normalized(normalized),
-    _thresh(thresh),
-    _steadyBaseTime(std::chrono::steady_clock::now()),
-    _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
-  _rosBaseTime = rclcpp::Clock().now();
+TrackSpatialDetectionConverter::TrackSpatialDetectionConverter(
+    std::string frameName, int width, int height, bool normalized, float thresh, bool getBaseDeviceTimestamp)
+    : _frameName(frameName),
+      _width(width),
+      _height(height),
+      _normalized(normalized),
+      _thresh(thresh),
+      _steadyBaseTime(std::chrono::steady_clock::now()),
+      _getBaseDeviceTimestamp(getBaseDeviceTimestamp) {
+    _rosBaseTime = rclcpp::Clock().now();
 }
 
 TrackSpatialDetectionConverter::~TrackSpatialDetectionConverter() = default;
 
 void TrackSpatialDetectionConverter::updateRosBaseTime() {
-  updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
+    updateBaseTime(_steadyBaseTime, _rosBaseTime, _totalNsChange);
 }
 
-void TrackSpatialDetectionConverter::toRosMsg(
-  std::shared_ptr<dai::Tracklets> trackData, 
-  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
-  // setting the header
-  std::chrono::_V2::steady_clock::time_point tstamp;
-  if(_getBaseDeviceTimestamp)
-      tstamp = trackData->getTimestampDevice();
-  else
-      tstamp = trackData->getTimestamp();
-
-  depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
-  opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
-  opDetectionMsg.header.frame_id = _frameName;
-  opDetectionMsg.detections.resize(trackData->tracklets.size());
-
-  // publishing
-  for(int i = 0; i < trackData->tracklets.size(); ++i) {
-    dai::Tracklet t = trackData->tracklets[i];
-    dai::Rect roi;
-    float xMin, yMin, xMax, yMax;
-
-    if(_normalized)
-          roi = t.roi;
+void TrackSpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::Tracklets> trackData,
+                                              std::deque<depthai_ros_msgs::msg::TrackDetection2DArray>& opDetectionMsgs) {
+    // setting the header
+    std::chrono::_V2::steady_clock::time_point tstamp;
+    if(_getBaseDeviceTimestamp)
+        tstamp = trackData->getTimestampDevice();
     else
-        roi = t.roi.denormalize(_width, _height);
+        tstamp = trackData->getTimestamp();
 
-    xMin = roi.topLeft().x;
-    yMin = roi.topLeft().y;
-    xMax = roi.bottomRight().x;
-    yMax = roi.bottomRight().y;
+    depthai_ros_msgs::msg::TrackDetection2DArray opDetectionMsg;
+    opDetectionMsg.header.stamp = getFrameTime(_rosBaseTime, _steadyBaseTime, tstamp);
+    opDetectionMsg.header.frame_id = _frameName;
+    opDetectionMsg.detections.resize(trackData->tracklets.size());
 
-    float xSize = xMax - xMin;
-    float ySize = yMax - yMin;
-    float xCenter = xMin + xSize / 2.;
-    float yCenter = yMin + ySize / 2.;
+    // publishing
+    for(int i = 0; i < trackData->tracklets.size(); ++i) {
+        dai::Tracklet t = trackData->tracklets[i];
+        dai::Rect roi;
+        float xMin, yMin, xMax, yMax;
 
-    opDetectionMsg.detections[i].results.resize(1);
+        if(_normalized)
+            roi = t.roi;
+        else
+            roi = t.roi.denormalize(_width, _height);
 
-    opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
-    opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
+        xMin = roi.topLeft().x;
+        yMin = roi.topLeft().y;
+        xMax = roi.bottomRight().x;
+        yMax = roi.bottomRight().y;
 
-    opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
-    opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
-    opDetectionMsg.detections[i].bbox.size_x = xSize;
-    opDetectionMsg.detections[i].bbox.size_y = ySize;
+        float xSize = xMax - xMin;
+        float ySize = yMax - yMin;
+        float xCenter = xMin + xSize / 2.;
+        float yCenter = yMin + ySize / 2.;
 
-    opDetectionMsg.detections[i].is_tracking = true;
-    std::stringstream track_id_str;
-    track_id_str << "" << t.id;
-    opDetectionMsg.detections[i].tracking_id = track_id_str.str();
-    opDetectionMsg.detections[i].tracking_age = t.age;
-    opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+        opDetectionMsg.detections[i].results.resize(1);
 
-    // converting mm to meters since per ros rep-103 lenght should always be in meters
-    opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
-    opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
-  }
+        opDetectionMsg.detections[i].results[0].hypothesis.class_id = std::to_string(t.label);
+        opDetectionMsg.detections[i].results[0].hypothesis.score = _thresh;
 
-  opDetectionMsgs.push_back(opDetectionMsg);
+        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+        opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
+        opDetectionMsg.detections[i].bbox.size_x = xSize;
+        opDetectionMsg.detections[i].bbox.size_y = ySize;
+
+        opDetectionMsg.detections[i].is_tracking = true;
+        std::stringstream track_id_str;
+        track_id_str << "" << t.id;
+        opDetectionMsg.detections[i].tracking_id = track_id_str.str();
+        opDetectionMsg.detections[i].tracking_age = t.age;
+        opDetectionMsg.detections[i].tracking_status = static_cast<int32_t>(t.status);
+
+        // converting mm to meters since per ros rep-103 lenght should always be in meters
+        opDetectionMsg.detections[i].results[0].pose.pose.position.x = t.spatialCoordinates.x / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.y = t.spatialCoordinates.y / 1000.0;
+        opDetectionMsg.detections[i].results[0].pose.pose.position.z = t.spatialCoordinates.z / 1000.0;
+    }
+
+    opDetectionMsgs.push_back(opDetectionMsg);
 }
 
 depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr TrackSpatialDetectionConverter::toRosMsgPtr(std::shared_ptr<dai::Tracklets> trackData) {
-  std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
-  toRosMsg(trackData, msgQueue);
-  auto msg = msgQueue.front();
+    std::deque<depthai_ros_msgs::msg::TrackDetection2DArray> msgQueue;
+    toRosMsg(trackData, msgQueue);
+    auto msg = msgQueue.front();
 
-  depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
+    depthai_ros_msgs::msg::TrackDetection2DArray::SharedPtr ptr = std::make_shared<depthai_ros_msgs::msg::TrackDetection2DArray>(msg);
 
-  return ptr;
+    return ptr;
 }
 
 }  // namespace ros

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -102,11 +102,15 @@ dai_add_node_ros2(feature_tracker src/feature_tracker_publisher.cpp)
 dai_add_node_ros2(stereo_node src/stereo_publisher.cpp)
 dai_add_node_ros2(yolov4_spatial_node src/yolov4_spatial_publisher.cpp)
 dai_add_node_ros2(yolov4_node src/yolov4_publisher.cpp)
+dai_add_node_ros2(tracker_yolov4_node src/tracker_yolov4_publisher.cpp)
+dai_add_node_ros2(tracker_yolov4_spatial_node src/tracker_yolov4_spatial_publisher.cpp)
 
 target_compile_definitions(mobilenet_node PRIVATE BLOB_NAME="${mobilenet_blob_name}")
 target_compile_definitions(yolov4_spatial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
 target_compile_definitions(yolov4_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
 target_compile_definitions(stereo_inertial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
+target_compile_definitions(tracker_yolov4_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
+target_compile_definitions(tracker_yolov4_spatial_node PRIVATE BLOB_NAME="${tiny_yolo_v4_blob_name}")
 
 if($ENV{ROS_DISTRO} STREQUAL "galactic")
   target_compile_definitions(rgb_stereo_node PRIVATE IS_GALACTIC)
@@ -128,6 +132,8 @@ install(TARGETS
         yolov4_spatial_node
         yolov4_node
         feature_tracker
+				tracker_yolov4_node
+				tracker_yolov4_spatial_node
         DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -132,8 +132,8 @@ install(TARGETS
         yolov4_spatial_node
         yolov4_node
         feature_tracker
-				tracker_yolov4_node
-				tracker_yolov4_spatial_node
+        tracker_yolov4_node
+        tracker_yolov4_spatial_node
         DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/depthai_examples/launch/tracker_yolov4_node.launch.py
+++ b/depthai_examples/launch/tracker_yolov4_node.launch.py
@@ -1,0 +1,159 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, launch_description_sources
+from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+import launch_ros.actions
+import launch_ros.descriptions
+
+
+def generate_launch_description():
+    depthai_examples_path = get_package_share_directory('depthai_examples')
+
+    default_rviz = os.path.join(depthai_examples_path,
+                                'rviz', 'pointCloud.rviz')
+    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
+    default_resources_path = os.path.join(depthai_examples_path,
+                                'resources')
+    print('Default resources path..............')
+    print(default_resources_path)
+    camera_model = LaunchConfiguration('camera_model',  default = 'OAK-D')
+    tf_prefix    = LaunchConfiguration('tf_prefix',     default = 'oak')
+    base_frame   = LaunchConfiguration('base_frame',    default = 'oak-d_frame')
+    parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
+
+    cam_pos_x = LaunchConfiguration('cam_pos_x',     default = '0.0')
+    cam_pos_y = LaunchConfiguration('cam_pos_y',     default = '0.0')
+    cam_pos_z = LaunchConfiguration('cam_pos_z',     default = '0.0')
+    cam_roll  = LaunchConfiguration('cam_roll',      default = '0.0')
+    cam_pitch = LaunchConfiguration('cam_pitch',     default = '0.0')
+    cam_yaw   = LaunchConfiguration('cam_yaw',       default = '0.0')
+
+    camera_param_uri   = LaunchConfiguration('camera_param_uri',  default = 'package://depthai_examples/params/camera')
+    nnName             = LaunchConfiguration('nnName', default = "x")
+    resourceBaseFolder = LaunchConfiguration('resourceBaseFolder', default = default_resources_path)
+    fullFrameTracking  = LaunchConfiguration('fullFrameTracking',  default = False)
+
+    declare_camera_model_cmd = DeclareLaunchArgument(
+        'camera_model',
+        default_value=camera_model,
+        description='The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.')
+
+    declare_tf_prefix_cmd = DeclareLaunchArgument(
+        'tf_prefix',
+        default_value=tf_prefix,
+        description='The name of the camera. It can be different from the camera model and it will be used in naming TF.')
+
+    declare_base_frame_cmd = DeclareLaunchArgument(
+        'base_frame',
+        default_value=base_frame,
+        description='Name of the base link.')
+
+    declare_parent_frame_cmd = DeclareLaunchArgument(
+        'parent_frame',
+        default_value=parent_frame,
+        description='Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.')
+
+    declare_pos_x_cmd = DeclareLaunchArgument(
+        'cam_pos_x',
+        default_value=cam_pos_x,
+        description='Position X of the camera with respect to the base frame.')
+
+    declare_pos_y_cmd = DeclareLaunchArgument(
+        'cam_pos_y',
+        default_value=cam_pos_y,
+        description='Position Y of the camera with respect to the base frame.')
+
+    declare_pos_z_cmd = DeclareLaunchArgument(
+        'cam_pos_z',
+        default_value=cam_pos_z,
+        description='Position Z of the camera with respect to the base frame.')
+
+    declare_roll_cmd = DeclareLaunchArgument(
+        'cam_roll',
+        default_value=cam_roll,
+        description='Roll orientation of the camera with respect to the base frame.')
+
+    declare_pitch_cmd = DeclareLaunchArgument(
+        'cam_pitch',
+        default_value=cam_pitch,
+        description='Pitch orientation of the camera with respect to the base frame.')
+
+    declare_yaw_cmd = DeclareLaunchArgument(
+        'cam_yaw',
+        default_value=cam_yaw,
+        description='Yaw orientation of the camera with respect to the base frame.')
+
+    declare_camera_param_uri_cmd = DeclareLaunchArgument(
+        'camera_param_uri',
+        default_value=camera_param_uri,
+        description='Sending camera yaml path')
+
+    declare_nnName_cmd = DeclareLaunchArgument(
+        'nnName',
+        default_value=nnName,
+        description='Path to the object detection blob needed for detection')
+
+    declare_resourceBaseFolder_cmd = DeclareLaunchArgument(
+        'resourceBaseFolder',
+        default_value=resourceBaseFolder,
+        description='Path to the resources folder which contains the default blobs for the network')
+
+    declare_fullFrameTracking_cmd = DeclareLaunchArgument(
+        'fullFrameTracking',
+        default_value=fullFrameTracking,
+        description='Set to true for tracking in entire frame')
+
+    urdf_launch = IncludeLaunchDescription(
+                            launch_description_sources.PythonLaunchDescriptionSource(
+                                    os.path.join(urdf_launch_dir, 'urdf_launch.py')),
+                            launch_arguments={'tf_prefix'   : tf_prefix,
+                                              'camera_model': camera_model,
+                                              'base_frame'  : base_frame,
+                                              'parent_frame': parent_frame,
+                                              'cam_pos_x'   : cam_pos_x,
+                                              'cam_pos_y'   : cam_pos_y,
+                                              'cam_pos_z'   : cam_pos_z,
+                                              'cam_roll'    : cam_roll,
+                                              'cam_pitch'   : cam_pitch,
+                                              'cam_yaw'     : cam_yaw}.items())
+
+    tracker_yolov4_node = launch_ros.actions.Node(
+            package='depthai_examples', executable='tracker_yolov4_node',
+            output='screen',
+            parameters=[{'tf_prefix': tf_prefix},
+                        {'camera_param_uri': camera_param_uri},
+                        {'nnName': nnName},
+                        {'resourceBaseFolder': resourceBaseFolder},
+												{'fullFrameTracking': fullFrameTracking}])
+
+    rviz_node = launch_ros.actions.Node(
+            package='rviz2', executable='rviz2', output='screen',
+            arguments=['--display-config', default_rviz])
+
+    ld = LaunchDescription()
+    ld.add_action(declare_tf_prefix_cmd)
+    ld.add_action(declare_camera_model_cmd)
+
+    ld.add_action(declare_base_frame_cmd)
+    ld.add_action(declare_parent_frame_cmd)
+
+    ld.add_action(declare_pos_x_cmd)
+    ld.add_action(declare_pos_y_cmd)
+    ld.add_action(declare_pos_z_cmd)
+    ld.add_action(declare_roll_cmd)
+    ld.add_action(declare_pitch_cmd)
+    ld.add_action(declare_yaw_cmd)
+
+    ld.add_action(declare_camera_param_uri_cmd)
+    ld.add_action(declare_nnName_cmd)
+    ld.add_action(declare_resourceBaseFolder_cmd)
+    ld.add_action(declare_fullFrameTracking_cmd)
+
+    ld.add_action(tracker_yolov4_node)
+    #ld.add_action(urdf_launch)
+
+    return ld
+

--- a/depthai_examples/launch/tracker_yolov4_spatial_node.launch.py
+++ b/depthai_examples/launch/tracker_yolov4_spatial_node.launch.py
@@ -1,0 +1,196 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription, launch_description_sources
+from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+import launch_ros.actions
+import launch_ros.descriptions
+
+
+def generate_launch_description():
+    depthai_examples_path = get_package_share_directory('depthai_examples')
+
+    default_rviz = os.path.join(depthai_examples_path,
+                                'rviz', 'pointCloud.rviz')
+    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
+    default_resources_path = os.path.join(depthai_examples_path,
+                                'resources')
+    print('Default resources path..............')
+    print(default_resources_path)
+    camera_model = LaunchConfiguration('camera_model',  default = 'OAK-D')
+    tf_prefix    = LaunchConfiguration('tf_prefix',     default = 'oak')
+    base_frame   = LaunchConfiguration('base_frame',    default = 'oak-d_frame')
+    parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
+
+    cam_pos_x = LaunchConfiguration('cam_pos_x',     default = '0.0')
+    cam_pos_y = LaunchConfiguration('cam_pos_y',     default = '0.0')
+    cam_pos_z = LaunchConfiguration('cam_pos_z',     default = '0.0')
+    cam_roll  = LaunchConfiguration('cam_roll',      default = '0.0')
+    cam_pitch = LaunchConfiguration('cam_pitch',     default = '0.0')
+    cam_yaw   = LaunchConfiguration('cam_yaw',       default = '0.0')
+
+    camera_param_uri   = LaunchConfiguration('camera_param_uri',  default = 'package://depthai_examples/params/camera')
+    sync_nn            = LaunchConfiguration('sync_nn',           default = True)
+    subpixel           = LaunchConfiguration('subpixel',          default = True)
+    nnName             = LaunchConfiguration('nnName', default = "x")
+    resourceBaseFolder = LaunchConfiguration('resourceBaseFolder', default = default_resources_path)
+    confidence         = LaunchConfiguration('confidence',         default = 200)
+    lrCheckTresh       = LaunchConfiguration('lrCheckTresh',       default = 5)
+    monoResolution     = LaunchConfiguration('monoResolution',     default = '400p')
+    fullFrameTracking  = LaunchConfiguration('fullFrameTracking',  default = False)
+
+    declare_camera_model_cmd = DeclareLaunchArgument(
+        'camera_model',
+        default_value=camera_model,
+        description='The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.')
+
+    declare_tf_prefix_cmd = DeclareLaunchArgument(
+        'tf_prefix',
+        default_value=tf_prefix,
+        description='The name of the camera. It can be different from the camera model and it will be used in naming TF.')
+
+    declare_base_frame_cmd = DeclareLaunchArgument(
+        'base_frame',
+        default_value=base_frame,
+        description='Name of the base link.')
+
+    declare_parent_frame_cmd = DeclareLaunchArgument(
+        'parent_frame',
+        default_value=parent_frame,
+        description='Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.')
+
+    declare_pos_x_cmd = DeclareLaunchArgument(
+        'cam_pos_x',
+        default_value=cam_pos_x,
+        description='Position X of the camera with respect to the base frame.')
+
+    declare_pos_y_cmd = DeclareLaunchArgument(
+        'cam_pos_y',
+        default_value=cam_pos_y,
+        description='Position Y of the camera with respect to the base frame.')
+
+    declare_pos_z_cmd = DeclareLaunchArgument(
+        'cam_pos_z',
+        default_value=cam_pos_z,
+        description='Position Z of the camera with respect to the base frame.')
+
+    declare_roll_cmd = DeclareLaunchArgument(
+        'cam_roll',
+        default_value=cam_roll,
+        description='Roll orientation of the camera with respect to the base frame.')
+
+    declare_pitch_cmd = DeclareLaunchArgument(
+        'cam_pitch',
+        default_value=cam_pitch,
+        description='Pitch orientation of the camera with respect to the base frame.')
+
+    declare_yaw_cmd = DeclareLaunchArgument(
+        'cam_yaw',
+        default_value=cam_yaw,
+        description='Yaw orientation of the camera with respect to the base frame.')
+
+    declare_camera_param_uri_cmd = DeclareLaunchArgument(
+        'camera_param_uri',
+        default_value=camera_param_uri,
+        description='Sending camera yaml path')
+
+    declare_sync_nn_cmd = DeclareLaunchArgument(
+        'sync_nn',
+        default_value=sync_nn,
+        description='Syncs the image output with the Detection.')
+
+    declare_subpixel_cmd = DeclareLaunchArgument(
+        'subpixel',
+        default_value=subpixel,
+        description='Enables subpixel stereo detection.')
+
+    declare_nnName_cmd = DeclareLaunchArgument(
+        'nnName',
+        default_value=nnName,
+        description='Path to the object detection blob needed for detection')
+
+    declare_resourceBaseFolder_cmd = DeclareLaunchArgument(
+        'resourceBaseFolder',
+        default_value=resourceBaseFolder,
+        description='Path to the resources folder which contains the default blobs for the network')
+
+    declare_confidence_cmd = DeclareLaunchArgument(
+        'confidence',
+        default_value=confidence,
+        description='Confidence that the disparity from the feature matching was good. 0-255. 255 being the lowest confidence.')
+
+    declare_lrCheckTresh_cmd = DeclareLaunchArgument(
+        'lrCheckTresh',
+        default_value=lrCheckTresh,
+        description='LR Threshold is the threshod of how much off the disparity on the l->r and r->l  ')
+
+    declare_monoResolution_cmd = DeclareLaunchArgument(
+        'monoResolution',
+        default_value=monoResolution,
+        description='Contains the resolution of the Mono Cameras. Available resolutions are 800p, 720p & 400p for OAK-D & 480p for OAK-D-Lite.')
+
+    declare_fullFrameTracking_cmd = DeclareLaunchArgument(
+        'fullFrameTracking',
+        default_value=fullFrameTracking,
+        description='Set to true for tracking in entire frame')
+
+    urdf_launch = IncludeLaunchDescription(
+                            launch_description_sources.PythonLaunchDescriptionSource(
+                                    os.path.join(urdf_launch_dir, 'urdf_launch.py')),
+                            launch_arguments={'tf_prefix'   : tf_prefix,
+                                              'camera_model': camera_model,
+                                              'base_frame'  : base_frame,
+                                              'parent_frame': parent_frame,
+                                              'cam_pos_x'   : cam_pos_x,
+                                              'cam_pos_y'   : cam_pos_y,
+                                              'cam_pos_z'   : cam_pos_z,
+                                              'cam_roll'    : cam_roll,
+                                              'cam_pitch'   : cam_pitch,
+                                              'cam_yaw'     : cam_yaw}.items())
+
+    tracker_yolov4_spatial_node = launch_ros.actions.Node(
+            package='depthai_examples', executable='tracker_yolov4_spatial_node',
+            output='screen',
+            parameters=[{'tf_prefix': tf_prefix},
+                        {'camera_param_uri': camera_param_uri},
+                        {'sync_nn': sync_nn},
+                        {'nnName': nnName},
+                        {'resourceBaseFolder': resourceBaseFolder},
+                        {'monoResolution': monoResolution},
+												{'fullFrameTracking': fullFrameTracking}])
+
+    rviz_node = launch_ros.actions.Node(
+            package='rviz2', executable='rviz2', output='screen',
+            arguments=['--display-config', default_rviz])
+
+    ld = LaunchDescription()
+    ld.add_action(declare_tf_prefix_cmd)
+    ld.add_action(declare_camera_model_cmd)
+
+    ld.add_action(declare_base_frame_cmd)
+    ld.add_action(declare_parent_frame_cmd)
+
+    ld.add_action(declare_pos_x_cmd)
+    ld.add_action(declare_pos_y_cmd)
+    ld.add_action(declare_pos_z_cmd)
+    ld.add_action(declare_roll_cmd)
+    ld.add_action(declare_pitch_cmd)
+    ld.add_action(declare_yaw_cmd)
+
+    ld.add_action(declare_camera_param_uri_cmd)
+    ld.add_action(declare_sync_nn_cmd)
+    ld.add_action(declare_subpixel_cmd)
+    ld.add_action(declare_nnName_cmd)
+    ld.add_action(declare_resourceBaseFolder_cmd)
+    ld.add_action(declare_confidence_cmd)
+    ld.add_action(declare_lrCheckTresh_cmd)
+    ld.add_action(declare_monoResolution_cmd)
+    ld.add_action(declare_fullFrameTracking_cmd)
+
+    ld.add_action(tracker_yolov4_spatial_node)
+    #ld.add_action(urdf_launch)
+
+    return ld
+

--- a/depthai_examples/src/tracker_yolov4_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_publisher.cpp
@@ -1,0 +1,173 @@
+#include <cstdio>
+#include <iostream>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "camera_info_manager/camera_info_manager.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+
+#include "depthai_bridge/BridgePublisher.hpp"
+#include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_bridge/TrackDetectionConverter.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/device/DataQueue.hpp"
+#include "depthai/device/Device.hpp"
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/node/ColorCamera.hpp"
+#include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
+#include "depthai/pipeline/node/StereoDepth.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
+
+const std::vector<std::string> label_map = {
+  "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+  "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+  "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+  "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+  "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+  "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+  "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+  "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+  "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+
+dai::Pipeline createPipeline(std::string nnPath, bool fullFrameTracking) {
+  dai::Pipeline pipeline;
+  auto colorCam = pipeline.create<dai::node::ColorCamera>();
+  auto detectionNetwork = pipeline.create<dai::node::YoloDetectionNetwork>();
+  auto tracker = pipeline.create<dai::node::ObjectTracker>();
+
+  // create xlink connections
+  auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+  auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+
+  xoutRgb->setStreamName("preview");
+  xoutTracker->setStreamName("tracklets");
+
+  colorCam->setPreviewSize(416, 416);
+  colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+  colorCam->setInterleaved(false);
+  colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+
+  // setting node configs
+  detectionNetwork->setBlobPath(nnPath);
+  detectionNetwork->setConfidenceThreshold(0.3f);
+  detectionNetwork->input.setBlocking(false);
+
+  // yolo specific parameters
+  detectionNetwork->setNumClasses(80);
+  detectionNetwork->setCoordinateSize(4);
+  detectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+  detectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+  detectionNetwork->setIouThreshold(0.5f);
+
+  // object tracker settings
+  tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+  tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+
+  // Link plugins CAM -> NN -> XLINK
+  colorCam->preview.link(detectionNetwork->input);
+  tracker->passthroughTrackerFrame.link(xoutRgb->input);
+
+  if (fullFrameTracking)
+  {
+    colorCam->setPreviewKeepAspectRatio(false);
+    colorCam->video.link(tracker->inputTrackerFrame);
+    //tracker->inputTrackerFrame.setBlocking(false);
+    // do not block the pipeline if it's too slow on full frame
+    //tracker->inputTrackerFrame.setQueueSize(2);
+  }
+  else
+  {
+    detectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+  }
+
+  detectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+  detectionNetwork->out.link(tracker->inputDetections);
+  tracker->out.link(xoutTracker->input);
+
+  return pipeline;
+}
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("tracker_yolov4_node");
+
+  std::string tfPrefix, resourceBaseFolder, nnPath;
+  std::string camera_param_uri;
+  bool fullFrameTracking;
+  std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+
+  node->declare_parameter("tf_prefix", "oak");
+  node->declare_parameter("camera_param_uri", camera_param_uri);
+  node->declare_parameter("nnName", "");
+  node->declare_parameter("resourceBaseFolder", "");
+  node->declare_parameter("fullFrameTracking", false);
+
+  node->get_parameter("tf_prefix", tfPrefix);
+  node->get_parameter("camera_param_uri", camera_param_uri);
+  node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+  node->get_parameter("fullFrameTracking", fullFrameTracking);
+
+  if(resourceBaseFolder.empty()) {
+    throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+  }
+
+  std::string nnParam;
+  node->get_parameter("nnName", nnParam);
+  if(nnParam != "x") {
+    node->get_parameter("nnName", nnName);
+  }
+
+  nnPath = resourceBaseFolder + "/" + nnName;
+  dai::Pipeline pipeline = createPipeline(nnPath, fullFrameTracking);
+  dai::Device device(pipeline);
+
+  auto colorQueue = device.getOutputQueue("preview", 30, false);
+  auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+  auto calibrationHandler = device.readCalibration();
+
+  int width, height;
+  auto boardName = calibrationHandler.getEepromData().boardName;
+  if(height > 480 && boardName == "OAK-D-LITE") {
+    width = 640;
+    height = 480;
+  }
+
+  dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+  auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
+  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(
+    colorQueue,
+    node,
+    std::string("color/image"),
+    std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+              &rgbConverter,  // since the converter has the same frame name
+                              // and image type is also same we can reuse it
+              std::placeholders::_1,
+              std::placeholders::_2),
+    30,
+    rgbCameraInfo,
+    "color");
+
+  dai::rosBridge::TrackDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
+  dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+    trackQueue,
+    node,
+    std::string("color/yolov4_tracklets"),
+    std::bind(&dai::rosBridge::TrackDetectionConverter::toRosMsg,
+              &trackConverter,
+              std::placeholders::_1,
+              std::placeholders::_2),
+    30);
+
+  rgbPublish.addPublisherCallback();
+  trackPublish.addPublisherCallback();
+
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/depthai_examples/src/tracker_yolov4_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_publisher.cpp
@@ -1,17 +1,16 @@
 #include <cstdio>
 #include <iostream>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/executors.hpp"
-#include "sensor_msgs/msg/image.hpp"
 #include "camera_info_manager/camera_info_manager.hpp"
-#include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
-
 #include "depthai_bridge/BridgePublisher.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_bridge/TrackDetectionConverter.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+#include "rclcpp/executors.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 
 // Inludes common necessary includes for development using depthai library
 #include "depthai/device/DataQueue.hpp"
@@ -19,155 +18,148 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/ColorCamera.hpp"
 #include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai/pipeline/node/StereoDepth.hpp"
-#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
 
 const std::vector<std::string> label_map = {
-  "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
-  "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
-  "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
-  "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
-  "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
-  "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
-  "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
-  "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
-  "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+    "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+    "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+    "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+    "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+    "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+    "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+    "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+    "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+    "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
 
 dai::Pipeline createPipeline(std::string nnPath, bool fullFrameTracking) {
-  dai::Pipeline pipeline;
-  auto colorCam = pipeline.create<dai::node::ColorCamera>();
-  auto detectionNetwork = pipeline.create<dai::node::YoloDetectionNetwork>();
-  auto tracker = pipeline.create<dai::node::ObjectTracker>();
+    dai::Pipeline pipeline;
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto detectionNetwork = pipeline.create<dai::node::YoloDetectionNetwork>();
+    auto tracker = pipeline.create<dai::node::ObjectTracker>();
 
-  // create xlink connections
-  auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
-  auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+    // create xlink connections
+    auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+    auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
 
-  xoutRgb->setStreamName("preview");
-  xoutTracker->setStreamName("tracklets");
+    xoutRgb->setStreamName("preview");
+    xoutTracker->setStreamName("tracklets");
 
-  colorCam->setPreviewSize(416, 416);
-  colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-  colorCam->setInterleaved(false);
-  colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+    colorCam->setPreviewSize(416, 416);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
-  // setting node configs
-  detectionNetwork->setBlobPath(nnPath);
-  detectionNetwork->setConfidenceThreshold(0.3f);
-  detectionNetwork->input.setBlocking(false);
+    // setting node configs
+    detectionNetwork->setBlobPath(nnPath);
+    detectionNetwork->setConfidenceThreshold(0.3f);
+    detectionNetwork->input.setBlocking(false);
 
-  // yolo specific parameters
-  detectionNetwork->setNumClasses(80);
-  detectionNetwork->setCoordinateSize(4);
-  detectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
-  detectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
-  detectionNetwork->setIouThreshold(0.5f);
+    // yolo specific parameters
+    detectionNetwork->setNumClasses(80);
+    detectionNetwork->setCoordinateSize(4);
+    detectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+    detectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+    detectionNetwork->setIouThreshold(0.5f);
 
-  // object tracker settings
-  tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
-  tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+    // object tracker settings
+    tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+    tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
 
-  // Link plugins CAM -> NN -> XLINK
-  colorCam->preview.link(detectionNetwork->input);
-  tracker->passthroughTrackerFrame.link(xoutRgb->input);
+    // Link plugins CAM -> NN -> XLINK
+    colorCam->preview.link(detectionNetwork->input);
+    tracker->passthroughTrackerFrame.link(xoutRgb->input);
 
-  if (fullFrameTracking)
-  {
-    colorCam->setPreviewKeepAspectRatio(false);
-    colorCam->video.link(tracker->inputTrackerFrame);
-    //tracker->inputTrackerFrame.setBlocking(false);
-    // do not block the pipeline if it's too slow on full frame
-    //tracker->inputTrackerFrame.setQueueSize(2);
-  }
-  else
-  {
-    detectionNetwork->passthrough.link(tracker->inputTrackerFrame);
-  }
+    if(fullFrameTracking) {
+        colorCam->setPreviewKeepAspectRatio(false);
+        colorCam->video.link(tracker->inputTrackerFrame);
+        // tracker->inputTrackerFrame.setBlocking(false);
+        //  do not block the pipeline if it's too slow on full frame
+        // tracker->inputTrackerFrame.setQueueSize(2);
+    } else {
+        detectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+    }
 
-  detectionNetwork->passthrough.link(tracker->inputDetectionFrame);
-  detectionNetwork->out.link(tracker->inputDetections);
-  tracker->out.link(xoutTracker->input);
+    detectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+    detectionNetwork->out.link(tracker->inputDetections);
+    tracker->out.link(xoutTracker->input);
 
-  return pipeline;
+    return pipeline;
 }
 
 int main(int argc, char** argv) {
-  rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("tracker_yolov4_node");
+    rclcpp::init(argc, argv);
+    auto node = rclcpp::Node::make_shared("tracker_yolov4_node");
 
-  std::string tfPrefix, resourceBaseFolder, nnPath;
-  std::string camera_param_uri;
-  bool fullFrameTracking;
-  std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+    std::string tfPrefix, resourceBaseFolder, nnPath;
+    std::string camera_param_uri;
+    bool fullFrameTracking;
+    std::string nnName(BLOB_NAME);  // Set your blob name for the model here
 
-  node->declare_parameter("tf_prefix", "oak");
-  node->declare_parameter("camera_param_uri", camera_param_uri);
-  node->declare_parameter("nnName", "");
-  node->declare_parameter("resourceBaseFolder", "");
-  node->declare_parameter("fullFrameTracking", false);
+    node->declare_parameter("tf_prefix", "oak");
+    node->declare_parameter("camera_param_uri", camera_param_uri);
+    node->declare_parameter("nnName", "");
+    node->declare_parameter("resourceBaseFolder", "");
+    node->declare_parameter("fullFrameTracking", false);
 
-  node->get_parameter("tf_prefix", tfPrefix);
-  node->get_parameter("camera_param_uri", camera_param_uri);
-  node->get_parameter("resourceBaseFolder", resourceBaseFolder);
-  node->get_parameter("fullFrameTracking", fullFrameTracking);
+    node->get_parameter("tf_prefix", tfPrefix);
+    node->get_parameter("camera_param_uri", camera_param_uri);
+    node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+    node->get_parameter("fullFrameTracking", fullFrameTracking);
 
-  if(resourceBaseFolder.empty()) {
-    throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
-  }
+    if(resourceBaseFolder.empty()) {
+        throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+    }
 
-  std::string nnParam;
-  node->get_parameter("nnName", nnParam);
-  if(nnParam != "x") {
-    node->get_parameter("nnName", nnName);
-  }
+    std::string nnParam;
+    node->get_parameter("nnName", nnParam);
+    if(nnParam != "x") {
+        node->get_parameter("nnName", nnName);
+    }
 
-  nnPath = resourceBaseFolder + "/" + nnName;
-  dai::Pipeline pipeline = createPipeline(nnPath, fullFrameTracking);
-  dai::Device device(pipeline);
+    nnPath = resourceBaseFolder + "/" + nnName;
+    dai::Pipeline pipeline = createPipeline(nnPath, fullFrameTracking);
+    dai::Device device(pipeline);
 
-  auto colorQueue = device.getOutputQueue("preview", 30, false);
-  auto trackQueue = device.getOutputQueue("tracklets", 30, false);
-  auto calibrationHandler = device.readCalibration();
+    auto colorQueue = device.getOutputQueue("preview", 30, false);
+    auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+    auto calibrationHandler = device.readCalibration();
 
-  int width, height;
-  auto boardName = calibrationHandler.getEepromData().boardName;
-  if(height > 480 && boardName == "OAK-D-LITE") {
-    width = 640;
-    height = 480;
-  }
+    int width, height;
+    auto boardName = calibrationHandler.getEepromData().boardName;
+    if(height > 480 && boardName == "OAK-D-LITE") {
+        width = 640;
+        height = 480;
+    }
 
-  dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
-  auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
-  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(
-    colorQueue,
-    node,
-    std::string("color/image"),
-    std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
-              &rgbConverter,  // since the converter has the same frame name
-                              // and image type is also same we can reuse it
-              std::placeholders::_1,
-              std::placeholders::_2),
-    30,
-    rgbCameraInfo,
-    "color");
+    dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+    auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
+                                                                                       node,
+                                                                                       std::string("color/image"),
+                                                                                       std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+                                                                                                 &rgbConverter,  // since the converter has the same frame name
+                                                                                                                 // and image type is also same we can reuse it
+                                                                                                 std::placeholders::_1,
+                                                                                                 std::placeholders::_2),
+                                                                                       30,
+                                                                                       rgbCameraInfo,
+                                                                                       "color");
 
-  dai::rosBridge::TrackDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
-  dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
-    trackQueue,
-    node,
-    std::string("color/yolov4_tracklets"),
-    std::bind(&dai::rosBridge::TrackDetectionConverter::toRosMsg,
-              &trackConverter,
-              std::placeholders::_1,
-              std::placeholders::_2),
-    30);
+    dai::rosBridge::TrackDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
+    dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+        trackQueue,
+        node,
+        std::string("color/yolov4_tracklets"),
+        std::bind(&dai::rosBridge::TrackDetectionConverter::toRosMsg, &trackConverter, std::placeholders::_1, std::placeholders::_2),
+        30);
 
-  rgbPublish.addPublisherCallback();
-  trackPublish.addPublisherCallback();
+    rgbPublish.addPublisherCallback();
+    trackPublish.addPublisherCallback();
 
-  rclcpp::spin(node);
+    rclcpp::spin(node);
 
-  return 0;
+    return 0;
 }

--- a/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
@@ -1,17 +1,16 @@
 #include <cstdio>
 #include <iostream>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/node.hpp"
-#include "rclcpp/executors.hpp"
-#include "sensor_msgs/msg/image.hpp"
 #include "camera_info_manager/camera_info_manager.hpp"
-#include "vision_msgs/msg/detection2_d_array.hpp"
-#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
-
 #include "depthai_bridge/BridgePublisher.hpp"
 #include "depthai_bridge/ImageConverter.hpp"
 #include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+#include "rclcpp/executors.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
 
 // Inludes common necessary includes for development using depthai library
 #include "depthai/device/DataQueue.hpp"
@@ -19,234 +18,229 @@
 #include "depthai/pipeline/Pipeline.hpp"
 #include "depthai/pipeline/node/ColorCamera.hpp"
 #include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
 #include "depthai/pipeline/node/StereoDepth.hpp"
-#include "depthai/pipeline/node/ObjectTracker.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
 
 const std::vector<std::string> label_map = {
-  "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
-  "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
-  "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
-  "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
-  "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
-  "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
-  "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
-  "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
-  "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+    "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+    "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+    "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+    "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+    "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+    "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+    "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+    "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+    "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
 
 dai::Pipeline createPipeline(bool syncNN, bool subpixel, std::string nnPath, int confidence, int LRchecktresh, std::string resolution, bool fullFrameTracking) {
-  dai::Pipeline pipeline;
-  dai::node::MonoCamera::Properties::SensorResolution monoResolution;
-  auto colorCam = pipeline.create<dai::node::ColorCamera>();
-  auto spatialDetectionNetwork = pipeline.create<dai::node::YoloSpatialDetectionNetwork>();
-  auto monoLeft = pipeline.create<dai::node::MonoCamera>();
-  auto monoRight = pipeline.create<dai::node::MonoCamera>();
-  auto stereo = pipeline.create<dai::node::StereoDepth>();
-  auto tracker = pipeline.create<dai::node::ObjectTracker>();
+    dai::Pipeline pipeline;
+    dai::node::MonoCamera::Properties::SensorResolution monoResolution;
+    auto colorCam = pipeline.create<dai::node::ColorCamera>();
+    auto spatialDetectionNetwork = pipeline.create<dai::node::YoloSpatialDetectionNetwork>();
+    auto monoLeft = pipeline.create<dai::node::MonoCamera>();
+    auto monoRight = pipeline.create<dai::node::MonoCamera>();
+    auto stereo = pipeline.create<dai::node::StereoDepth>();
+    auto tracker = pipeline.create<dai::node::ObjectTracker>();
 
-  // create xlink connections
-  auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
-  auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
-  auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+    // create xlink connections
+    auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+    auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
+    auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
 
-  xoutRgb->setStreamName("preview");
-  xoutDepth->setStreamName("depth");
-  xoutTracker->setStreamName("tracklets");
+    xoutRgb->setStreamName("preview");
+    xoutDepth->setStreamName("depth");
+    xoutTracker->setStreamName("tracklets");
 
-  colorCam->setPreviewSize(416, 416);
-  colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
-  colorCam->setInterleaved(false);
-  colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+    colorCam->setPreviewSize(416, 416);
+    colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+    colorCam->setInterleaved(false);
+    colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
 
-  if(resolution == "720p") {
-    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_720_P;
-  } else if(resolution == "400p") {
-    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_400_P;
-  } else if(resolution == "800p") {
-    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_800_P;
-  } else if(resolution == "480p") {
-    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_480_P;
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", resolution.c_str());
-    throw std::runtime_error("Invalid mono camera resolution.");
-  }
+    if(resolution == "720p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_720_P;
+    } else if(resolution == "400p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_400_P;
+    } else if(resolution == "800p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_800_P;
+    } else if(resolution == "480p") {
+        monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_480_P;
+    } else {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", resolution.c_str());
+        throw std::runtime_error("Invalid mono camera resolution.");
+    }
 
-  monoLeft->setResolution(monoResolution);
-  monoLeft->setBoardSocket(dai::CameraBoardSocket::CAM_B);
-  monoRight->setResolution(monoResolution);
-  monoRight->setBoardSocket(dai::CameraBoardSocket::CAM_C);
+    monoLeft->setResolution(monoResolution);
+    monoLeft->setBoardSocket(dai::CameraBoardSocket::CAM_B);
+    monoRight->setResolution(monoResolution);
+    monoRight->setBoardSocket(dai::CameraBoardSocket::CAM_C);
 
-  /// setting node configs
-  stereo->initialConfig.setConfidenceThreshold(confidence);
-  stereo->setRectifyEdgeFillColor(0);  // black, to better see the cutout
-  stereo->initialConfig.setLeftRightCheckThreshold(LRchecktresh);
-  stereo->setSubpixel(subpixel);
-  stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
+    /// setting node configs
+    stereo->initialConfig.setConfidenceThreshold(confidence);
+    stereo->setRectifyEdgeFillColor(0);  // black, to better see the cutout
+    stereo->initialConfig.setLeftRightCheckThreshold(LRchecktresh);
+    stereo->setSubpixel(subpixel);
+    stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
 
-  spatialDetectionNetwork->setBlobPath(nnPath);
-  spatialDetectionNetwork->setConfidenceThreshold(0.3f);
-  spatialDetectionNetwork->input.setBlocking(false);
-  spatialDetectionNetwork->setBoundingBoxScaleFactor(0.5);
-  spatialDetectionNetwork->setDepthLowerThreshold(100);
-  spatialDetectionNetwork->setDepthUpperThreshold(5000);
+    spatialDetectionNetwork->setBlobPath(nnPath);
+    spatialDetectionNetwork->setConfidenceThreshold(0.3f);
+    spatialDetectionNetwork->input.setBlocking(false);
+    spatialDetectionNetwork->setBoundingBoxScaleFactor(0.5);
+    spatialDetectionNetwork->setDepthLowerThreshold(100);
+    spatialDetectionNetwork->setDepthUpperThreshold(5000);
 
-  // yolo specific parameters
-  spatialDetectionNetwork->setNumClasses(80);
-  spatialDetectionNetwork->setCoordinateSize(4);
-  spatialDetectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
-  spatialDetectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
-  spatialDetectionNetwork->setIouThreshold(0.5f);
+    // yolo specific parameters
+    spatialDetectionNetwork->setNumClasses(80);
+    spatialDetectionNetwork->setCoordinateSize(4);
+    spatialDetectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+    spatialDetectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+    spatialDetectionNetwork->setIouThreshold(0.5f);
 
-  // object tracker settings
-  tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
-  tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+    // object tracker settings
+    tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+    tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
 
-  // Link plugins CAM -> STEREO -> XLINK
-  monoLeft->out.link(stereo->left);
-  monoRight->out.link(stereo->right);
+    // Link plugins CAM -> STEREO -> XLINK
+    monoLeft->out.link(stereo->left);
+    monoRight->out.link(stereo->right);
 
-  // Link plugins CAM -> NN -> XLINK
-  colorCam->preview.link(spatialDetectionNetwork->input);
-  tracker->passthroughTrackerFrame.link(xoutRgb->input);
+    // Link plugins CAM -> NN -> XLINK
+    colorCam->preview.link(spatialDetectionNetwork->input);
+    tracker->passthroughTrackerFrame.link(xoutRgb->input);
 
-  if (fullFrameTracking)
-  {
-    colorCam->setPreviewKeepAspectRatio(false);
-    colorCam->video.link(tracker->inputTrackerFrame);
-    //tracker->inputTrackerFrame.setBlocking(false);
-    // do not block the pipeline if it's too slow on full frame
-    //tracker->inputTrackerFrame.setQueueSize(2);
-  }
-  else
-  {
-    spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
-  }
+    if(fullFrameTracking) {
+        colorCam->setPreviewKeepAspectRatio(false);
+        colorCam->video.link(tracker->inputTrackerFrame);
+        // tracker->inputTrackerFrame.setBlocking(false);
+        //  do not block the pipeline if it's too slow on full frame
+        // tracker->inputTrackerFrame.setQueueSize(2);
+    } else {
+        spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+    }
 
-  spatialDetectionNetwork->passthrough.link(tracker->inputDetectionFrame);
-  spatialDetectionNetwork->out.link(tracker->inputDetections);
-  tracker->out.link(xoutTracker->input);
-  stereo->depth.link(spatialDetectionNetwork->inputDepth);
-  spatialDetectionNetwork->passthroughDepth.link(xoutDepth->input);
+    spatialDetectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+    spatialDetectionNetwork->out.link(tracker->inputDetections);
+    tracker->out.link(xoutTracker->input);
+    stereo->depth.link(spatialDetectionNetwork->inputDepth);
+    spatialDetectionNetwork->passthroughDepth.link(xoutDepth->input);
 
-  return pipeline;
+    return pipeline;
 }
 
 int main(int argc, char** argv) {
-  rclcpp::init(argc, argv);
-  auto node = rclcpp::Node::make_shared("tracker_yolov4_spatial_node");
+    rclcpp::init(argc, argv);
+    auto node = rclcpp::Node::make_shared("tracker_yolov4_spatial_node");
 
-  std::string tfPrefix, resourceBaseFolder, nnPath;
-  std::string camera_param_uri;
-  std::string nnName(BLOB_NAME);  // Set your blob name for the model here
-  bool syncNN, subpixel, fullFrameTracking;
-  int confidence = 200, LRchecktresh = 5;
-  std::string monoResolution = "400p";
+    std::string tfPrefix, resourceBaseFolder, nnPath;
+    std::string camera_param_uri;
+    std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+    bool syncNN, subpixel, fullFrameTracking;
+    int confidence = 200, LRchecktresh = 5;
+    std::string monoResolution = "400p";
 
-  node->declare_parameter("tf_prefix", "oak");
-  node->declare_parameter("camera_param_uri", camera_param_uri);
-  node->declare_parameter("sync_nn", true);
-  node->declare_parameter("subpixel", true);
-  node->declare_parameter("nnName", "");
-  node->declare_parameter("confidence", confidence);
-  node->declare_parameter("LRchecktresh", LRchecktresh);
-  node->declare_parameter("monoResolution", monoResolution);
-  node->declare_parameter("resourceBaseFolder", "");
-  node->declare_parameter("fullFrameTracking", false);
+    node->declare_parameter("tf_prefix", "oak");
+    node->declare_parameter("camera_param_uri", camera_param_uri);
+    node->declare_parameter("sync_nn", true);
+    node->declare_parameter("subpixel", true);
+    node->declare_parameter("nnName", "");
+    node->declare_parameter("confidence", confidence);
+    node->declare_parameter("LRchecktresh", LRchecktresh);
+    node->declare_parameter("monoResolution", monoResolution);
+    node->declare_parameter("resourceBaseFolder", "");
+    node->declare_parameter("fullFrameTracking", false);
 
-  node->get_parameter("tf_prefix", tfPrefix);
-  node->get_parameter("camera_param_uri", camera_param_uri);
-  node->get_parameter("sync_nn", syncNN);
-  node->get_parameter("subpixel", subpixel);
-  node->get_parameter("confidence", confidence);
-  node->get_parameter("LRchecktresh", LRchecktresh);
-  node->get_parameter("monoResolution", monoResolution);
-  node->get_parameter("resourceBaseFolder", resourceBaseFolder);
-  node->get_parameter("fullFrameTracking", fullFrameTracking);
+    node->get_parameter("tf_prefix", tfPrefix);
+    node->get_parameter("camera_param_uri", camera_param_uri);
+    node->get_parameter("sync_nn", syncNN);
+    node->get_parameter("subpixel", subpixel);
+    node->get_parameter("confidence", confidence);
+    node->get_parameter("LRchecktresh", LRchecktresh);
+    node->get_parameter("monoResolution", monoResolution);
+    node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+    node->get_parameter("fullFrameTracking", fullFrameTracking);
 
-  if(resourceBaseFolder.empty()) {
-    throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
-  }
+    if(resourceBaseFolder.empty()) {
+        throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+    }
 
-  std::string nnParam;
-  node->get_parameter("nnName", nnParam);
-  if(nnParam != "x") {
-      node->get_parameter("nnName", nnName);
-  }
+    std::string nnParam;
+    node->get_parameter("nnName", nnParam);
+    if(nnParam != "x") {
+        node->get_parameter("nnName", nnName);
+    }
 
-  nnPath = resourceBaseFolder + "/" + nnName;
-  dai::Pipeline pipeline = createPipeline(syncNN, subpixel, nnPath, confidence, LRchecktresh, monoResolution, fullFrameTracking);
-  dai::Device device(pipeline);
+    nnPath = resourceBaseFolder + "/" + nnName;
+    dai::Pipeline pipeline = createPipeline(syncNN, subpixel, nnPath, confidence, LRchecktresh, monoResolution, fullFrameTracking);
+    dai::Device device(pipeline);
 
-  auto colorQueue = device.getOutputQueue("preview", 30, false);
-  auto depthQueue = device.getOutputQueue("depth", 30, false);
-  auto trackQueue = device.getOutputQueue("tracklets", 30, false);
-  auto calibrationHandler = device.readCalibration();
+    auto colorQueue = device.getOutputQueue("preview", 30, false);
+    auto depthQueue = device.getOutputQueue("depth", 30, false);
+    auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+    auto calibrationHandler = device.readCalibration();
 
-  int width, height;
-  if(monoResolution == "720p") {
-    width = 1280;
-    height = 720;
-  } else if(monoResolution == "400p") {
-    width = 640;
-    height = 400;
-  } else if(monoResolution == "800p") {
-    width = 1280;
-    height = 800;
-  } else if(monoResolution == "480p") {
-    width = 640;
-    height = 480;
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", monoResolution.c_str());
-    throw std::runtime_error("Invalid mono camera resolution.");
-  }
+    int width, height;
+    if(monoResolution == "720p") {
+        width = 1280;
+        height = 720;
+    } else if(monoResolution == "400p") {
+        width = 640;
+        height = 400;
+    } else if(monoResolution == "800p") {
+        width = 1280;
+        height = 800;
+    } else if(monoResolution == "480p") {
+        width = 640;
+        height = 480;
+    } else {
+        RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", monoResolution.c_str());
+        throw std::runtime_error("Invalid mono camera resolution.");
+    }
 
-  auto boardName = calibrationHandler.getEepromData().boardName;
-  if(height > 480 && boardName == "OAK-D-LITE") {
-    width = 640;
-    height = 480;
-  }
+    auto boardName = calibrationHandler.getEepromData().boardName;
+    if(height > 480 && boardName == "OAK-D-LITE") {
+        width = 640;
+        height = 480;
+    }
 
-  dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
-  auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
-  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
-    node,
-    std::string("color/image"),
-    std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
-              &rgbConverter,  // since the converter has the same frame name
-                              // and image type is also same we can reuse it
-              std::placeholders::_1,
-              std::placeholders::_2),
-    30,
-    rgbCameraInfo,
-    "color");
+    dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+    auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
+                                                                                       node,
+                                                                                       std::string("color/image"),
+                                                                                       std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+                                                                                                 &rgbConverter,  // since the converter has the same frame name
+                                                                                                                 // and image type is also same we can reuse it
+                                                                                                 std::placeholders::_1,
+                                                                                                 std::placeholders::_2),
+                                                                                       30,
+                                                                                       rgbCameraInfo,
+                                                                                       "color");
 
-  dai::rosBridge::TrackSpatialDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
-  dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
-    trackQueue,
-    node, std::string("color/yolov4_Spatial_tracklets"),
-    std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg,
-              &trackConverter,
-              std::placeholders::_1,
-              std::placeholders::_2),
-    30);
+    dai::rosBridge::TrackSpatialDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
+    dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+        trackQueue,
+        node,
+        std::string("color/yolov4_Spatial_tracklets"),
+        std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg, &trackConverter, std::placeholders::_1, std::placeholders::_2),
+        30);
 
-  dai::rosBridge::ImageConverter depthConverter(tfPrefix + "_right_camera_optical_frame", true);
-  auto rightCameraInfo = depthConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_C, width, height);
-  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> depthPublish(
-    depthQueue,
-    node,
-    std::string("stereo/depth"),
-    std::bind(&dai::rosBridge::ImageConverter::toRosMsg, &depthConverter, std::placeholders::_1, std::placeholders::_2),
-    30,
-    rightCameraInfo,
-    "stereo");
+    dai::rosBridge::ImageConverter depthConverter(tfPrefix + "_right_camera_optical_frame", true);
+    auto rightCameraInfo = depthConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_C, width, height);
+    dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> depthPublish(
+        depthQueue,
+        node,
+        std::string("stereo/depth"),
+        std::bind(&dai::rosBridge::ImageConverter::toRosMsg, &depthConverter, std::placeholders::_1, std::placeholders::_2),
+        30,
+        rightCameraInfo,
+        "stereo");
 
-  depthPublish.addPublisherCallback();
-  trackPublish.addPublisherCallback();
-  rgbPublish.addPublisherCallback();
+    depthPublish.addPublisherCallback();
+    trackPublish.addPublisherCallback();
+    rgbPublish.addPublisherCallback();
 
-  rclcpp::spin(node);
+    rclcpp::spin(node);
 
-  return 0;
+    return 0;
 }

--- a/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
+++ b/depthai_examples/src/tracker_yolov4_spatial_publisher.cpp
@@ -1,0 +1,252 @@
+#include <cstdio>
+#include <iostream>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp/executors.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "camera_info_manager/camera_info_manager.hpp"
+#include "vision_msgs/msg/detection2_d_array.hpp"
+#include "depthai_ros_msgs/msg/track_detection2_d_array.hpp"
+
+#include "depthai_bridge/BridgePublisher.hpp"
+#include "depthai_bridge/ImageConverter.hpp"
+#include "depthai_bridge/TrackSpatialDetectionConverter.hpp"
+
+// Inludes common necessary includes for development using depthai library
+#include "depthai/device/DataQueue.hpp"
+#include "depthai/device/Device.hpp"
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/node/ColorCamera.hpp"
+#include "depthai/pipeline/node/MonoCamera.hpp"
+#include "depthai/pipeline/node/SpatialDetectionNetwork.hpp"
+#include "depthai/pipeline/node/StereoDepth.hpp"
+#include "depthai/pipeline/node/ObjectTracker.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
+
+const std::vector<std::string> label_map = {
+  "person",        "bicycle",      "car",           "motorbike",     "aeroplane",   "bus",         "train",       "truck",        "boat",
+  "traffic light", "fire hydrant", "stop sign",     "parking meter", "bench",       "bird",        "cat",         "dog",          "horse",
+  "sheep",         "cow",          "elephant",      "bear",          "zebra",       "giraffe",     "backpack",    "umbrella",     "handbag",
+  "tie",           "suitcase",     "frisbee",       "skis",          "snowboard",   "sports ball", "kite",        "baseball bat", "baseball glove",
+  "skateboard",    "surfboard",    "tennis racket", "bottle",        "wine glass",  "cup",         "fork",        "knife",        "spoon",
+  "bowl",          "banana",       "apple",         "sandwich",      "orange",      "broccoli",    "carrot",      "hot dog",      "pizza",
+  "donut",         "cake",         "chair",         "sofa",          "pottedplant", "bed",         "diningtable", "toilet",       "tvmonitor",
+  "laptop",        "mouse",        "remote",        "keyboard",      "cell phone",  "microwave",   "oven",        "toaster",      "sink",
+  "refrigerator",  "book",         "clock",         "vase",          "scissors",    "teddy bear",  "hair drier",  "toothbrush"};
+
+dai::Pipeline createPipeline(bool syncNN, bool subpixel, std::string nnPath, int confidence, int LRchecktresh, std::string resolution, bool fullFrameTracking) {
+  dai::Pipeline pipeline;
+  dai::node::MonoCamera::Properties::SensorResolution monoResolution;
+  auto colorCam = pipeline.create<dai::node::ColorCamera>();
+  auto spatialDetectionNetwork = pipeline.create<dai::node::YoloSpatialDetectionNetwork>();
+  auto monoLeft = pipeline.create<dai::node::MonoCamera>();
+  auto monoRight = pipeline.create<dai::node::MonoCamera>();
+  auto stereo = pipeline.create<dai::node::StereoDepth>();
+  auto tracker = pipeline.create<dai::node::ObjectTracker>();
+
+  // create xlink connections
+  auto xoutRgb = pipeline.create<dai::node::XLinkOut>();
+  auto xoutDepth = pipeline.create<dai::node::XLinkOut>();
+  auto xoutTracker = pipeline.create<dai::node::XLinkOut>();
+
+  xoutRgb->setStreamName("preview");
+  xoutDepth->setStreamName("depth");
+  xoutTracker->setStreamName("tracklets");
+
+  colorCam->setPreviewSize(416, 416);
+  colorCam->setResolution(dai::ColorCameraProperties::SensorResolution::THE_1080_P);
+  colorCam->setInterleaved(false);
+  colorCam->setColorOrder(dai::ColorCameraProperties::ColorOrder::BGR);
+
+  if(resolution == "720p") {
+    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_720_P;
+  } else if(resolution == "400p") {
+    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_400_P;
+  } else if(resolution == "800p") {
+    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_800_P;
+  } else if(resolution == "480p") {
+    monoResolution = dai::node::MonoCamera::Properties::SensorResolution::THE_480_P;
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", resolution.c_str());
+    throw std::runtime_error("Invalid mono camera resolution.");
+  }
+
+  monoLeft->setResolution(monoResolution);
+  monoLeft->setBoardSocket(dai::CameraBoardSocket::CAM_B);
+  monoRight->setResolution(monoResolution);
+  monoRight->setBoardSocket(dai::CameraBoardSocket::CAM_C);
+
+  /// setting node configs
+  stereo->initialConfig.setConfidenceThreshold(confidence);
+  stereo->setRectifyEdgeFillColor(0);  // black, to better see the cutout
+  stereo->initialConfig.setLeftRightCheckThreshold(LRchecktresh);
+  stereo->setSubpixel(subpixel);
+  stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
+
+  spatialDetectionNetwork->setBlobPath(nnPath);
+  spatialDetectionNetwork->setConfidenceThreshold(0.3f);
+  spatialDetectionNetwork->input.setBlocking(false);
+  spatialDetectionNetwork->setBoundingBoxScaleFactor(0.5);
+  spatialDetectionNetwork->setDepthLowerThreshold(100);
+  spatialDetectionNetwork->setDepthUpperThreshold(5000);
+
+  // yolo specific parameters
+  spatialDetectionNetwork->setNumClasses(80);
+  spatialDetectionNetwork->setCoordinateSize(4);
+  spatialDetectionNetwork->setAnchors({10, 14, 23, 27, 37, 58, 81, 82, 135, 169, 344, 319});
+  spatialDetectionNetwork->setAnchorMasks({{"side13", {3, 4, 5}}, {"side26", {1, 2, 3}}});
+  spatialDetectionNetwork->setIouThreshold(0.5f);
+
+  // object tracker settings
+  tracker->setTrackerType(dai::TrackerType::ZERO_TERM_COLOR_HISTOGRAM);
+  tracker->setTrackerIdAssignmentPolicy(dai::TrackerIdAssignmentPolicy::UNIQUE_ID);
+
+  // Link plugins CAM -> STEREO -> XLINK
+  monoLeft->out.link(stereo->left);
+  monoRight->out.link(stereo->right);
+
+  // Link plugins CAM -> NN -> XLINK
+  colorCam->preview.link(spatialDetectionNetwork->input);
+  tracker->passthroughTrackerFrame.link(xoutRgb->input);
+
+  if (fullFrameTracking)
+  {
+    colorCam->setPreviewKeepAspectRatio(false);
+    colorCam->video.link(tracker->inputTrackerFrame);
+    //tracker->inputTrackerFrame.setBlocking(false);
+    // do not block the pipeline if it's too slow on full frame
+    //tracker->inputTrackerFrame.setQueueSize(2);
+  }
+  else
+  {
+    spatialDetectionNetwork->passthrough.link(tracker->inputTrackerFrame);
+  }
+
+  spatialDetectionNetwork->passthrough.link(tracker->inputDetectionFrame);
+  spatialDetectionNetwork->out.link(tracker->inputDetections);
+  tracker->out.link(xoutTracker->input);
+  stereo->depth.link(spatialDetectionNetwork->inputDepth);
+  spatialDetectionNetwork->passthroughDepth.link(xoutDepth->input);
+
+  return pipeline;
+}
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("tracker_yolov4_spatial_node");
+
+  std::string tfPrefix, resourceBaseFolder, nnPath;
+  std::string camera_param_uri;
+  std::string nnName(BLOB_NAME);  // Set your blob name for the model here
+  bool syncNN, subpixel, fullFrameTracking;
+  int confidence = 200, LRchecktresh = 5;
+  std::string monoResolution = "400p";
+
+  node->declare_parameter("tf_prefix", "oak");
+  node->declare_parameter("camera_param_uri", camera_param_uri);
+  node->declare_parameter("sync_nn", true);
+  node->declare_parameter("subpixel", true);
+  node->declare_parameter("nnName", "");
+  node->declare_parameter("confidence", confidence);
+  node->declare_parameter("LRchecktresh", LRchecktresh);
+  node->declare_parameter("monoResolution", monoResolution);
+  node->declare_parameter("resourceBaseFolder", "");
+  node->declare_parameter("fullFrameTracking", false);
+
+  node->get_parameter("tf_prefix", tfPrefix);
+  node->get_parameter("camera_param_uri", camera_param_uri);
+  node->get_parameter("sync_nn", syncNN);
+  node->get_parameter("subpixel", subpixel);
+  node->get_parameter("confidence", confidence);
+  node->get_parameter("LRchecktresh", LRchecktresh);
+  node->get_parameter("monoResolution", monoResolution);
+  node->get_parameter("resourceBaseFolder", resourceBaseFolder);
+  node->get_parameter("fullFrameTracking", fullFrameTracking);
+
+  if(resourceBaseFolder.empty()) {
+    throw std::runtime_error("Send the path to the resouce folder containing NNBlob in \'resourceBaseFolder\' ");
+  }
+
+  std::string nnParam;
+  node->get_parameter("nnName", nnParam);
+  if(nnParam != "x") {
+      node->get_parameter("nnName", nnName);
+  }
+
+  nnPath = resourceBaseFolder + "/" + nnName;
+  dai::Pipeline pipeline = createPipeline(syncNN, subpixel, nnPath, confidence, LRchecktresh, monoResolution, fullFrameTracking);
+  dai::Device device(pipeline);
+
+  auto colorQueue = device.getOutputQueue("preview", 30, false);
+  auto depthQueue = device.getOutputQueue("depth", 30, false);
+  auto trackQueue = device.getOutputQueue("tracklets", 30, false);
+  auto calibrationHandler = device.readCalibration();
+
+  int width, height;
+  if(monoResolution == "720p") {
+    width = 1280;
+    height = 720;
+  } else if(monoResolution == "400p") {
+    width = 640;
+    height = 400;
+  } else if(monoResolution == "800p") {
+    width = 1280;
+    height = 800;
+  } else if(monoResolution == "480p") {
+    width = 640;
+    height = 480;
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Invalid parameter. -> monoResolution: %s", monoResolution.c_str());
+    throw std::runtime_error("Invalid mono camera resolution.");
+  }
+
+  auto boardName = calibrationHandler.getEepromData().boardName;
+  if(height > 480 && boardName == "OAK-D-LITE") {
+    width = 640;
+    height = 480;
+  }
+
+  dai::rosBridge::ImageConverter rgbConverter(tfPrefix + "_rgb_camera_optical_frame", false);
+  auto rgbCameraInfo = rgbConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_A, -1, -1);
+  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> rgbPublish(colorQueue,
+    node,
+    std::string("color/image"),
+    std::bind(&dai::rosBridge::ImageConverter::toRosMsg,
+              &rgbConverter,  // since the converter has the same frame name
+                              // and image type is also same we can reuse it
+              std::placeholders::_1,
+              std::placeholders::_2),
+    30,
+    rgbCameraInfo,
+    "color");
+
+  dai::rosBridge::TrackSpatialDetectionConverter trackConverter(tfPrefix + "_rgb_camera_optical_frame", 416, 416, fullFrameTracking, 0.3);
+  dai::rosBridge::BridgePublisher<depthai_ros_msgs::msg::TrackDetection2DArray, dai::Tracklets> trackPublish(
+    trackQueue,
+    node, std::string("color/yolov4_Spatial_tracklets"),
+    std::bind(&dai::rosBridge::TrackSpatialDetectionConverter::toRosMsg,
+              &trackConverter,
+              std::placeholders::_1,
+              std::placeholders::_2),
+    30);
+
+  dai::rosBridge::ImageConverter depthConverter(tfPrefix + "_right_camera_optical_frame", true);
+  auto rightCameraInfo = depthConverter.calibrationToCameraInfo(calibrationHandler, dai::CameraBoardSocket::CAM_C, width, height);
+  dai::rosBridge::BridgePublisher<sensor_msgs::msg::Image, dai::ImgFrame> depthPublish(
+    depthQueue,
+    node,
+    std::string("stereo/depth"),
+    std::bind(&dai::rosBridge::ImageConverter::toRosMsg, &depthConverter, std::placeholders::_1, std::placeholders::_2),
+    30,
+    rightCameraInfo,
+    "stereo");
+
+  depthPublish.addPublisherCallback();
+  trackPublish.addPublisherCallback();
+  rgbPublish.addPublisherCallback();
+
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -31,6 +31,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   # "msg/ImageMarkerArray.msg"
   "msg/SpatialDetection.msg"
   "msg/SpatialDetectionArray.msg"
+  "msg/TrackDetection2D.msg"
+  "msg/TrackDetection2DArray.msg"
   "srv/TriggerNamed.srv"
   "srv/NormalizedImageCrop.srv"
   DEPENDENCIES builtin_interfaces geometry_msgs std_msgs vision_msgs sensor_msgs

--- a/depthai_ros_msgs/msg/TrackDetection2D.msg
+++ b/depthai_ros_msgs/msg/TrackDetection2D.msg
@@ -1,0 +1,25 @@
+
+# Class probabilities
+vision_msgs/ObjectHypothesisWithPose[] results
+
+# 2D bounding box surrounding the object.
+vision_msgs/BoundingBox2D bbox
+
+# If true, this message contains object tracking information.
+bool is_tracking
+
+# ID used for consistency across multiple detection messages. This value will
+# likely differ from the id field set in each individual ObjectHypothesis.
+# If you set this field, be sure to also set is_tracking to True.
+string tracking_id
+
+# Age: number of frames the object is being tracked
+int32 tracking_age
+
+# Status of the tracking:
+# 0 = NEW -> the object is newly added.
+# 1 = TRACKED -> the object is being tracked.
+# 2 = LOST -> the object gets lost now. The object can be tracked again automatically (long term tracking) 
+#			  or by specifying detected object manually (short term and zero term tracking).
+# 3 = REMOVED -> the object is removed.
+int32 tracking_status

--- a/depthai_ros_msgs/msg/TrackDetection2DArray.msg
+++ b/depthai_ros_msgs/msg/TrackDetection2DArray.msg
@@ -1,0 +1,7 @@
+# A list of 2D tracklets, for a multi-object 2D tracker.
+
+std_msgs/Header header
+# A list of the tracking proposals.
+TrackDetection2D[] detections
+
+## These messages are created as close as possible to the official vision_msgs(http://wiki.ros.org/vision_msgs)


### PR DESCRIPTION
## Overview
Author: @daniqsilva25

## Issue 
Issue link: [#146](https://github.com/luxonis/depthai-ros/issues/146)
Issue description: Absence of a tracking converter in ROS2 Humble. This PR adds a tracking converter to enable object tracking with ROS2.
Related PRs: [#494](https://github.com/luxonis/depthai-ros/pull/494)

## Changes
ROS distro: Humble
List of changes:
* Added a track detection converter and track spatial detection converter for tracking purposes with 2D or 3D detections, respectively;
* Added new ROS2 messages for tracking: TrackDetection2D and TrackDetection2DArray. The first message adds two important fields for tracking tasks: tracking age and tracking status, both available in the depthai pipeline. The second message is just an array of the first one;
* Added two YOLOv4-based object tracking ROS node examples in depthai_examples.

## Testing
Hardware used: OAK-1, OAK-D
Depthai library version: 2.21.2.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
