### PR TITLE
Added Env Hooks so that depthai xacro can be used with gazebo sim

### DIFF
--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -15,4 +15,8 @@ install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch
         FILES_MATCHING PATTERN "*.py")
 install(DIRECTORY urdf DESTINATION share/${PROJECT_NAME})
 
+
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.dsv.in")
+
 ament_package()

--- a/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GAZEBO_MODEL_PATH;share
+prepend-non-duplicate;GAZEBO_RESOURCE_PATH;share

--- a/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
@@ -1,0 +1,3 @@
+
+ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX"
+ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX"


### PR DESCRIPTION
## Overview
Author: Rahul Harsha Cheppally

## Issue 
Issue link (if present):
Issue description:
Related PRs

## Changes
ROS distro: Humble 
List of changes: Added Env Hooks into Depthai descriptions package

## Testing
Hardware used: X86, ubuntu 22.04 
Depthai library version: NA


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
