### PR TITLE
fix appending features behind all the zeros occurring at coordinates …

### DIFF
--- a/depthai_bridge/src/TrackedFeaturesConverter.cpp
+++ b/depthai_bridge/src/TrackedFeaturesConverter.cpp
@@ -33,16 +33,14 @@ void TrackedFeaturesConverter::toRosMsg(std::shared_ptr<dai::TrackedFeatures> in
     msg.header.frame_id = _frameName;
     msg.features.resize(inFeatures->trackedFeatures.size());
 
-    for(const auto& feature : inFeatures->trackedFeatures) {
-        depthai_ros_msgs::msg::TrackedFeature ft;
-        ft.header = msg.header;
-        ft.position.x = feature.position.x;
-        ft.position.y = feature.position.y;
-        ft.age = feature.age;
-        ft.id = feature.id;
-        ft.harris_score = feature.harrisScore;
-        ft.tracking_error = feature.trackingError;
-        msg.features.emplace_back(ft);
+    for(int i = 0; i < inFeatures->trackedFeatures.size(); ++i) {
+        msg.features[i].header = msg.header;
+        msg.features[i].position.x = inFeatures->trackedFeatures[i].position.x;
+        msg.features[i].position.y = inFeatures->trackedFeatures[i].position.y;
+        msg.features[i].age = inFeatures->trackedFeatures[i].age;
+        msg.features[i].id = inFeatures->trackedFeatures[i].id;
+        msg.features[i].harris_score = inFeatures->trackedFeatures[i].harrisScore;
+        msg.features[i].tracking_error = inFeatures->trackedFeatures[i].trackingError;
     }
     featureMsgs.push_back(msg);
 }


### PR DESCRIPTION
## Overview
Author: Owen Chen

## Issue 
Issue link (if present):
Issue description: There are a lot of zero points (almost 50% of total features) at coordinate(0,0) sending out from camera_node (depthai_bridge) 

To quick duplicate this issue, run
$ ros2 run depthai_examples feature_tracker 

When you run ros2 topic echo /features_right or /featueres_left, you will get 
- header:
    stamp:
      sec: 0
      nanosec: 0
    frame_id: ''
  position:
    x: 0.0
    y: 0.0
    z: 0.0
  id: 0
  age: 0
  harris_score: 0.0
  tracking_error: 0.0
- header:
    stamp:
      sec: 0
      nanosec: 0
    frame_id: ''
  position:
    x: 0.0
    y: 0.0
    z: 0.0
  id: 0
  age: 0
  harris_score: 0.0
  tracking_error: 0.0

I also wrote ros node to subscribe /features_right or /features_left raw data, almost 50% of total features are appending zero
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 0,  y: 0
keypoint x: 129.689,  y: 82.449
keypoint x: 139.115,  y: 79.3655
keypoint x: 130.634,  y: 36.6569
keypoint x: 118.756,  y: 94.4681
keypoint x: 142.136,  y: 92.7242
keypoint x: 136.938,  y: 71.487  
....etc

Related PRs

## Changes
ROS distro: humble
List of changes: 
changed implementation in TrackedFeaturesConverter.cpp to fix appending features behind all the zeros occurring at coordinates (0,0)

## Testing
Hardware used: Luxonis OAK-D Stereo Camera with Lenovo notebook
Depthai library version: 2.23.0.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
![Screenshot from 2024-02-23 10-47-20](https://github.com/luxonis/depthai-ros/assets/146738365/cd94101c-7770-490c-8e16-d532470535a9)