### PR TITLE
Add Ignition Gazebo hooks that work with Gazebo Sim Fortress (humble).

### DIFF
--- a/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
@@ -1,2 +1,4 @@
 prepend-non-duplicate;GAZEBO_MODEL_PATH;share
 prepend-non-duplicate;GAZEBO_RESOURCE_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_MODEL_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share

--- a/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
@@ -1,3 +1,5 @@
 
 ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX"
 ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX"
+ament_prepend_unique_value IGN_GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX"


### PR DESCRIPTION
The same as in #507, but now adding hooks for Gazebo Sim Fortress that is default in Humble.
Still using `IGN_` prefix in humble therefore targeting only `humble` branch.

Main branch should probably get `GZ_SIM_` prefix, but did't test that.
