### PR TITLE
Fix resource paths for Ignition Gazebo

### DIFF
--- a/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.dsv.in
@@ -1,2 +1,4 @@
 prepend-non-duplicate;GAZEBO_MODEL_PATH;share
 prepend-non-duplicate;GAZEBO_RESOURCE_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_MODEL_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share

--- a/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
+++ b/depthai_descriptions/env-hooks/depthai_descriptions.sh.in
@@ -1,3 +1,5 @@
 
 ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX"
 ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX"
+ament_prepend_unique_value IGN_GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX"

--- a/depthai_descriptions/urdf/include/base_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/base_macro.urdf.xacro
@@ -21,7 +21,7 @@
             <visual>
                 <origin xyz="0 0 0" rpy="0 0 0"/>
                 <geometry>
-                    <mesh filename="package://depthai_descriptions/urdf/models/${model}.stl" />
+                    <mesh filename="file://$(find depthai_descriptions)/urdf/models/${model}.stl" />
                 </geometry>
                 <material name="mat">
                     <color rgba="${r} ${g} ${b} ${a}"/>


### PR DESCRIPTION
## Overview
Author: Nikola Banović

## Issue 
When depending on `depthai-descriptions` package, Ignition Gazebo cannot find mesh files.
 
The `package://` syntax for resolving the model path does not allow Ignition to automatically find the required resources.
```
<geometry>
    <mesh filename="package://depthai_descriptions/urdf/models/${model}.stl" />
</geometry>
```
changing this to `file://$(find my_pkg)` syntax allows this to happen automatically
```
<geometry>
    <mesh filename="file://$(find depthai_descriptions)/urdf/models/${model}.stl" />
</geometry>
```

## Changes
ROS distro: humble
- `base_macro.urdf.xacro`:  changed path to mesh file

## Optional changes
I've noticed that the environment hooks present only add the `GAZEBO_RESOURCE_PATH`, while [Ignition Gazebo](https://gazebosim.org/api/gazebo/5.0/resources.html) for humble uses `IGN_GAZEBO_RESOURCE_PATH`. I've added hooks for that in the files below.
- `depthai_descriptions.dsv.in`
- `depthai_descriptions.sh.in`