### PR TITLE
Use packages to find mesh at run time

### DIFF
--- a/depthai_descriptions/urdf/include/base_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/base_macro.urdf.xacro
@@ -2,8 +2,8 @@
 <robot name="base"
     xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:macro name="base" params="camera_name camera_model parent base_frame 
-                                           cam_pos_x cam_pos_y cam_pos_z 
+    <xacro:macro name="base" params="camera_name camera_model parent base_frame
+                                           cam_pos_x cam_pos_y cam_pos_z
                                            cam_roll cam_pitch cam_yaw has_imu r:=0.8 g:=0.8 b:=0.8 a:=0.8 ">
         <!-- base_link of the sensor-->
         <link name="${base_frame}"/>
@@ -21,7 +21,7 @@
             <visual>
                 <origin xyz="0 0 0" rpy="0 0 0"/>
                 <geometry>
-                    <mesh filename="file://$(find depthai_descriptions)/urdf/models/${model}.stl" />
+                    <mesh filename="package://depthai_descriptions/urdf/models/${model}.stl" />
                 </geometry>
                 <material name="mat">
                     <color rgba="${r} ${g} ${b} ${a}"/>


### PR DESCRIPTION
Hello
Using `packages` instead of `find` makes the package searched in runtime and not at the compilation stage. Thanks to this, you can run visualizations on remote equipment where the file path is different.
Regards
