### PR TITLE
H.264 ROS output for RGB and Mono nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
    && apt-get -y install --no-install-recommends software-properties-common git libusb-1.0-0-dev wget zsh python3-colcon-common-extensions
 
 # install latest
-RUN apt-get install ros-${ROS_DISTRO}-depthai
+RUN apt-get -y install ros-${ROS_DISTRO}-depthai
 
 ENV DEBIAN_FRONTEND=dialog
 RUN sh -c "$(wget https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
    && apt-get -y install --no-install-recommends software-properties-common git libusb-1.0-0-dev wget zsh python3-colcon-common-extensions
 
+# install latest
+RUN apt-get install ros-${ROS_DISTRO}-depthai
 
 ENV DEBIAN_FRONTEND=dialog
 RUN sh -c "$(wget https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)"

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(composition_interfaces REQUIRED)
+find_package(ffmpeg_image_transport_msgs REQUIRED)
 
 set(dependencies
   camera_info_manager
@@ -56,6 +57,7 @@ set(dependencies
   tf2_geometry_msgs
   tf2
   composition_interfaces
+  ffmpeg_image_transport_msgs
 )
 
 include_directories(

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -11,10 +11,12 @@
 #include "depthai-shared/common/Point2f.hpp"
 #include "depthai/device/CalibrationHandler.hpp"
 #include "depthai/pipeline/datatype/ImgFrame.hpp"
+#include "depthai/pipeline/datatype/EncodedFrame.hpp"
 #include "rclcpp/time.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/header.hpp"
+#include "ffmpeg_image_transport_msgs/msg/ffmpeg_packet.hpp"
 
 namespace dai {
 
@@ -22,7 +24,9 @@ namespace ros {
 
 namespace StdMsgs = std_msgs::msg;
 namespace ImageMsgs = sensor_msgs::msg;
+namespace FFMPEGMsgs = ffmpeg_image_transport_msgs::msg;
 using ImagePtr = ImageMsgs::Image::SharedPtr;
+using FFMPEGPacketPtr = FFMPEGMsgs::FFMPEGPacket::SharedPtr;
 
 using TimePoint = std::chrono::time_point<std::chrono::steady_clock, std::chrono::steady_clock::duration>;
 
@@ -83,6 +87,9 @@ class ImageConverter {
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<ImageMsgs::Image>& outImageMsgs);
     ImageMsgs::Image toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> inData, const sensor_msgs::msg::CameraInfo& info = sensor_msgs::msg::CameraInfo());
     ImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
+
+    FFMPEGMsgs::FFMPEGPacket toRosVideoMsgRawPtr(std::shared_ptr<dai::EncodedFrame> inData, int fw, int fh);
+    // FFMPEGPacketPtr toRosMsgH264Ptr(std::shared_ptr<dai::EncodedFrame> inData);
 
     void toDaiMsg(const ImageMsgs::Image& inMsg, dai::ImgFrame& outData);
 

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -30,6 +30,7 @@ rclcpp
 sensor_msgs
 diagnostic_updater
 diagnostic_msgs
+ffmpeg_image_transport_msgs
 )
 
 set(SENSOR_DEPS

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -6,6 +6,7 @@
 #include "image_transport/image_transport.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "ffmpeg_image_transport_msgs/msg/ffmpeg_packet.hpp"
 
 namespace dai {
 class Pipeline;
@@ -59,16 +60,17 @@ class Mono : public BaseNode {
     std::unique_ptr<dai::ros::ImageConverter> imageConverter;
     image_transport::CameraPublisher monoPubIT;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr monoPub;
+    rclcpp::Publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>::SharedPtr h264Pub;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub;
     std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager;
     std::shared_ptr<dai::node::MonoCamera> monoCamNode;
-    std::shared_ptr<dai::node::VideoEncoder> videoEnc;
+    std::shared_ptr<dai::node::VideoEncoder> videoEnc, videoEncH264;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
-    std::shared_ptr<dai::DataOutputQueue> monoQ;
+    std::shared_ptr<dai::DataOutputQueue> monoQ, h264Q;
     std::shared_ptr<dai::DataInputQueue> controlQ;
-    std::shared_ptr<dai::node::XLinkOut> xoutMono;
+    std::shared_ptr<dai::node::XLinkOut> xoutMono, xoutH264;
     std::shared_ptr<dai::node::XLinkIn> xinControl;
-    std::string monoQName, controlQName;
+    std::string monoQName, controlQName, h264QName;
 };
 
 }  // namespace dai_nodes

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -5,6 +5,7 @@
 #include "image_transport/image_transport.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "ffmpeg_image_transport_msgs/msg/ffmpeg_packet.hpp"
 
 namespace dai {
 class Pipeline;
@@ -63,16 +64,17 @@ class RGB : public BaseNode {
     std::unique_ptr<dai::ros::ImageConverter> imageConverter;
     image_transport::CameraPublisher rgbPubIT, previewPubIT;
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr rgbPub, previewPub;
+    rclcpp::Publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>::SharedPtr h264Pub;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr rgbInfoPub, previewInfoPub;
     std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager, previewInfoManager;
     std::shared_ptr<dai::node::ColorCamera> colorCamNode;
-    std::shared_ptr<dai::node::VideoEncoder> videoEnc;
+    std::shared_ptr<dai::node::VideoEncoder> videoEnc, videoEncH264;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
-    std::shared_ptr<dai::DataOutputQueue> colorQ, previewQ;
+    std::shared_ptr<dai::DataOutputQueue> colorQ, previewQ, h264Q;
     std::shared_ptr<dai::DataInputQueue> controlQ;
-    std::shared_ptr<dai::node::XLinkOut> xoutColor, xoutPreview;
+    std::shared_ptr<dai::node::XLinkOut> xoutColor, xoutPreview, xoutH264;
     std::shared_ptr<dai::node::XLinkIn> xinControl;
-    std::string ispQName, previewQName, controlQName;
+    std::string ispQName, previewQName, controlQName, h264QName;
 };
 
 }  // namespace dai_nodes

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -12,6 +12,7 @@
 #include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "image_transport/camera_publisher.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
+#include "ffmpeg_image_transport_msgs/msg/ffmpeg_packet.hpp"
 
 namespace dai {
 class Device;
@@ -61,6 +62,14 @@ void cameraPub(const std::string& /*name*/,
                dai::ros::ImageConverter& converter,
                image_transport::CameraPublisher& pub,
                std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
+               bool lazyPub = true);
+
+void videoPub(const std::string& /*name*/,
+               const std::shared_ptr<dai::ADatatype>& data,
+               dai::ros::ImageConverter& converter,
+               rclcpp::Publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>::SharedPtr pub,
+               int w,
+               int h,
                bool lazyPub = true);
 
 void splitPub(const std::string& /*name*/,

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -18,6 +18,7 @@
   <depend>vision_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>ffmpeg_image_transport_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>image_transport_plugins</depend>

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -31,13 +31,14 @@ RGB::RGB(const std::string& daiNodeName,
     ph = std::make_unique<param_handlers::SensorParamHandler>(node, daiNodeName, socket);
     ph->declareParams(colorCamNode, sensor, publish);
     setXinXout(pipeline);
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_INFO(node->get_logger(), "Node %s created", daiNodeName.c_str());
 }
 RGB::~RGB() = default;
 void RGB::setNames() {
     ispQName = getName() + "_isp";
     previewQName = getName() + "_preview";
     controlQName = getName() + "_control";
+    h264QName = getName() + "_h264";
 }
 
 void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
@@ -62,31 +63,44 @@ void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
         xoutPreview->input.setBlocking(false);
         colorCamNode->preview.link(xoutPreview->input);
     }
+    if(ph->getParam<bool>("i_enable_h264")) {
+        RCLCPP_INFO(getROSNode()->get_logger(), "Setting up h264 output %s (q=%d)", h264QName.c_str(), ph->getParam<int>("i_h264_quality"));
+        videoEncH264 = sensor_helpers::createEncoder(pipeline, ph->getParam<int>("i_h264_quality"), dai::VideoEncoderProperties::Profile::H264_HIGH);
+        videoEncH264->setKeyframeFrequency(30); // one kf / second @ 30 hz
+        colorCamNode->video.link(videoEncH264->input);
+
+        xoutH264 = pipeline->create<dai::node::XLinkOut>();
+        xoutH264->setStreamName(h264QName);
+        xoutH264->input.setQueueSize(2);
+        xoutH264->input.setBlocking(false);
+        videoEncH264->out.link(xoutH264->input);
+    }
     xinControl = pipeline->create<dai::node::XLinkIn>();
     xinControl->setStreamName(controlQName);
     xinControl->out.link(colorCamNode->inputControl);
 }
 
 void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
+
+    auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+    
+    imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
+    imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
+    
+    if(ph->getParam<bool>("i_low_bandwidth")) {
+        imageConverter->convertFromBitstream(dai::RawImgFrame::Type::BGR888i);
+    }
+    if(ph->getParam<bool>("i_add_exposure_offset")) {
+        auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
+        imageConverter->addExposureOffset(offset);
+    }
+    if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
+        imageConverter->reverseStereoSocketOrder();
+    }
     if(ph->getParam<bool>("i_publish_topic")) {
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        colorQ = device->getOutputQueue(ispQName, ph->getParam<int>("i_max_q_size"), false);
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
-        imageConverter =
-            std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
-        imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-        if(ph->getParam<bool>("i_low_bandwidth")) {
-            imageConverter->convertFromBitstream(dai::RawImgFrame::Type::BGR888i);
-        }
-        if(ph->getParam<bool>("i_add_exposure_offset")) {
-            auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
-            imageConverter->addExposureOffset(offset);
-        }
-
-        if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
-            imageConverter->reverseStereoSocketOrder();
-        }
-
         if(ph->getParam<std::string>("i_calibration_file").empty()) {
             infoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
                                                                     *imageConverter,
@@ -97,7 +111,6 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         } else {
             infoManager->loadCameraInfo(ph->getParam<std::string>("i_calibration_file"));
         }
-        colorQ = device->getOutputQueue(ispQName, ph->getParam<int>("i_max_q_size"), false);
         if(ipcEnabled()) {
             rgbPub = getROSNode()->create_publisher<sensor_msgs::msg::Image>("~/" + getName() + "/image_raw", 10);
             rgbInfoPub = getROSNode()->create_publisher<sensor_msgs::msg::CameraInfo>("~/" + getName() + "/camera_info", 10);
@@ -123,12 +136,8 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
     }
     if(ph->getParam<bool>("i_enable_preview")) {
         previewQ = device->getOutputQueue(previewQName, ph->getParam<int>("i_max_q_size"), false);
-
         previewInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + previewQName).get(), previewQName);
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
-        imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
-        imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         if(ph->getParam<std::string>("i_calibration_file").empty()) {
             previewInfoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
                                                                            *imageConverter,
@@ -156,15 +165,31 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
                                             ph->getParam<bool>("i_enable_lazy_publisher")));
         }
     };
+    if(ph->getParam<bool>("i_enable_h264")) {
+        RCLCPP_INFO(getROSNode()->get_logger(), "Setting up h264 queue %s", tfPrefix.c_str());
+
+        h264Q = device->getOutputQueue(h264QName, ph->getParam<int>("i_max_q_size"), false);
+        h264Pub = getROSNode()->create_publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>("~/" + getName() + "/h264", 10);
+        h264Q->addCallback(std::bind(sensor_helpers::videoPub,
+                                        std::placeholders::_1,
+                                        std::placeholders::_2,
+                                        *imageConverter,
+                                        h264Pub,
+                                        ph->getParam<int>("i_width"), ph->getParam<int>("i_height"), //it's be nice to get these from EncodedFrame
+                                        ph->getParam<bool>("i_enable_lazy_publisher")));
+    }
     controlQ = device->getInputQueue(controlQName);
 }
 
 void RGB::closeQueues() {
     if(ph->getParam<bool>("i_publish_topic")) {
         colorQ->close();
-        if(ph->getParam<bool>("i_enable_preview")) {
-            previewQ->close();
-        }
+    }
+    if(ph->getParam<bool>("i_enable_preview")) {
+        previewQ->close();
+    }
+    if(ph->getParam<bool>("i_enable_h264")) {
+        h264Q->close();
     }
     controlQ->close();
 }

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -33,6 +33,8 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
     declareAndLogParam<bool>("i_reverse_stereo_socket_order", false);
+    declareAndLogParam<bool>("i_enable_h264", false);
+    declareAndLogParam<int>("i_h264_quality", 80);   
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {


### PR DESCRIPTION
## Overview
Author: Mirek Burkon

## Issue 
Issue link (if present):
Issue description: H.264 encrypted frames were unavailable via the ROS interface
Related PRs

## Changes
ROS distro: humble
List of changes:

## Testing
Hardware used: Oak-D Lite + Raspberry Pi 5
Depthai library version: 2.24.0-1jammy.20240308.165854 arm64


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
https://www.youtube.com/watch?v=1n1EZhmPSoE