### PR TITLE
Ip autodiscovery fix Humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Depthai ROS Repository
 Hi and welcome to the main depthai-ros respository! Here you can find ROS related code for OAK cameras from Luxonis. Don't have one? You can get them [here!](https://shop.luxonis.com/)
 
-You can find the newest documentation [here](https://docs-beta.luxonis.com/software/ros/depthai-ros/intro/)
+You can find the newest documentation [here](https://docs-beta.luxonis.com/software/ros/)

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -253,7 +253,7 @@ void Camera::startDevice() {
     } else {
         RCLCPP_INFO(this->get_logger(),
                     "PoE camera detected. Consider enabling low bandwidth for specific image topics (see "
-                    "readme).");
+                    "Readme->DepthAI ROS Driver->Specific camera configurations).");
     }
 }
 


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/525
Issue description: Cameras on different subnets cannot be found
Related PRs

## Changes
ROS distro: Humble
List of changes:
- Change startup mechanism to mitigate the issue when IP is used
## Testing
Hardware used: OAK-D-POE
Depthai library version: 2.26.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
