### PR TITLE
RS Mode & Sync - Humble

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3.3.0
-    - uses: ros-tooling/setup-ros@0.5.0
+    - uses: ros-tooling/setup-ros@0.7
       with:
         required-ros-distributions: ${{ env.ROS_DISTRO }}
     - uses: ros-tooling/action-ros2-lint@0.1.3
@@ -50,7 +50,7 @@ jobs:
         linter: [xmllint, pep257, lint_cmake]
     steps:
     - uses: actions/checkout@v3.3.0
-    - uses: ros-tooling/setup-ros@0.5.0
+    - uses: ros-tooling/setup-ros@0.7
       with:
         required-ros-distributions: ${{ env.ROS_DISTRO }}
     - uses: ros-tooling/action-ros2-lint@0.1.3

--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3.3.0
-    - uses: ros-tooling/setup-ros@0.7
+    - uses: ros-tooling/setup-ros@0.7.8
       with:
         required-ros-distributions: ${{ env.ROS_DISTRO }}
     - uses: ros-tooling/action-ros2-lint@0.1.3
@@ -50,7 +50,7 @@ jobs:
         linter: [xmllint, pep257, lint_cmake]
     steps:
     - uses: actions/checkout@v3.3.0
-    - uses: ros-tooling/setup-ros@0.7
+    - uses: ros-tooling/setup-ros@0.7.8
       with:
         required-ros-distributions: ${{ env.ROS_DISTRO }}
     - uses: ros-tooling/action-ros2-lint@0.1.3

--- a/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
+++ b/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
@@ -27,7 +27,8 @@ class TFPublisher {
                          const std::string& camYaw,
                          const std::string& imuFromDescr,
                          const std::string& customURDFLocation,
-                         const std::string& customXacroArgs);
+                         const std::string& customXacroArgs,
+                         const bool rsCompatibilityMode);
     /**
      * @brief Obtain URDF description by running Xacro with provided arguments.
      */
@@ -65,30 +66,37 @@ class TFPublisher {
      */
     bool modelNameAvailable();
     std::string getCamSocketName(int socketNum);
-    std::unique_ptr<rclcpp::AsyncParametersClient> _paramClient;
-    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> _tfPub;
-    std::string _camName;
-    std::string _camModel;
-    std::string _baseFrame;
-    std::string _parentFrame;
-    std::string _camPosX;
-    std::string _camPosY;
-    std::string _camPosZ;
-    std::string _camRoll;
-    std::string _camPitch;
-    std::string _camYaw;
-    std::string _imuFromDescr;
-    std::string _customURDFLocation;
-    std::string _customXacroArgs;
-    std::vector<dai::CameraFeatures> _camFeatures;
-    rclcpp::Logger _logger;
-    const std::unordered_map<dai::CameraBoardSocket, std::string> _socketNameMap = {
+    std::unique_ptr<rclcpp::AsyncParametersClient> paramClient;
+    std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tfPub;
+    std::string camName;
+    std::string camModel;
+    std::string baseFrame;
+    std::string parentFrame;
+    std::string camPosX;
+    std::string camPosY;
+    std::string camPosZ;
+    std::string camRoll;
+    std::string camPitch;
+    std::string camYaw;
+    std::string imuFromDescr;
+    std::string customURDFLocation;
+    std::string customXacroArgs;
+    std::vector<dai::CameraFeatures> camFeatures;
+    bool rsCompatibilityMode;
+    rclcpp::Logger logger;
+    const std::unordered_map<dai::CameraBoardSocket, std::string> socketNameMap = {
         {dai::CameraBoardSocket::AUTO, "rgb"},
         {dai::CameraBoardSocket::CAM_A, "rgb"},
         {dai::CameraBoardSocket::CAM_B, "left"},
         {dai::CameraBoardSocket::CAM_C, "right"},
         {dai::CameraBoardSocket::CAM_D, "left_back"},
         {dai::CameraBoardSocket::CAM_E, "right_back"},
+    };
+    const std::unordered_map<dai::CameraBoardSocket, std::string> rsSocketNameMap = {
+        {dai::CameraBoardSocket::AUTO, "color"},
+        {dai::CameraBoardSocket::CAM_A, "color"},
+        {dai::CameraBoardSocket::CAM_B, "infra2"},
+        {dai::CameraBoardSocket::CAM_C, "infra1"},
     };
 };
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
+++ b/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
@@ -4,11 +4,11 @@
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nlohmann/json.hpp"
-#include "rclcpp/parameter_client.hpp"
 #include "rclcpp/logger.hpp"
+#include "rclcpp/parameter_client.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
 
-namespace rclcpp{
+namespace rclcpp {
 class Node;
 }  // namespace rclcpp
 

--- a/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
+++ b/depthai_bridge/include/depthai_bridge/TFPublisher.hpp
@@ -4,15 +4,19 @@
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "nlohmann/json.hpp"
-#include "rclcpp/node.hpp"
 #include "rclcpp/parameter_client.hpp"
+#include "rclcpp/logger.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
+
+namespace rclcpp{
+class Node;
+}  // namespace rclcpp
 
 namespace dai {
 namespace ros {
 class TFPublisher {
    public:
-    explicit TFPublisher(rclcpp::Node* node,
+    explicit TFPublisher(std::shared_ptr<rclcpp::Node> node,
                          const dai::CalibrationHandler& calHandler,
                          const std::vector<dai::CameraFeatures>& camFeatures,
                          const std::string& camName,
@@ -54,13 +58,13 @@ class TFPublisher {
      * Frame names are based on socket names and use following convention: [base_frame]_[socket_name]_camera_frame and
      * [base_frame]_[socket_name]_camera_optical_frame
      */
-    void publishCamTransforms(nlohmann::json camData, rclcpp::Node* node);
+    void publishCamTransforms(nlohmann::json camData, std::shared_ptr<rclcpp::Node> node);
     /**
      * @brief Publish IMU transform based on calibration data.
      * Frame name is based on IMU name and uses following convention: [base_frame]_imu_frame.
      * If IMU extrinsics are not set, warning is printed out and imu frame is published with zero translation and rotation.
      */
-    void publishImuTransform(nlohmann::json json, rclcpp::Node* node);
+    void publishImuTransform(nlohmann::json json, std::shared_ptr<rclcpp::Node> node);
     /**
      * @brief Check if model STL file is available in depthai_descriptions package.
      */

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -61,8 +61,8 @@ void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetectio
 
         opDetectionMsg.detections[i].results[0].class_id = std::to_string(inNetData->detections[i].label);
         opDetectionMsg.detections[i].results[0].score = inNetData->detections[i].confidence;
- 
-		opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
+
+        opDetectionMsg.detections[i].bbox.center.position.x = xCenter;
         opDetectionMsg.detections[i].bbox.center.position.y = yCenter;
         opDetectionMsg.detections[i].bbox.size_x = xSize;
         opDetectionMsg.detections[i].bbox.size_y = ySize;

--- a/depthai_bridge/src/TFPublisher.cpp
+++ b/depthai_bridge/src/TFPublisher.cpp
@@ -35,31 +35,33 @@ TFPublisher::TFPublisher(rclcpp::Node* node,
                          const std::string& camYaw,
                          const std::string& imuFromDescr,
                          const std::string& customURDFLocation,
-                         const std::string& customXacroArgs)
-    : _camName(camName),
-      _camModel(camModel),
-      _baseFrame(baseFrame),
-      _parentFrame(parentFrame),
-      _camPosX(camPosX),
-      _camPosY(camPosY),
-      _camPosZ(camPosZ),
-      _camRoll(camRoll),
-      _camPitch(camPitch),
-      _camYaw(camYaw),
-      _camFeatures(camFeatures),
-      _imuFromDescr(imuFromDescr),
-      _customURDFLocation(customURDFLocation),
-      _customXacroArgs(customXacroArgs),
-      _logger(node->get_logger()) {
-    _tfPub = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+                         const std::string& customXacroArgs,
+						 const bool rsCompatibilityMode)
+    : camName(camName),
+      camModel(camModel),
+      baseFrame(baseFrame),
+      parentFrame(parentFrame),
+      camPosX(camPosX),
+      camPosY(camPosY),
+      camPosZ(camPosZ),
+      camRoll(camRoll),
+      camPitch(camPitch),
+      camYaw(camYaw),
+      camFeatures(camFeatures),
+      imuFromDescr(imuFromDescr),
+      customURDFLocation(customURDFLocation),
+      customXacroArgs(customXacroArgs),
+	  rsCompatibilityMode(rsCompatibilityMode),
+      logger(node->get_logger()) {
+    tfPub = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
 
-    _paramClient = std::make_unique<rclcpp::AsyncParametersClient>(node, _camName + std::string("_state_publisher"));
+    paramClient = std::make_unique<rclcpp::AsyncParametersClient>(node, camName + std::string("_state_publisher"));
 
     auto json = calHandler.eepromToJson();
     auto camData = json["cameraData"];
     publishDescription();
     publishCamTransforms(camData, node);
-    if(_imuFromDescr != "true") {
+    if(imuFromDescr != "true") {
         publishImuTransform(json, node);
     }
 }
@@ -67,8 +69,8 @@ TFPublisher::TFPublisher(rclcpp::Node* node,
 void TFPublisher::publishDescription() {
     auto urdf = getURDF();
     auto robotDescr = rclcpp::Parameter("robot_description", urdf);
-    auto result = _paramClient->set_parameters({robotDescr});
-    RCLCPP_INFO(_logger, "Published URDF");
+    auto result = paramClient->set_parameters({robotDescr});
+    RCLCPP_INFO(logger, "Published URDF");
 }
 
 void TFPublisher::publishCamTransforms(nlohmann::json camData, rclcpp::Node* node) {
@@ -83,26 +85,26 @@ void TFPublisher::publishCamTransforms(nlohmann::json camData, rclcpp::Node* nod
         ts.transform.translation = transFromExtr(extrinsics["translation"]);
 
         std::string name = getCamSocketName(cam[0]);
-        ts.child_frame_id = _baseFrame + std::string("_") + name + std::string("_camera_frame");
+        ts.child_frame_id = baseFrame + std::string("_") + name + std::string("_camera_frame");
         // check if the camera is at the end of the chain
         if(extrinsics["toCameraSocket"] != -1) {
-            ts.header.frame_id = _baseFrame + std::string("_") + getCamSocketName(extrinsics["toCameraSocket"].get<int>()) + std::string("_camera_frame");
+            ts.header.frame_id = baseFrame + std::string("_") + getCamSocketName(extrinsics["toCameraSocket"].get<int>()) + std::string("_camera_frame");
         } else {
-            ts.header.frame_id = _baseFrame;
+            ts.header.frame_id = baseFrame;
             ts.transform.rotation.w = 1.0;
             ts.transform.rotation.x = 0.0;
             ts.transform.rotation.y = 0.0;
             ts.transform.rotation.z = 0.0;
         }
         // rotate optical fransform
-        opticalTS.child_frame_id = _baseFrame + std::string("_") + name + std::string("_camera_optical_frame");
+        opticalTS.child_frame_id = baseFrame + std::string("_") + name + std::string("_camera_optical_frame");
         opticalTS.header.frame_id = ts.child_frame_id;
         opticalTS.transform.rotation.w = 0.5;
         opticalTS.transform.rotation.x = -0.5;
         opticalTS.transform.rotation.y = 0.5;
         opticalTS.transform.rotation.z = -0.5;
-        _tfPub->sendTransform(ts);
-        _tfPub->sendTransform(opticalTS);
+        tfPub->sendTransform(ts);
+        tfPub->sendTransform(opticalTS);
     }
 }
 void TFPublisher::publishImuTransform(nlohmann::json json, rclcpp::Node* node) {
@@ -110,24 +112,27 @@ void TFPublisher::publishImuTransform(nlohmann::json json, rclcpp::Node* node) {
     ts.header.stamp = node->get_clock()->now();
     auto imuExtr = json["imuExtrinsics"];
     if(imuExtr["toCameraSocket"] != -1) {
-        ts.header.frame_id = _baseFrame + std::string("_") + getCamSocketName(imuExtr["toCameraSocket"].get<int>()) + std::string("_camera_frame");
+        ts.header.frame_id = baseFrame + std::string("_") + getCamSocketName(imuExtr["toCameraSocket"].get<int>()) + std::string("_camera_frame");
     } else {
-        ts.header.frame_id = _baseFrame;
+        ts.header.frame_id = baseFrame;
     }
-    ts.child_frame_id = _baseFrame + std::string("_imu_frame");
+    ts.child_frame_id = baseFrame + std::string("_imu_frame");
 
     ts.transform.rotation = quatFromRotM(imuExtr["rotationMatrix"]);
     ts.transform.translation = transFromExtr(imuExtr["translation"]);
     bool zeroTrans = ts.transform.translation.x == 0 && ts.transform.translation.y == 0 && ts.transform.translation.z == 0;
     bool zeroRot = ts.transform.rotation.w == 1 && ts.transform.rotation.x == 0 && ts.transform.rotation.y == 0 && ts.transform.rotation.z == 0;
     if(zeroTrans || zeroRot) {
-        RCLCPP_WARN(_logger, "IMU extrinsics appear to be default. Check if the IMU is calibrated.");
+        RCLCPP_WARN(logger, "IMU extrinsics appear to be default. Check if the IMU is calibrated.");
     }
-    _tfPub->sendTransform(ts);
+    tfPub->sendTransform(ts);
 }
 
 std::string TFPublisher::getCamSocketName(int socketNum) {
-    return _socketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
+	if(rsCompatibilityMode) {
+		return rsSocketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
+	}
+    return socketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
 }
 
 geometry_msgs::msg::Vector3 TFPublisher::transFromExtr(nlohmann::json translation) {
@@ -165,8 +170,8 @@ bool TFPublisher::modelNameAvailable() {
     if((dir = opendir(path.c_str())) != NULL) {
         while((ent = readdir(dir)) != NULL) {
             auto name = std::string(ent->d_name);
-            RCLCPP_DEBUG(_logger, "Found model: %s", name.c_str());
-            if(name == _camModel + ".stl") {
+            RCLCPP_DEBUG(logger, "Found model: %s", name.c_str());
+            if(name == camModel + ".stl") {
                 return true;
             }
         }
@@ -178,63 +183,63 @@ bool TFPublisher::modelNameAvailable() {
 }
 
 std::string TFPublisher::prepareXacroArgs() {
-    if(!_customURDFLocation.empty() || !modelNameAvailable()) {
+    if(!customURDFLocation.empty() || !modelNameAvailable()) {
         RCLCPP_ERROR(
-            _logger,
+            logger,
             "Model name %s not found in depthai_descriptions package. If camera model is autodetected, please notify developers. Using default model: OAK-D",
-            _camModel.c_str());
-        _camModel = "OAK-D";
+            camModel.c_str());
+        camModel = "OAK-D";
     }
 
-    std::string xacroArgs = "camera_name:=" + _camName;
-    xacroArgs += " camera_model:=" + _camModel;
-    xacroArgs += " base_frame:=" + _baseFrame;
-    xacroArgs += " parent_frame:=" + _parentFrame;
-    xacroArgs += " cam_pos_x:=" + _camPosX;
-    xacroArgs += " cam_pos_y:=" + _camPosY;
-    xacroArgs += " cam_pos_z:=" + _camPosZ;
-    xacroArgs += " cam_roll:=" + _camRoll;
-    xacroArgs += " cam_pitch:=" + _camPitch;
-    xacroArgs += " cam_yaw:=" + _camYaw;
-    xacroArgs += " has_imu:=" + _imuFromDescr;
+    std::string xacroArgs = "camera_name:=" + camName;
+    xacroArgs += " camera_model:=" + camModel;
+    xacroArgs += " base_frame:=" + baseFrame;
+    xacroArgs += " parent_frame:=" + parentFrame;
+    xacroArgs += " cam_pos_x:=" + camPosX;
+    xacroArgs += " cam_pos_y:=" + camPosY;
+    xacroArgs += " cam_pos_z:=" + camPosZ;
+    xacroArgs += " cam_roll:=" + camRoll;
+    xacroArgs += " cam_pitch:=" + camPitch;
+    xacroArgs += " cam_yaw:=" + camYaw;
+    xacroArgs += " has_imu:=" + imuFromDescr;
     return xacroArgs;
 }
 
 void TFPublisher::convertModelName() {
-    if(_camModel.find("OAK-D-PRO-POE") != std::string::npos || _camModel.find("OAK-D-PRO-W-POE") != std::string::npos
-       || _camModel.find("OAK-D-S2-POE") != std::string::npos) {
-        _camModel = "OAK-D-POE";
-    } else if(_camModel.find("OAK-D-LITE") != std::string::npos) {
-        _camModel = "OAK-D-PRO";
-    } else if(_camModel.find("OAK-D-S2") != std::string::npos) {
-        _camModel = "OAK-D-PRO";
-    } else if(_camModel.find("OAK-D-PRO-W") != std::string::npos) {
-        _camModel = "OAK-D-PRO";
-    } else if(_camModel.find("OAK-D-PRO") != std::string::npos) {
-        _camModel = "OAK-D-PRO";
-    } else if(_camModel.find("OAK-D-POE")) {
-        _camModel = "OAK-D-POE";
-    } else if(_camModel.find("OAK-D") != std::string::npos) {
-        _camModel = "OAK-D";
+    if(camModel.find("OAK-D-PRO-POE") != std::string::npos || camModel.find("OAK-D-PRO-W-POE") != std::string::npos
+       || camModel.find("OAK-D-S2-POE") != std::string::npos) {
+        camModel = "OAK-D-POE";
+    } else if(camModel.find("OAK-D-LITE") != std::string::npos) {
+        camModel = "OAK-D-PRO";
+    } else if(camModel.find("OAK-D-S2") != std::string::npos) {
+        camModel = "OAK-D-PRO";
+    } else if(camModel.find("OAK-D-PRO-W") != std::string::npos) {
+        camModel = "OAK-D-PRO";
+    } else if(camModel.find("OAK-D-PRO") != std::string::npos) {
+        camModel = "OAK-D-PRO";
+    } else if(camModel.find("OAK-D-POE")) {
+        camModel = "OAK-D-POE";
+    } else if(camModel.find("OAK-D") != std::string::npos) {
+        camModel = "OAK-D";
     } else {
-        RCLCPP_WARN(_logger, "Unable to match model name: %s to available model family.", _camModel.c_str());
+        RCLCPP_WARN(logger, "Unable to match model name: %s to available model family.", camModel.c_str());
     }
 }
 
 std::string TFPublisher::getURDF() {
     std::string args, path;
-    if(_customXacroArgs.empty()) {
+    if(customXacroArgs.empty()) {
         args = prepareXacroArgs();
     } else {
-        args = _customXacroArgs;
+        args = customXacroArgs;
     }
-    if(_customURDFLocation.empty()) {
+    if(customURDFLocation.empty()) {
         path = ament_index_cpp::get_package_share_directory("depthai_descriptions") + "/urdf/base_descr.urdf.xacro ";
     } else {
-        path = _customURDFLocation + " ";
+        path = customURDFLocation + " ";
     }
     std::string cmd = "xacro " + path + args;
-    RCLCPP_DEBUG(_logger, "Xacro command: %s", cmd.c_str());
+    RCLCPP_DEBUG(logger, "Xacro command: %s", cmd.c_str());
     std::array<char, 128> buffer;
     std::string result;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);

--- a/depthai_bridge/src/TFPublisher.cpp
+++ b/depthai_bridge/src/TFPublisher.cpp
@@ -20,7 +20,7 @@
 
 namespace dai {
 namespace ros {
-TFPublisher::TFPublisher(rclcpp::Node* node,
+TFPublisher::TFPublisher(std::shared_ptr<rclcpp::Node> node,
                          const dai::CalibrationHandler& calHandler,
                          const std::vector<dai::CameraFeatures>& camFeatures,
                          const std::string& camName,
@@ -36,7 +36,7 @@ TFPublisher::TFPublisher(rclcpp::Node* node,
                          const std::string& imuFromDescr,
                          const std::string& customURDFLocation,
                          const std::string& customXacroArgs,
-						 const bool rsCompatibilityMode)
+                         const bool rsCompatibilityMode)
     : camName(camName),
       camModel(camModel),
       baseFrame(baseFrame),
@@ -51,7 +51,7 @@ TFPublisher::TFPublisher(rclcpp::Node* node,
       imuFromDescr(imuFromDescr),
       customURDFLocation(customURDFLocation),
       customXacroArgs(customXacroArgs),
-	  rsCompatibilityMode(rsCompatibilityMode),
+      rsCompatibilityMode(rsCompatibilityMode),
       logger(node->get_logger()) {
     tfPub = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
 
@@ -73,7 +73,7 @@ void TFPublisher::publishDescription() {
     RCLCPP_INFO(logger, "Published URDF");
 }
 
-void TFPublisher::publishCamTransforms(nlohmann::json camData, rclcpp::Node* node) {
+void TFPublisher::publishCamTransforms(nlohmann::json camData, std::shared_ptr<rclcpp::Node> node) {
     for(auto& cam : camData) {
         geometry_msgs::msg::TransformStamped ts;
         geometry_msgs::msg::TransformStamped opticalTS;
@@ -107,7 +107,7 @@ void TFPublisher::publishCamTransforms(nlohmann::json camData, rclcpp::Node* nod
         tfPub->sendTransform(opticalTS);
     }
 }
-void TFPublisher::publishImuTransform(nlohmann::json json, rclcpp::Node* node) {
+void TFPublisher::publishImuTransform(nlohmann::json json, std::shared_ptr<rclcpp::Node> node) {
     geometry_msgs::msg::TransformStamped ts;
     ts.header.stamp = node->get_clock()->now();
     auto imuExtr = json["imuExtrinsics"];
@@ -129,9 +129,9 @@ void TFPublisher::publishImuTransform(nlohmann::json json, rclcpp::Node* node) {
 }
 
 std::string TFPublisher::getCamSocketName(int socketNum) {
-	if(rsCompatibilityMode) {
-		return rsSocketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
-	}
+    if(rsCompatibilityMode) {
+        return rsSocketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
+    }
     return socketNameMap.at(static_cast<dai::CameraBoardSocket>(socketNum));
 }
 

--- a/depthai_descriptions/launch/urdf_launch.py
+++ b/depthai_descriptions/launch/urdf_launch.py
@@ -10,149 +10,168 @@ from launch_ros.descriptions import ComposableNode
 
 
 def launch_setup(context, *args, **kwargs):
-    bringup_dir = get_package_share_directory('depthai_descriptions')
-    use_base_descr = LaunchConfiguration('use_base_descr', default='false')
-    xacro_path = ''
-    if use_base_descr.perform(context) == 'true':
-        xacro_path = os.path.join(bringup_dir, 'urdf', 'base_descr.urdf.xacro')
+    bringup_dir = get_package_share_directory("depthai_descriptions")
+    use_base_descr = LaunchConfiguration("use_base_descr", default="false")
+    xacro_path = ""
+    if use_base_descr.perform(context) == "true":
+        xacro_path = os.path.join(bringup_dir, "urdf", "base_descr.urdf.xacro")
     else:
-        xacro_path = os.path.join(bringup_dir, 'urdf', 'depthai_descr.urdf.xacro')
+        xacro_path = os.path.join(bringup_dir, "urdf", "depthai_descr.urdf.xacro")
 
-    camera_model = LaunchConfiguration('camera_model',  default='OAK-D')
-    tf_prefix = LaunchConfiguration('tf_prefix',     default='oak')
-    base_frame = LaunchConfiguration('base_frame',    default='oak-d_frame')
-    parent_frame = LaunchConfiguration(
-        'parent_frame',  default='oak-d-base-frame')
-    cam_pos_x = LaunchConfiguration('cam_pos_x',     default='0.0')
-    cam_pos_y = LaunchConfiguration('cam_pos_y',     default='0.0')
-    cam_pos_z = LaunchConfiguration('cam_pos_z',     default='0.0')
-    cam_roll = LaunchConfiguration('cam_roll',      default='1.5708')
-    cam_pitch = LaunchConfiguration('cam_pitch',     default='0.0')
-    cam_yaw = LaunchConfiguration('cam_yaw',       default='1.5708')
-    namespace = LaunchConfiguration('namespace',     default='')
-    rs_compat = LaunchConfiguration('rs_compat', default='false')
-    use_composition = LaunchConfiguration('use_composition', default='false')
+    camera_model = LaunchConfiguration("camera_model", default="OAK-D")
+    tf_prefix = LaunchConfiguration("tf_prefix", default="oak")
+    base_frame = LaunchConfiguration("base_frame", default="oak-d_frame")
+    parent_frame = LaunchConfiguration("parent_frame", default="oak-d-base-frame")
+    cam_pos_x = LaunchConfiguration("cam_pos_x", default="0.0")
+    cam_pos_y = LaunchConfiguration("cam_pos_y", default="0.0")
+    cam_pos_z = LaunchConfiguration("cam_pos_z", default="0.0")
+    cam_roll = LaunchConfiguration("cam_roll", default="1.5708")
+    cam_pitch = LaunchConfiguration("cam_pitch", default="0.0")
+    cam_yaw = LaunchConfiguration("cam_yaw", default="1.5708")
+    namespace = LaunchConfiguration("namespace", default="")
+    rs_compat = LaunchConfiguration("rs_compat", default="false")
+    use_composition = LaunchConfiguration("use_composition", default="false")
 
-    name = LaunchConfiguration('tf_prefix').perform(context)
-
+    name = LaunchConfiguration("tf_prefix").perform(context)
+    robot_description = {
+        "robot_description": Command(
+            [
+                "xacro",
+                " ",
+                xacro_path,
+                " ",
+                "camera_name:=",
+                tf_prefix,
+                " ",
+                "camera_model:=",
+                camera_model,
+                " ",
+                "base_frame:=",
+                base_frame,
+                " ",
+                "parent_frame:=",
+                parent_frame,
+                " ",
+                "cam_pos_x:=",
+                cam_pos_x,
+                " ",
+                "cam_pos_y:=",
+                cam_pos_y,
+                " ",
+                "cam_pos_z:=",
+                cam_pos_z,
+                " ",
+                "cam_roll:=",
+                cam_roll,
+                " ",
+                "cam_pitch:=",
+                cam_pitch,
+                " ",
+                "cam_yaw:=",
+                cam_yaw,
+                " ",
+                "rs_compat:=",
+                rs_compat,
+            ]
+        )
+    }
     return [
         Node(
-            package='robot_state_publisher',
+            package="robot_state_publisher",
             condition=UnlessCondition(use_composition),
-            executable='robot_state_publisher',
-            name=name+'_state_publisher',
+            executable="robot_state_publisher",
+            name=name + "_state_publisher",
             namespace=namespace,
-            parameters=[{'robot_description': Command(
-                [
-                    'xacro', ' ', xacro_path, ' ',
-                    'camera_name:=', tf_prefix, ' ',
-                    'camera_model:=', camera_model, ' ',
-                    'base_frame:=', base_frame, ' ',
-                    'parent_frame:=', parent_frame, ' ',
-                    'cam_pos_x:=', cam_pos_x, ' ',
-                    'cam_pos_y:=', cam_pos_y, ' ',
-                    'cam_pos_z:=', cam_pos_z, ' ',
-                    'cam_roll:=', cam_roll, ' ',
-                    'cam_pitch:=', cam_pitch, ' ',
-                    'cam_yaw:=', cam_yaw, ' ',
-                    'rs_compat:=', rs_compat
-                ])}]
-            ),
-            LoadComposableNodes(
-            target_container=namespace.perform(context)+"/"+name+'_container',
+            parameters=[robot_description],
+        ),
+        LoadComposableNodes(
+            target_container=f"{namespace.perform(context)}/{name}_container",
             condition=IfCondition(use_composition),
             composable_node_descriptions=[
                 ComposableNode(
-                    package='robot_state_publisher',
-                    plugin='robot_state_publisher::RobotStatePublisher',
-                    name=name+'_state_publisher',
+                    package="robot_state_publisher",
+                    plugin="robot_state_publisher::RobotStatePublisher",
+                    name=name + "_state_publisher",
                     namespace=namespace,
-                    parameters=[{'robot_description': Command(
-                        [
-                            'xacro', ' ', xacro_path, ' ',
-                            'camera_name:=', tf_prefix, ' ',
-                            'camera_model:=', camera_model, ' ',
-                            'base_frame:=', base_frame, ' ',
-                            'parent_frame:=', parent_frame, ' ',
-                            'cam_pos_x:=', cam_pos_x, ' ',
-                            'cam_pos_y:=', cam_pos_y, ' ',
-                            'cam_pos_z:=', cam_pos_z, ' ',
-                            'cam_roll:=', cam_roll, ' ',
-                            'cam_pitch:=', cam_pitch, ' ',
-                            'cam_yaw:=', cam_yaw, ' ',
-                            'rs_compat:=', rs_compat
-                        ])}]
-                )])
-            ]
+                    parameters=[robot_description],
+                )
+            ],
+        ),
+    ]
 
 
 def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
-            'namespace',
-            default_value='',
-            description='Specifies the namespace of the robot state publisher node. Default value will be ""'),
+            "namespace",
+            default_value="",
+            description='Specifies the namespace of the robot state publisher node. Default value will be ""',
+        ),
         DeclareLaunchArgument(
-            'camera_model',
-            default_value='OAK-D',
-            description='The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.'),
-
+            "camera_model",
+            default_value="OAK-D",
+            description="The model of the camera. Using a wrong camera model can disable camera features. Valid models: `OAK-D, OAK-D-LITE`.",
+        ),
         DeclareLaunchArgument(
-            'tf_prefix',
-            default_value='oak',
-            description='The name of the camera. It can be different from the camera model and it will be used as node `namespace`.'),
-
+            "tf_prefix",
+            default_value="oak",
+            description="The name of the camera. It can be different from the camera model and it will be used as node `namespace`.",
+        ),
         DeclareLaunchArgument(
-            'base_frame',
-            default_value='oak-d_frame',
-            description='Name of the base link.'),
-
+            "base_frame",
+            default_value="oak-d_frame",
+            description="Name of the base link.",
+        ),
         DeclareLaunchArgument(
-            'parent_frame',
-            default_value='oak-d-base-frame',
-            description='Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.'),
-
+            "parent_frame",
+            default_value="oak-d-base-frame",
+            description="Name of the parent link from other a robot TF for example that can be connected to the base of the OAK.",
+        ),
         DeclareLaunchArgument(
-            'cam_pos_x',
-            default_value='0.0',
-            description='Position X of the camera with respect to the base frame.'),
-
+            "cam_pos_x",
+            default_value="0.0",
+            description="Position X of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'cam_pos_y',
-            default_value='0.0',
-            description='Position Y of the camera with respect to the base frame.'),
-
+            "cam_pos_y",
+            default_value="0.0",
+            description="Position Y of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'cam_pos_z',
-            default_value='0.0',
-            description='Position Z of the camera with respect to the base frame.'),
-
+            "cam_pos_z",
+            default_value="0.0",
+            description="Position Z of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'cam_roll',
-            default_value='0.0',
-            description='Roll orientation of the camera with respect to the base frame.'),
-
+            "cam_roll",
+            default_value="0.0",
+            description="Roll orientation of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'cam_pitch',
-            default_value='0.0',
-            description='Pitch orientation of the camera with respect to the base frame.'),
-
+            "cam_pitch",
+            default_value="0.0",
+            description="Pitch orientation of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'cam_yaw',
-            default_value='0.0',
-            description='Yaw orientation of the camera with respect to the base frame.'),
+            "cam_yaw",
+            default_value="0.0",
+            description="Yaw orientation of the camera with respect to the base frame.",
+        ),
         DeclareLaunchArgument(
-            'use_composition',
-            default_value='false',
-            description='Use composition to start the robot_state_publisher node. Default value will be false'),
+            "use_composition",
+            default_value="false",
+            description="Use composition to start the robot_state_publisher node. Default value will be false",
+        ),
         DeclareLaunchArgument(
-            'use_base_descr',
-            default_value='false',
-            description='Launch base description. Default value will be false'),
+            "use_base_descr",
+            default_value="false",
+            description="Launch base description. Default value will be false",
+        ),
         DeclareLaunchArgument(
-                'rs_compat',
-                default_value='false',
-                description='Enable RealSense compatibility mode. Default value will be false'),
+            "rs_compat",
+            default_value="false",
+            description="Enable RealSense compatibility mode. Default value will be false",
+        ),
     ]
 
     return LaunchDescription(

--- a/depthai_descriptions/urdf/base_descr.urdf.xacro
+++ b/depthai_descriptions/urdf/base_descr.urdf.xacro
@@ -1,21 +1,25 @@
 <?xml version="1.0"?>
 <robot name="depthai_camera" xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:arg name="camera_name"   default="oak" />
-    <xacro:arg name="camera_model"  default="OAK-D" />
-    <xacro:arg name="base_frame"    default="oak-d_frame" />
-    <xacro:arg name="parent_frame"  default="oak-d-base-frame" />
-    <xacro:arg name="cam_pos_x"     default="0.0" />
-    <xacro:arg name="cam_pos_y"     default="0.0" />
-    <xacro:arg name="cam_pos_z"     default="0.0" />
-    <xacro:arg name="cam_roll"      default="0.0" />
-    <xacro:arg name="cam_pitch"     default="0.0" />
-    <xacro:arg name="cam_yaw"       default="0.0" />
-    <xacro:arg name="has_imu"       default="false" />
+	<xacro:arg name="camera_name" default="oak" />
+	<xacro:arg name="camera_model" default="OAK-D" />
+	<xacro:arg name="base_frame" default="oak-d_frame" />
+	<xacro:arg name="parent_frame" default="oak-d-base-frame" />
+	<xacro:arg name="cam_pos_x" default="0.0" />
+	<xacro:arg name="cam_pos_y" default="0.0" />
+	<xacro:arg name="cam_pos_z" default="0.0" />
+	<xacro:arg name="cam_roll" default="0.0" />
+	<xacro:arg name="cam_pitch" default="0.0" />
+	<xacro:arg name="cam_yaw" default="0.0" />
+	<xacro:arg name="has_imu" default="false" />
 
-    <xacro:include filename="$(find depthai_descriptions)/urdf/include/base_macro.urdf.xacro"/>
+	<xacro:include filename="$(find depthai_descriptions)/urdf/include/base_macro.urdf.xacro" />
 
-    <link name="$(arg parent_frame)"/>
-    <xacro:base camera_name = "$(arg camera_name)" parent = "$(arg parent_frame)" camera_model = "$(arg camera_model)" base_frame = "$(arg base_frame)" cam_pos_x = "$(arg cam_pos_x)" cam_pos_y = "$(arg cam_pos_y)" cam_pos_z = "$(arg cam_pos_z)" cam_roll = "$(arg cam_roll)" cam_pitch = "$(arg cam_pitch)" cam_yaw = "$(arg cam_yaw)" has_imu="$(arg has_imu)"/>
+	<link name="$(arg parent_frame)" />
+	<xacro:base camera_name="$(arg camera_name)" parent="$(arg parent_frame)"
+		camera_model="$(arg camera_model)" base_frame="$(arg base_frame)"
+		cam_pos_x="$(arg cam_pos_x)" cam_pos_y="$(arg cam_pos_y)" cam_pos_z="$(arg cam_pos_z)"
+		cam_roll="$(arg cam_roll)" cam_pitch="$(arg cam_pitch)" cam_yaw="$(arg cam_yaw)"
+		has_imu="$(arg has_imu)" />
 
 </robot>

--- a/depthai_descriptions/urdf/depthai_descr.urdf.xacro
+++ b/depthai_descriptions/urdf/depthai_descr.urdf.xacro
@@ -1,20 +1,25 @@
 <?xml version="1.0"?>
 <robot name="depthai_camera" xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:arg name="camera_name"   default="oak" />
-    <xacro:arg name="camera_model"  default="OAK-D" />
-    <xacro:arg name="base_frame"    default="oak-d_frame" />
-    <xacro:arg name="parent_frame"  default="oak-d-base-frame" />
-    <xacro:arg name="cam_pos_x"     default="0.0" />
-    <xacro:arg name="cam_pos_y"     default="0.0" />
-    <xacro:arg name="cam_pos_z"     default="0.0" />
-    <xacro:arg name="cam_roll"      default="0.0" />
-    <xacro:arg name="cam_pitch"     default="0.0" />
-    <xacro:arg name="cam_yaw"       default="0.0" />
+	<xacro:arg name="camera_name" default="oak" />
+	<xacro:arg name="camera_model" default="OAK-D" />
+	<xacro:arg name="base_frame" default="oak-d_frame" />
+	<xacro:arg name="parent_frame" default="oak-d-base-frame" />
+	<xacro:arg name="cam_pos_x" default="0.0" />
+	<xacro:arg name="cam_pos_y" default="0.0" />
+	<xacro:arg name="cam_pos_z" default="0.0" />
+	<xacro:arg name="cam_roll" default="0.0" />
+	<xacro:arg name="cam_pitch" default="0.0" />
+	<xacro:arg name="cam_yaw" default="0.0" />
+	<xacro:arg name="rs_compat" default="false" />
 
-    <xacro:include filename="$(find depthai_descriptions)/urdf/include/depthai_macro.urdf.xacro"/>
+	<xacro:include filename="$(find depthai_descriptions)/urdf/include/depthai_macro.urdf.xacro" />
 
-    <link name="$(arg parent_frame)"/>
-    <xacro:depthai_camera camera_name = "$(arg camera_name)" parent = "$(arg parent_frame)" camera_model = "$(arg camera_model)" base_frame = "$(arg base_frame)" cam_pos_x = "$(arg cam_pos_x)" cam_pos_y = "$(arg cam_pos_y)" cam_pos_z = "$(arg cam_pos_z)" cam_roll = "$(arg cam_roll)" cam_pitch = "$(arg cam_pitch)" cam_yaw = "$(arg cam_yaw)"/>
+	<link name="$(arg parent_frame)" />
+	<xacro:depthai_camera camera_name="$(arg camera_name)" parent="$(arg parent_frame)"
+		camera_model="$(arg camera_model)" base_frame="$(arg base_frame)"
+		cam_pos_x="$(arg cam_pos_x)" cam_pos_y="$(arg cam_pos_y)" cam_pos_z="$(arg cam_pos_z)"
+		cam_roll="$(arg cam_roll)" cam_pitch="$(arg cam_pitch)" cam_yaw="$(arg cam_yaw)"
+		rs_compat="$(arg rs_compat)" />
 
 </robot>

--- a/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
+++ b/depthai_descriptions/urdf/include/depthai_macro.urdf.xacro
@@ -1,120 +1,139 @@
 <?xml version="1.0"?>
 <robot name="depthai_camera"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+	xmlns:xacro="http://ros.org/wiki/xacro">
 
-    <xacro:macro name="depthai_camera" params="camera_name camera_model parent base_frame 
+	<xacro:macro name="depthai_camera"
+		params="camera_name camera_model parent base_frame 
                                            cam_pos_x cam_pos_y cam_pos_z 
-                                           cam_roll cam_pitch cam_yaw r:=0.8 g:=0.8 b:=0.8 a:=0.8 simulation:=false">
+                                           cam_roll cam_pitch cam_yaw r:=0.8 g:=0.8 b:=0.8 a:=0.8 simulation:=false rs_compat:=false">
 
-        <xacro:include filename="$(find depthai_descriptions)/urdf/include/base_macro.urdf.xacro"/>
-        <xacro:property name="M_PI" value="3.1415926535897931" />
-        <xacro:property name="model" value="${camera_model}" />
-        <xacro:property name="has_imu" value="false" />
-        <xacro:property name="baseline" value="0.075" />
+		<xacro:include filename="$(find depthai_descriptions)/urdf/include/base_macro.urdf.xacro" />
+		<xacro:property name="M_PI" value="3.1415926535897931" />
+		<xacro:property name="model" value="${camera_model}" />
+		<xacro:property name="has_imu" value="false" />
+		<xacro:property name="baseline" value="0.075" />
 
-        <xacro:if value="${model in ['OAK-D-SR']}">
-            <xacro:property name="baseline" value="0.02" />
-        </xacro:if>
+		<xacro:if value="${rs_compat}">
+			<xacro:property name="frame_suffix" value="frame" />
+			<xacro:property name="optical_frame_suffix" value="optical_frame" />
+			<xacro:property name="rgb_name" value="color" />
+			<xacro:property name="left_name" value="infra2" />
+			<xacro:property name="right_name" value="infra1" />
+		</xacro:if>
+		<xacro:unless value="${rs_compat}">
+			<xacro:property name="frame_suffix" value="camera_frame" />
+			<xacro:property name="optical_frame_suffix" value="camera_optical_frame" />
+			<xacro:property name="rgb_name" value="rgb" />
+			<xacro:property name="left_name" value="left" />
+			<xacro:property name="right_name" value="right" />
+		</xacro:unless>
 
-        <xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
-            <xacro:property name="has_imu" value="true" />
-        </xacro:if>
+		<xacro:if value="${model in ['OAK-D-SR']}">
+			<xacro:property name="baseline" value="0.02" />
+		</xacro:if>
 
-        <xacro:base camera_name="${camera_name}" parent="${parent}" camera_model="${camera_model}" base_frame="${base_frame}" cam_pos_x="${cam_pos_x}" cam_pos_y="${cam_pos_y}" cam_pos_z="${cam_pos_z}" cam_roll="${cam_roll}" cam_pitch="${cam_pitch}" cam_yaw="${cam_yaw}" has_imu="${has_imu}" simulation="${simulation}"/>
+		<xacro:if value="${model in ['OAK-D', 'OAK-D-PRO', 'OAK-D-POE']}">
+			<xacro:property name="has_imu" value="true" />
+		</xacro:if>
 
-        <!-- RGB Camera -->
-        <xacro:unless value="${model in ['OAK-D-SR']}">
-            <link name="${camera_name}_rgb_camera_frame" />
+		<xacro:base camera_name="${camera_name}" parent="${parent}" camera_model="${camera_model}"
+			base_frame="${base_frame}" cam_pos_x="${cam_pos_x}" cam_pos_y="${cam_pos_y}"
+			cam_pos_z="${cam_pos_z}" cam_roll="${cam_roll}" cam_pitch="${cam_pitch}"
+			cam_yaw="${cam_yaw}" has_imu="${has_imu}" simulation="${simulation}" />
 
-            <joint name="${camera_name}_rgb_camera_joint" type="fixed">
-                <parent link="${base_frame}"/>
-                <child link="${camera_name}_rgb_camera_frame"/>
-                <origin xyz="0 0 0" rpy="0 0 0" />
-            </joint>
+		<!-- RGB Camera -->
+		<xacro:unless value="${model in ['OAK-D-SR']}">
+			<link name="${camera_name}_${rgb_name}_${frame_suffix}" />
 
-            <link name="${camera_name}_rgb_camera_optical_frame"/>
+			<joint name="${camera_name}_rgb_camera_joint" type="fixed">
+				<parent link="${base_frame}" />
+				<child link="${camera_name}_${rgb_name}_${frame_suffix}" />
+				<origin xyz="0 0 0" rpy="0 0 0" />
+			</joint>
 
-            <joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
-                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-                <parent link="${camera_name}_rgb_camera_frame"/>
-                <child link="${camera_name}_rgb_camera_optical_frame"/>
-            </joint>
-        </xacro:unless>
-        <xacro:unless value="${model in ['OAK-D-LR']}">
+			<link name="${camera_name}_${rgb_name}_${optical_frame_suffix}" />
 
-            <!-- Left Camera -->
-            <link name="${camera_name}_left_camera_frame" />
+			<joint name="${camera_name}_rgb_camera_optical_joint" type="fixed">
+				<origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}" />
+				<parent link="${camera_name}_${rgb_name}_${frame_suffix}" />
+				<child link="${camera_name}_${rgb_name}_${optical_frame_suffix}" />
+			</joint>
+		</xacro:unless>
+		<xacro:unless value="${model in ['OAK-D-LR']}">
 
-            <joint name="${camera_name}_left_camera_joint" type="fixed">
-                <parent link="${base_frame}"/>
-                <child link="${camera_name}_left_camera_frame"/>
-                <origin xyz="0 ${baseline/2} 0" rpy="0 0 0" />
-            </joint>
+			<!-- Left Camera -->
+			<link name="${camera_name}_${left_name}_${frame_suffix}" />
 
-            <link name="${camera_name}_left_camera_optical_frame"/>
+			<joint name="${camera_name}_left_camera_joint" type="fixed">
+				<parent link="${base_frame}" />
+				<child link="${camera_name}_${left_name}_${frame_suffix}" />
+				<origin xyz="0 ${baseline/2} 0" rpy="0 0 0" />
+			</joint>
 
-            <joint name="${camera_name}_left_camera_optical_joint" type="fixed">
-                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-                <parent link="${camera_name}_left_camera_frame"/>
-                <child link="${camera_name}_left_camera_optical_frame"/>
-            </joint>
+			<link name="${camera_name}_${left_name}_${optical_frame_suffix}" />
+
+			<joint name="${camera_name}_left_camera_optical_joint" type="fixed">
+				<origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}" />
+				<parent link="${camera_name}_${left_name}_${frame_suffix}" />
+				<child link="${camera_name}_${left_name}_${optical_frame_suffix}" />
+			</joint>
 
 
-            <!-- right Camera -->
-            <link name="${camera_name}_right_camera_frame" />
+			<!-- right Camera -->
+			<link name="${camera_name}_${right_name}_${frame_suffix}" />
 
-            <joint name="${camera_name}_right_camera_joint" type="fixed">
-                <parent link="${base_frame}"/>
-                <child link="${camera_name}_right_camera_frame"/>
-                <origin xyz="0 -${baseline/2} 0" rpy="0 0 0" />
-            </joint>
+			<joint name="${camera_name}_right_camera_joint" type="fixed">
+				<parent link="${base_frame}" />
+				<child link="${camera_name}_${right_name}_${frame_suffix}" />
+				<origin xyz="0 -${baseline/2} 0" rpy="0 0 0" />
+			</joint>
 
-            <link name="${camera_name}_right_camera_optical_frame"/>
+			<link name="${camera_name}_${right_name}_${optical_frame_suffix}" />
 
-            <joint name="${camera_name}_right_camera_optical_joint" type="fixed">
-                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-                <parent link="${camera_name}_right_camera_frame"/>
-                <child link="${camera_name}_right_camera_optical_frame"/>
-            </joint>
+			<joint name="${camera_name}_right_camera_optical_joint" type="fixed">
+				<origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}" />
+				<parent link="${camera_name}_${right_name}_${frame_suffix}" />
+				<child link="${camera_name}_${right_name}_${optical_frame_suffix}" />
+			</joint>
 
-        </xacro:unless>
+		</xacro:unless>
 
-        <xacro:if value="${model in ['OAK-D-LR']}">
+		<xacro:if value="${model in ['OAK-D-LR']}">
 
-            <!-- left Camera -->
-            <link name="${camera_name}_left_camera_frame" />
+			<!-- left Camera -->
+			<link name="${camera_name}_${left_name}_${frame_suffix}" />
 
-            <joint name="${camera_name}_left_camera_joint" type="fixed">
-                <parent link="${base_frame}"/>
-                <child link="${camera_name}_left_camera_frame"/>
-                <origin xyz="0 0.1 0" rpy="0 0 0" />
-            </joint>
+			<joint name="${camera_name}_left_camera_joint" type="fixed">
+				<parent link="${base_frame}" />
+				<child link="${camera_name}_${left_name}_${frame_suffix}" />
+				<origin xyz="0 0.1 0" rpy="0 0 0" />
+			</joint>
 
-            <link name="${camera_name}_left_camera_optical_frame"/>
+			<link name="${camera_name}_${left_name}_${optical_frame_suffix}" />
 
-            <joint name="${camera_name}_left_camera_optical_joint" type="fixed">
-                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-                <parent link="${camera_name}_left_camera_frame"/>
-                <child link="${camera_name}_left_camera_optical_frame"/>
-            </joint>
+			<joint name="${camera_name}_left_camera_optical_joint" type="fixed">
+				<origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}" />
+				<parent link="${camera_name}_${left_name}_${frame_suffix}" />
+				<child link="${camera_name}_${left_name}_${optical_frame_suffix}" />
+			</joint>
 
-            <!-- right Camera -->
-            <link name="${camera_name}_right_camera_frame" />
+			<!-- right Camera -->
+			<link name="${camera_name}_${right_name}_${frame_suffix}" />
 
-            <joint name="${camera_name}_right_camera_joint" type="fixed">
-                <parent link="${base_frame}"/>
-                <child link="${camera_name}_right_camera_frame"/>
-                <origin xyz="0 -0.05 0" rpy="0 0 0" />
-            </joint>
+			<joint name="${camera_name}_right_camera_joint" type="fixed">
+				<parent link="${base_frame}" />
+				<child link="${camera_name}_${right_name}_${frame_suffix}" />
+				<origin xyz="0 -0.05 0" rpy="0 0 0" />
+			</joint>
 
-            <link name="${camera_name}_right_camera_optical_frame"/>
+			<link name="${camera_name}_${right_name}_${optical_frame_suffix}" />
 
-            <joint name="${camera_name}_right_camera_optical_joint" type="fixed">
-                <origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}"/>
-                <parent link="${camera_name}_right_camera_frame"/>
-                <child link="${camera_name}_right_camera_optical_frame"/>
-            </joint>
-        </xacro:if>
-    </xacro:macro>
+			<joint name="${camera_name}_right_camera_optical_joint" type="fixed">
+				<origin xyz="0 0 0" rpy="-${M_PI/2} 0.0 -${M_PI/2}" />
+				<parent link="${camera_name}_${right_name}_${frame_suffix}" />
+				<child link="${camera_name}_${right_name}_${optical_frame_suffix}" />
+			</joint>
+		</xacro:if>
+	</xacro:macro>
 
 </robot>

--- a/depthai_examples/launch/rgb_stereo_node.launch.py
+++ b/depthai_examples/launch/rgb_stereo_node.launch.py
@@ -42,8 +42,8 @@ def generate_launch_description():
     previewHeight   = LaunchConfiguration('previewHeight',   default = 300)
 
     # IR Brightness. OAK-D-Pro only.
-    dotProjectormA   = LaunchConfiguration('dotProjectormA',     default = 0.0)
-    floodLightmA     = LaunchConfiguration('floodLightmA',       default = 0.0)
+    dotProjectorIntensity   = LaunchConfiguration('dotProjectorIntensity',     default = 0.0)
+    floodLightIntensity     = LaunchConfiguration('floodLightIntensity',       default = 0.0)
 
     declare_camera_model_cmd = DeclareLaunchArgument(
         'camera_model',
@@ -156,14 +156,14 @@ def generate_launch_description():
         default_value=previewHeight,
         description='Height of preview image')
 
-    declare_dotProjectormA_cmd = DeclareLaunchArgument(
-        'dotProjectormA',
-        default_value=dotProjectormA,
+    declare_dotProjectorIntensity_cmd = DeclareLaunchArgument(
+        'dotProjectorIntensity',
+        default_value=dotProjectorIntensity,
         description='Brightness of IR Dot projector on OAK-D-Pro in mA.')
 
-    declare_floodLightmA_cmd = DeclareLaunchArgument(
-        'floodLightmA',
-        default_value=floodLightmA,
+    declare_floodLightIntensity_cmd = DeclareLaunchArgument(
+        'floodLightIntensity',
+        default_value=floodLightIntensity,
         description='Brightness of IR Flood LED on OAK-D-Pro in mA.')
 
     urdf_launch = IncludeLaunchDescription(
@@ -196,8 +196,8 @@ def generate_launch_description():
                         {'useDepth': useDepth},
                         {'previewWidth': previewWidth},
                         {'previewHeight': previewHeight},
-                        {'dotProjectormA': dotProjectormA},
-                        {'floodLightmA': floodLightmA}])
+                        {'dotProjectorIntensity': dotProjectorIntensity},
+                        {'floodLightIntensity': floodLightIntensity}])
 
     metric_converter_node = launch_ros.actions.ComposableNodeContainer(
             name='container',
@@ -270,8 +270,8 @@ def generate_launch_description():
     ld.add_action(declare_previewWidth_cmd)
     ld.add_action(declare_previewHeight_cmd)
 
-    ld.add_action(declare_dotProjectormA_cmd)
-    ld.add_action(declare_floodLightmA_cmd)
+    ld.add_action(declare_dotProjectorIntensity_cmd)
+    ld.add_action(declare_floodLightIntensity_cmd)
 
     ld.add_action(rgb_stereo_node)
     ld.add_action(urdf_launch)

--- a/depthai_examples/launch/stereo_inertial_node.launch.py
+++ b/depthai_examples/launch/stereo_inertial_node.launch.py
@@ -73,8 +73,8 @@ def generate_launch_description():
 
     enableDotProjector = LaunchConfiguration('enableDotProjector', default = False)
     enableFloodLight   = LaunchConfiguration('enableFloodLight', default = False)
-    dotProjectormA     = LaunchConfiguration('dotProjectormA', default = 200.0)
-    floodLightmA       = LaunchConfiguration('floodLightmA', default = 200.0)
+    dotProjectorIntensity     = LaunchConfiguration('dotProjectorIntensity', default = 0.5)
+    floodLightIntensity       = LaunchConfiguration('floodLightIntensity', default = 0.5)
     enableRosBaseTimeUpdate       = LaunchConfiguration('enableRosBaseTimeUpdate', default = False)
     enableRviz         = LaunchConfiguration('enableRviz', default = True)
 
@@ -286,15 +286,15 @@ def generate_launch_description():
         default_value=enableFloodLight,
         description='Set this to true to enable the flood light for night vision (Available only on Pro models).')
    
-    declare_dotProjectormA_cmd = DeclareLaunchArgument(
-        'dotProjectormA',
-        default_value=dotProjectormA,
-        description='Set the mA at which you intend to drive the dotProjector. Default is set to 200mA.')
+    declare_dotProjectorIntensity_cmd = DeclareLaunchArgument(
+        'dotProjectorIntensity',
+        default_value=dotProjectorIntensity,
+        description='Set the mA at which you intend to drive the dotProjector. Default is set to 0.5.')
 
-    declare_floodLightmA_cmd = DeclareLaunchArgument(
-        'floodLightmA',
-        default_value=floodLightmA,
-        description='Set the mA at which you intend to drive the FloodLight. Default is set to 200mA.')
+    declare_floodLightIntensity_cmd = DeclareLaunchArgument(
+        'floodLightIntensity',
+        default_value=floodLightIntensity,
+        description='Set the mA at which you intend to drive the FloodLight. Default is set to 0.5.')
     declare_enableRosBaseTimeUpdate_cmd = DeclareLaunchArgument(
         'enableRosBaseTimeUpdate',
         default_value=enableRosBaseTimeUpdate,
@@ -364,8 +364,8 @@ def generate_launch_description():
                         
                         {'enableDotProjector':      enableDotProjector},
                         {'enableFloodLight':        enableFloodLight},
-                        {'dotProjectormA':          dotProjectormA},
-                        {'floodLightmA':            floodLightmA},
+                        {'dotProjectorIntensity':          dotProjectorIntensity},
+                        {'floodLightIntensity':            floodLightIntensity},
                         {'enableRosBaseTimeUpdate': enableRosBaseTimeUpdate}
                         ])
     
@@ -484,8 +484,8 @@ def generate_launch_description():
 
     ld.add_action(declare_enableDotProjector_cmd)
     ld.add_action(declare_enableFloodLight_cmd)
-    ld.add_action(declare_dotProjectormA_cmd)
-    ld.add_action(declare_floodLightmA_cmd)
+    ld.add_action(declare_dotProjectorIntensity_cmd)
+    ld.add_action(declare_floodLightIntensity_cmd)
 
     ld.add_action(declare_enableRviz_cmd)
 

--- a/depthai_examples/src/rgb_stereo_node.cpp
+++ b/depthai_examples/src/rgb_stereo_node.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     bool lrcheck, extended, subpixel;
     bool useVideo, usePreview, useDepth;
     int confidence, LRchecktresh, previewWidth, previewHeight;
-    float dotProjectormA, floodLightmA;
+    float dotProjectorIntensity, floodLightIntensity;
 
     node->declare_parameter("tf_prefix", "oak");
     node->declare_parameter("lrcheck", true);
@@ -150,8 +150,8 @@ int main(int argc, char** argv) {
     node->declare_parameter("useDepth", true);
     node->declare_parameter("previewWidth", 300);
     node->declare_parameter("previewHeight", 300);
-    node->declare_parameter("dotProjectormA", 0.0f);
-    node->declare_parameter("floodLightmA", 0.0f);
+    node->declare_parameter("dotProjectorIntensity", 0.0f);
+    node->declare_parameter("floodLightIntensity", 0.0f);
 
     node->get_parameter("tf_prefix", tfPrefix);
     node->get_parameter("lrcheck", lrcheck);
@@ -166,8 +166,8 @@ int main(int argc, char** argv) {
     node->get_parameter("useDepth", useDepth);
     node->get_parameter("previewWidth", previewWidth);
     node->get_parameter("previewHeight", previewHeight);
-    node->get_parameter("dotProjectormA", dotProjectormA);
-    node->get_parameter("floodLightmA", floodLightmA);
+    node->get_parameter("dotProjectorIntensity", dotProjectorIntensity);
+    node->get_parameter("floodLightIntensity", floodLightIntensity);
 
     int colorWidth, colorHeight;
     if(colorResolution == "1080p") {
@@ -204,10 +204,10 @@ int main(int argc, char** argv) {
     std::shared_ptr<rclcpp::ParameterEventHandler> param_subscriber;
     std::shared_ptr<rclcpp::ParameterCallbackHandle> dot_cb_handle, flood_cb_handle;
     auto cb = [node, &device](const rclcpp::Parameter& p) {
-        if(p.get_name() == std::string("dotProjectormA")) {
+        if(p.get_name() == std::string("dotProjectorIntensity")) {
             RCLCPP_INFO(node->get_logger(), "Updating Dot Projector current to %f", p.as_double());
             device.setIrLaserDotProjectorBrightness(static_cast<float>(p.as_double()));
-        } else if(p.get_name() == std::string("floodLightmA")) {
+        } else if(p.get_name() == std::string("floodLightIntensity")) {
             RCLCPP_INFO(node->get_logger(), "Updating Flood Light current to %f", p.as_double());
             device.setIrFloodLightBrightness(static_cast<float>(p.as_double()));
         }
@@ -216,27 +216,27 @@ int main(int argc, char** argv) {
     if(boardName.find("PRO") != std::string::npos) {
         param_subscriber = std::make_shared<rclcpp::ParameterEventHandler>(node);
 
-        dot_cb_handle = param_subscriber->add_parameter_callback("dotProjectormA", cb);
-        flood_cb_handle = param_subscriber->add_parameter_callback("floodLightmA", cb);
+        dot_cb_handle = param_subscriber->add_parameter_callback("dotProjectorIntensity", cb);
+        flood_cb_handle = param_subscriber->add_parameter_callback("floodLightIntensity", cb);
     }
 
 #else
     rclcpp::TimerBase::SharedPtr timer;
-    auto cb = [node, &device, &dotProjectormA, &floodLightmA]() {
+    auto cb = [node, &device, &dotProjectorIntensity, &floodLightIntensity]() {
         // rclcpp::Parameter p;
-        float dotProjectormATemp, floodLightmATemp;
-        node->get_parameter("dotProjectormA", dotProjectormATemp);
-        node->get_parameter("floodLightmA", floodLightmATemp);
-        if(dotProjectormATemp != dotProjectormA) {
-            dotProjectormA = dotProjectormATemp;
-            RCLCPP_INFO(node->get_logger(), "Updating Dot Projector current to %f", dotProjectormA);
-            device.setIrLaserDotProjectorBrightness(static_cast<float>(dotProjectormA));
+        float dotProjectorIntensityTemp, floodLightIntensityTemp;
+        node->get_parameter("dotProjectorIntensity", dotProjectorIntensityTemp);
+        node->get_parameter("floodLightIntensity", floodLightIntensityTemp);
+        if(dotProjectorIntensityTemp != dotProjectorIntensity) {
+            dotProjectorIntensity = dotProjectorIntensityTemp;
+            RCLCPP_INFO(node->get_logger(), "Updating Dot Projector current to %f", dotProjectorIntensity);
+            device.setIrLaserDotProjectorIntensity(static_cast<float>(dotProjectorIntensity));
         }
 
-        if(floodLightmATemp != floodLightmA) {
-            floodLightmA = floodLightmATemp;
-            RCLCPP_INFO(node->get_logger(), "Updating Flood Light current to %f", floodLightmA);
-            device.setIrFloodLightBrightness(static_cast<float>(floodLightmA));
+        if(floodLightIntensityTemp != floodLightIntensity) {
+            floodLightIntensity = floodLightIntensityTemp;
+            RCLCPP_INFO(node->get_logger(), "Updating Flood Light current to %f", floodLightIntensity);
+            device.setIrFloodLightIntensity(static_cast<float>(floodLightIntensity));
         }
     };
     if(boardName.find("PRO") != std::string::npos) {

--- a/depthai_examples/src/stereo_inertial_publisher.cpp
+++ b/depthai_examples/src/stereo_inertial_publisher.cpp
@@ -295,7 +295,7 @@ int main(int argc, char** argv) {
     bool enableSpatialDetection, enableDotProjector, enableFloodLight;
     bool usb2Mode, poeMode, syncNN;
     double angularVelCovariance, linearAccelCovariance;
-    double dotProjectormA, floodLightmA;
+    double dotProjectorIntensity, floodLightIntensity;
     bool enableRosBaseTimeUpdate;
     std::string nnName(BLOB_NAME);  // Set your blob name for the model here
 
@@ -337,8 +337,8 @@ int main(int argc, char** argv) {
 
     node->declare_parameter("enableDotProjector", false);
     node->declare_parameter("enableFloodLight", false);
-    node->declare_parameter("dotProjectormA", 200.0);
-    node->declare_parameter("floodLightmA", 200.0);
+    node->declare_parameter("dotProjectorIntensity", 0.5);
+    node->declare_parameter("floodLightIntensity", 0.5);
     node->declare_parameter("enableRosBaseTimeUpdate", false);
 
     // updating parameters if defined in launch file.
@@ -380,8 +380,8 @@ int main(int argc, char** argv) {
 
     node->get_parameter("enableDotProjector", enableDotProjector);
     node->get_parameter("enableFloodLight", enableFloodLight);
-    node->get_parameter("dotProjectormA", dotProjectormA);
-    node->get_parameter("floodLightmA", floodLightmA);
+    node->get_parameter("dotProjectorIntensity", dotProjectorIntensity);
+    node->get_parameter("floodLightIntensity", floodLightIntensity);
     node->get_parameter("enableRosBaseTimeUpdate", enableRosBaseTimeUpdate);
 
     if(resourceBaseFolder.empty()) {
@@ -485,11 +485,11 @@ int main(int argc, char** argv) {
     std::vector<std::tuple<std::string, int, int>> irDrivers = device->getIrDrivers();
     if(!irDrivers.empty()) {
         if(enableDotProjector) {
-            device->setIrLaserDotProjectorBrightness(dotProjectormA);
+            device->setIrLaserDotProjectorIntensity(dotProjectorIntensity);
         }
 
         if(enableFloodLight) {
-            device->setIrFloodLightBrightness(floodLightmA);
+            device->setIrFloodLightIntensity(floodLightIntensity);
         }
     }
 

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(
   src/param_handlers/sensor_param_handler.cpp
   src/param_handlers/feature_tracker_param_handler.cpp
   src/param_handlers/stereo_param_handler.cpp
+  src/param_handlers/sync_param_handler.cpp
 )
 
 ament_target_dependencies(${COMMON_LIB_NAME} ${COMMON_DEPS})

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(
   src/dai_nodes/sensors/mono.cpp
   src/dai_nodes/sensors/feature_tracker.cpp
   src/dai_nodes/sensors/sensor_wrapper.cpp
+  src/dai_nodes/sensors/sync.cpp
   src/dai_nodes/stereo.cpp
 )
 

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(
   src/param_handlers/sensor_param_handler.cpp
   src/param_handlers/feature_tracker_param_handler.cpp
   src/param_handlers/stereo_param_handler.cpp
+  src/param_handlers/pipeline_gen_param_handler.cpp
   src/param_handlers/sync_param_handler.cpp
 )
 

--- a/depthai_ros_driver/config/camera.yaml
+++ b/depthai_ros_driver/config/camera.yaml
@@ -1,4 +1,4 @@
-/oak:
+/**:
   ros__parameters:
     camera:
       i_enable_imu: true

--- a/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
@@ -77,10 +77,10 @@ class Camera : public rclcpp::Node {
      * Runs onConfigure();
      */
     void start();
-	/*
-	 * Since we cannot use shared_from this before the object is initialized, we need to use a timer to start the device.
-	 */
-	void indirectStart();
+    /*
+     * Since we cannot use shared_from this before the object is initialized, we need to use a timer to start the device.
+     */
+    void indirectStart();
     void restart();
     void diagCB(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg);
 
@@ -93,8 +93,8 @@ class Camera : public rclcpp::Node {
     std::shared_ptr<dai::Device> device;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
     bool camRunning = false;
-	bool initialized = false;
+    bool initialized = false;
     std::unique_ptr<dai::ros::TFPublisher> tfPub;
-	rclcpp::TimerBase::SharedPtr startTimer;
+    rclcpp::TimerBase::SharedPtr startTimer;
 };
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
@@ -77,6 +77,10 @@ class Camera : public rclcpp::Node {
      * Runs onConfigure();
      */
     void start();
+	/*
+	 * Since we cannot use shared_from this before the object is initialized, we need to use a timer to start the device.
+	 */
+	void indirectStart();
     void restart();
     void diagCB(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg);
 
@@ -89,6 +93,8 @@ class Camera : public rclcpp::Node {
     std::shared_ptr<dai::Device> device;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
     bool camRunning = false;
+	bool initialized = false;
     std::unique_ptr<dai::ros::TFPublisher> tfPub;
+	rclcpp::TimerBase::SharedPtr startTimer;
 };
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -10,6 +10,9 @@
 namespace dai {
 class Pipeline;
 class Device;
+namespace node {
+class XLinkOut;
+}  // namespace node
 }  // namespace dai
 
 namespace rclcpp {
@@ -19,6 +22,9 @@ class Parameter;
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
+namespace sensor_helpers {
+class ImagePublisher;
+}  // namespace sensor_helpers
 class BaseNode {
    public:
     /**
@@ -33,6 +39,8 @@ class BaseNode {
     virtual void updateParams(const std::vector<rclcpp::Parameter>& params);
     virtual void link(dai::Node::Input in, int linkType = 0);
     virtual dai::Node::Input getInput(int linkType = 0);
+	virtual dai::Node::Input getInputByName(const std::string& name="");
+	virtual std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType = 0);
     virtual void setupQueues(std::shared_ptr<dai::Device> device) = 0;
     /**
      * @brief      Sets the names of the queues.
@@ -45,6 +53,7 @@ class BaseNode {
      */
     virtual void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) = 0;
     virtual void closeQueues() = 0;
+	std::shared_ptr<dai::node::XLinkOut> setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name);
 
     void setNodeName(const std::string& daiNodeName);
     void setROSNodePointer(std::shared_ptr<rclcpp::Node> node);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <depthai-shared/common/CameraBoardSocket.hpp>
 #include <memory>
 #include <string>
 
@@ -65,6 +66,7 @@ class BaseNode {
      */
     std::string getTFPrefix(const std::string& frameName = "");
     bool ipcEnabled();
+    std::string getSocketName(dai::CameraBoardSocket socket);
 
    private:
     rclcpp::Node* baseNode;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -40,7 +40,7 @@ class BaseNode {
     virtual void link(dai::Node::Input in, int linkType = 0);
     virtual dai::Node::Input getInput(int linkType = 0);
 	virtual dai::Node::Input getInputByName(const std::string& name="");
-	virtual std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType = 0);
+	virtual std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers();
     virtual void setupQueues(std::shared_ptr<dai::Device> device) = 0;
     /**
      * @brief      Sets the names of the queues.

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -65,8 +65,15 @@ class BaseNode {
      * @param[in]  frameName  The frame name
      */
     std::string getTFPrefix(const std::string& frameName = "");
+	/**
+	 * @brief    Append ROS node name to the frameName given and append optical frame suffix to it.
+	 *
+	 * @param[in]  frameName  The frame name
+	 */
+	std::string getOpticalTFPrefix(const std::string& frameName = "");
     bool ipcEnabled();
     std::string getSocketName(dai::CameraBoardSocket socket);
+	bool rsCompabilityMode();
 
    private:
     rclcpp::Node* baseNode;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -53,15 +53,12 @@ class BaseNode {
      * @param      pipeline  The pipeline
      */
     virtual void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) = 0;
-    void setupOutput(std::shared_ptr<dai::Pipeline> pipeline,
-                     const std::string& qName,
-                     std::shared_ptr<dai::node::XLinkOut>& xout,
-                     std::shared_ptr<dai::node::VideoEncoder>& encoder,
-					 std::shared_ptr<sensor_helpers::ImagePublisher>& pub,
-                     std::function<void(dai::Node::Input& input)> nodeLink,
-                     bool isSynced,
-                     bool isLowBandwidth,
-                     int quality);
+    std::shared_ptr<sensor_helpers::ImagePublisher> setupOutput(std::shared_ptr<dai::Pipeline> pipeline,
+                                                                const std::string& qName,
+                                                                std::function<void(dai::Node::Input input)> nodeLink,
+                                                                bool isSynced = false,
+                                                                bool isLowBandwidth = false,
+                                                                int quality = 50);
     virtual void closeQueues() = 0;
     std::shared_ptr<dai::node::XLinkOut> setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name);
 

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -12,6 +12,7 @@ class Pipeline;
 class Device;
 namespace node {
 class XLinkOut;
+class VideoEncoder;
 }  // namespace node
 }  // namespace dai
 
@@ -39,8 +40,8 @@ class BaseNode {
     virtual void updateParams(const std::vector<rclcpp::Parameter>& params);
     virtual void link(dai::Node::Input in, int linkType = 0);
     virtual dai::Node::Input getInput(int linkType = 0);
-	virtual dai::Node::Input getInputByName(const std::string& name="");
-	virtual std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers();
+    virtual dai::Node::Input getInputByName(const std::string& name = "");
+    virtual std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers();
     virtual void setupQueues(std::shared_ptr<dai::Device> device) = 0;
     /**
      * @brief      Sets the names of the queues.
@@ -52,8 +53,17 @@ class BaseNode {
      * @param      pipeline  The pipeline
      */
     virtual void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) = 0;
+    void setupOutput(std::shared_ptr<dai::Pipeline> pipeline,
+                     const std::string& qName,
+                     std::shared_ptr<dai::node::XLinkOut>& xout,
+                     std::shared_ptr<dai::node::VideoEncoder>& encoder,
+					 std::shared_ptr<sensor_helpers::ImagePublisher>& pub,
+                     std::function<void(dai::Node::Input& input)> nodeLink,
+                     bool isSynced,
+                     bool isLowBandwidth,
+                     int quality);
     virtual void closeQueues() = 0;
-	std::shared_ptr<dai::node::XLinkOut> setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name);
+    std::shared_ptr<dai::node::XLinkOut> setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name);
 
     void setNodeName(const std::string& daiNodeName);
     void setROSNodePointer(std::shared_ptr<rclcpp::Node> node);
@@ -75,21 +85,22 @@ class BaseNode {
      * @param[in]  frameName  The frame name
      */
     std::string getTFPrefix(const std::string& frameName = "");
-	/**
-	 * @brief    Append ROS node name to the frameName given and append optical frame suffix to it.
-	 *
-	 * @param[in]  frameName  The frame name
-	 */
-	std::string getOpticalTFPrefix(const std::string& frameName = "");
+    /**
+     * @brief    Append ROS node name to the frameName given and append optical frame suffix to it.
+     *
+     * @param[in]  frameName  The frame name
+     */
+    std::string getOpticalTFPrefix(const std::string& frameName = "");
     bool ipcEnabled();
     std::string getSocketName(dai::CameraBoardSocket socket);
-	bool rsCompabilityMode();
-	rclcpp::Logger getLogger();
+    bool rsCompabilityMode();
+    rclcpp::Logger getLogger();
+
    private:
     std::shared_ptr<rclcpp::Node> baseNode;
     std::string baseDAINodeName;
     bool intraProcessEnabled;
-	rclcpp::Logger logger;
+    rclcpp::Logger logger;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "depthai/pipeline/Node.hpp"
+#include "rclcpp/logger.hpp"
 
 namespace dai {
 class Pipeline;
@@ -27,7 +28,7 @@ class BaseNode {
      * @param      node         The node
      * @param      pipeline     The pipeline
      */
-    BaseNode(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline);
     virtual ~BaseNode();
     virtual void updateParams(const std::vector<rclcpp::Parameter>& params);
     virtual void link(dai::Node::Input in, int linkType = 0);
@@ -46,13 +47,13 @@ class BaseNode {
     virtual void closeQueues() = 0;
 
     void setNodeName(const std::string& daiNodeName);
-    void setROSNodePointer(rclcpp::Node* node);
+    void setROSNodePointer(std::shared_ptr<rclcpp::Node> node);
     /**
      * @brief      Gets the ROS node pointer.
      *
      * @return     The ROS node pointer.
      */
-    rclcpp::Node* getROSNode();
+    std::shared_ptr<rclcpp::Node> getROSNode();
     /**
      * @brief      Gets the name of the node.
      *
@@ -74,11 +75,12 @@ class BaseNode {
     bool ipcEnabled();
     std::string getSocketName(dai::CameraBoardSocket socket);
 	bool rsCompabilityMode();
-
+	rclcpp::Logger getLogger();
    private:
-    rclcpp::Node* baseNode;
+    std::shared_ptr<rclcpp::Node> baseNode;
     std::string baseDAINodeName;
     bool intraProcessEnabled;
+	rclcpp::Logger logger;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -62,7 +62,7 @@ class Detection : public BaseNode {
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
         std::string socketName = getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
-        auto tfPrefix = getTFPrefix(socketName);
+        auto tfPrefix = getOpticalTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
@@ -72,8 +72,7 @@ class Detection : public BaseNode {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;
         }
-        detConverter = std::make_unique<dai::ros::ImgDetectionConverter>(
-            tfPrefix + "_camera_optical_frame", width, height, false, ph->getParam<bool>("i_get_base_device_timestamp"));
+        detConverter = std::make_unique<dai::ros::ImgDetectionConverter>(tfPrefix, width, height, false, ph->getParam<bool>("i_get_base_device_timestamp"));
         detConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         rclcpp::PublisherOptions options;
         options.qos_overriding_options = rclcpp::QosOverridingOptions();
@@ -82,7 +81,7 @@ class Detection : public BaseNode {
 
         if(ph->getParam<bool>("i_enable_passthrough")) {
             ptQ = device->getOutputQueue(ptQName, ph->getParam<int>("i_max_q_size"), false);
-            imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
+            imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false);
             imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
             infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
                 getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -129,7 +129,7 @@ class Detection : public BaseNode {
         xoutNN->setStreamName(nnQName);
         detectionNode->out.link(xoutNN->input);
         if(ph->getParam<bool>("i_enable_passthrough")) {
-            setupOutput(pipeline, ptQName, xoutPT, nullptr, ptPub, [&](dai::Node::Input& input) { detectionNode->passthrough.link(input); }, false, false, 50);
+            ptPub = setupOutput(pipeline, ptQName, [&](dai::Node::Input input) { detectionNode->passthrough.link(input); });
         }
     };
     /**

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -61,7 +61,7 @@ class Detection : public BaseNode {
      */
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
+        std::string socketName = getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
         auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/detection.hpp
@@ -89,8 +89,7 @@ class Detection : public BaseNode {
                                                                     width,
                                                                     height));
 
-            ptPub = std::make_shared<sensor_helpers::ImagePublisher>(
-                getROSNode(), "~/" + getName() + "passthrough", true, ipcEnabled(), infoManager, imageConverter);
+            ptPub->setup(getROSNode(), "~/" + getName() + "passthrough", true, ipcEnabled(), infoManager, imageConverter);
             ptPub->addQueueCB(ptQ);
         }
     };
@@ -135,6 +134,7 @@ class Detection : public BaseNode {
             xoutPT->setStreamName(ptQName);
             detectionNode->passthrough.link(xoutPT->input);
         }
+        ptPub = std::make_shared<sensor_helpers::ImagePublisher>();
     };
     /**
      * @brief      Closes the queues for the DetectionNetwork node and the passthrough.

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/nn_wrapper.hpp
@@ -27,7 +27,7 @@ namespace dai_nodes {
 class NNWrapper : public BaseNode {
    public:
     explicit NNWrapper(const std::string& daiNodeName,
-                       rclcpp::Node* node,
+                       std::shared_ptr<rclcpp::Node> node,
                        std::shared_ptr<dai::Pipeline> pipeline,
                        const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNWrapper();

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
@@ -58,7 +58,7 @@ class Segmentation : public BaseNode {
     cv::Mat decodeDeeplab(cv::Mat mat);
     void segmentationCB(const std::string& name, const std::shared_ptr<dai::ADatatype>& data);
     std::vector<std::string> labelNames;
-    std::unique_ptr<dai::ros::ImageConverter> imageConverter;
+    std::shared_ptr<dai::ros::ImageConverter> imageConverter;
     std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager;
     image_transport::CameraPublisher nnPub, ptPub;
     sensor_msgs::msg::CameraInfo nnInfo;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/segmentation.hpp
@@ -42,7 +42,7 @@ namespace nn {
 class Segmentation : public BaseNode {
    public:
     Segmentation(const std::string& daiNodeName,
-                 rclcpp::Node* node,
+                 std::shared_ptr<rclcpp::Node> node,
                  std::shared_ptr<dai::Pipeline> pipeline,
                  const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~Segmentation();

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -78,7 +78,7 @@ class SpatialDetection : public BaseNode {
                                                                   width,
                                                                   height));
 
-			ptPub = std::make_shared<sensor_helpers::ImagePublisher>(getROSNode(), "~/" + getName() + "/passthrough", true, ipcEnabled(), ptInfoMan, ptImageConverter);
+			ptPub->setup(getROSNode(), "~/" + getName() + "/passthrough", true, ipcEnabled(), ptInfoMan, ptImageConverter);
 			ptPub->addQueueCB(ptQ);
         }
 
@@ -99,8 +99,7 @@ class SpatialDetection : public BaseNode {
                                                                        ph->getOtherNodeParam<int>("stereo", "i_width"),
                                                                        ph->getOtherNodeParam<int>("stereo", "i_height")));
 
-			ptDepthPub = std::make_shared<sensor_helpers::ImagePublisher>(
-				getROSNode(), "~/" + getName() + "/passthrough_depth", true, ipcEnabled(), ptDepthInfoMan, ptDepthImageConverter);
+				ptDepthPub->setup(getROSNode(), "~/" + getName() + "/passthrough_depth", true, ipcEnabled(), ptDepthInfoMan, ptDepthImageConverter);
 			ptDepthPub->addQueueCB(ptDepthQ);
         }
     };
@@ -130,11 +129,13 @@ class SpatialDetection : public BaseNode {
             xoutPT = pipeline->create<dai::node::XLinkOut>();
             xoutPT->setStreamName(ptQName);
             spatialNode->passthrough.link(xoutPT->input);
+			ptPub = std::make_shared<sensor_helpers::ImagePublisher>();
         }
         if(ph->getParam<bool>("i_enable_passthrough_depth")) {
             xoutPTDepth = pipeline->create<dai::node::XLinkOut>();
             xoutPTDepth->setStreamName(ptDepthQName);
             spatialNode->passthroughDepth.link(xoutPTDepth->input);
+			ptDepthPub = std::make_shared<sensor_helpers::ImagePublisher>();
         }
     };
     void closeQueues() override {

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -50,7 +50,7 @@ class SpatialDetection : public BaseNode {
     };
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
-        std::string socketName = utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
+        std::string socketName = getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
         auto tfPrefix = getTFPrefix(socketName);
         int width;
         int height;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -51,7 +51,7 @@ class SpatialDetection : public BaseNode {
     void setupQueues(std::shared_ptr<dai::Device> device) override {
         nnQ = device->getOutputQueue(nnQName, ph->getParam<int>("i_max_q_size"), false);
         std::string socketName = getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")));
-        auto tfPrefix = getTFPrefix(socketName);
+        auto tfPrefix = getOpticalTFPrefix(socketName);
         int width;
         int height;
         if(ph->getParam<bool>("i_disable_resize")) {
@@ -61,8 +61,7 @@ class SpatialDetection : public BaseNode {
             width = imageManip->initialConfig.getResizeConfig().width;
             height = imageManip->initialConfig.getResizeConfig().height;
         }
-        detConverter = std::make_unique<dai::ros::SpatialDetectionConverter>(
-            tfPrefix + "_camera_optical_frame", width, height, false, ph->getParam<bool>("i_get_base_device_timestamp"));
+        detConverter = std::make_unique<dai::ros::SpatialDetectionConverter>(tfPrefix, width, height, false, ph->getParam<bool>("i_get_base_device_timestamp"));
         detConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         nnQ->addCallback(std::bind(&SpatialDetection::spatialCB, this, std::placeholders::_1, std::placeholders::_2));
         rclcpp::PublisherOptions options;
@@ -71,7 +70,7 @@ class SpatialDetection : public BaseNode {
 
         if(ph->getParam<bool>("i_enable_passthrough")) {
             ptQ = device->getOutputQueue(ptQName, ph->getParam<int>("i_max_q_size"), false);
-            ptImageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
+            ptImageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false);
             ptImageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
             ptInfoMan = std::make_shared<camera_info_manager::CameraInfoManager>(
                 getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
@@ -92,7 +91,7 @@ class SpatialDetection : public BaseNode {
                 tfPrefix = getTFPrefix("right");
             };
             ptDepthQ = device->getOutputQueue(ptDepthQName, ph->getParam<int>("i_max_q_size"), false);
-            ptDepthImageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
+            ptDepthImageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false);
             ptDepthImageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
             ptDepthInfoMan = std::make_shared<camera_info_manager::CameraInfoManager>(
                 getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/feature_tracker.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/feature_tracker.hpp
@@ -31,7 +31,7 @@ namespace dai_nodes {
 
 class FeatureTracker : public BaseNode {
    public:
-    explicit FeatureTracker(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    explicit FeatureTracker(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline);
     ~FeatureTracker();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/imu.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/imu.hpp
@@ -33,7 +33,10 @@ namespace dai_nodes {
 
 class Imu : public BaseNode {
    public:
-    explicit Imu(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, std::shared_ptr<dai::Device> device);
+    explicit Imu(const std::string& daiNodeName,
+                 std::shared_ptr<rclcpp::Node> node,
+                 std::shared_ptr<dai::Pipeline> pipeline,
+                 std::shared_ptr<dai::Device> device);
     ~Imu();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/imu.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/imu.hpp
@@ -33,7 +33,7 @@ namespace dai_nodes {
 
 class Imu : public BaseNode {
    public:
-    explicit Imu(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, std::shared_ptr<dai::Device> device);
+    explicit Imu(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, std::shared_ptr<dai::Device> device);
     ~Imu();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -54,6 +54,7 @@ class Mono : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
+	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
 
    private:
     std::shared_ptr<dai::ros::ImageConverter> imageConverter;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -54,7 +54,7 @@ class Mono : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
+	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     std::shared_ptr<dai::ros::ImageConverter> imageConverter;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -1,11 +1,6 @@
 #pragma once
 
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
-#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
-#include "image_transport/camera_publisher.hpp"
-#include "image_transport/image_transport.hpp"
-#include "sensor_msgs/msg/camera_info.hpp"
-#include "sensor_msgs/msg/image.hpp"
 
 namespace dai {
 class Pipeline;
@@ -38,6 +33,11 @@ namespace param_handlers {
 class SensorParamHandler;
 }
 namespace dai_nodes {
+namespace sensor_helpers {
+struct ImageSensor;
+class ImagePublisher;
+}
+
 
 class Mono : public BaseNode {
    public:
@@ -56,10 +56,8 @@ class Mono : public BaseNode {
     void closeQueues() override;
 
    private:
-    std::unique_ptr<dai::ros::ImageConverter> imageConverter;
-    image_transport::CameraPublisher monoPubIT;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr monoPub;
-    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub;
+    std::shared_ptr<dai::ros::ImageConverter> imageConverter;
+	std::shared_ptr<sensor_helpers::ImagePublisher> imagePublisher;
     std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager;
     std::shared_ptr<dai::node::MonoCamera> monoCamNode;
     std::shared_ptr<dai::node::VideoEncoder> videoEnc;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -42,7 +42,7 @@ class ImagePublisher;
 class Mono : public BaseNode {
    public:
     explicit Mono(const std::string& daiNodeName,
-                  rclcpp::Node* node,
+                  std::shared_ptr<rclcpp::Node> node,
                   std::shared_ptr<dai::Pipeline> pipeline,
                   dai::CameraBoardSocket socket,
                   sensor_helpers::ImageSensor sensor,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/mono.hpp
@@ -5,28 +5,18 @@
 namespace dai {
 class Pipeline;
 class Device;
-class DataOutputQueue;
 class DataInputQueue;
 class ADatatype;
 namespace node {
 class MonoCamera;
 class XLinkIn;
-class XLinkOut;
-class VideoEncoder;
 }  // namespace node
-namespace ros {
-class ImageConverter;
-}
 }  // namespace dai
 
 namespace rclcpp {
 class Node;
 class Parameter;
 }  // namespace rclcpp
-
-namespace camera_info_manager {
-class CameraInfoManager;
-}
 
 namespace depthai_ros_driver {
 namespace param_handlers {
@@ -36,8 +26,7 @@ namespace dai_nodes {
 namespace sensor_helpers {
 struct ImageSensor;
 class ImagePublisher;
-}
-
+}  // namespace sensor_helpers
 
 class Mono : public BaseNode {
    public:
@@ -54,18 +43,13 @@ class Mono : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
+    std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
-    std::shared_ptr<dai::ros::ImageConverter> imageConverter;
-	std::shared_ptr<sensor_helpers::ImagePublisher> imagePublisher;
-    std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager;
+    std::shared_ptr<sensor_helpers::ImagePublisher> imagePublisher;
     std::shared_ptr<dai::node::MonoCamera> monoCamNode;
-    std::shared_ptr<dai::node::VideoEncoder> videoEnc;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
-    std::shared_ptr<dai::DataOutputQueue> monoQ;
     std::shared_ptr<dai::DataInputQueue> controlQ;
-    std::shared_ptr<dai::node::XLinkOut> xoutMono;
     std::shared_ptr<dai::node::XLinkIn> xinControl;
     std::string monoQName, controlQName;
 };

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
-#include "image_transport/camera_publisher.hpp"
-#include "image_transport/image_transport.hpp"
-#include "sensor_msgs/msg/camera_info.hpp"
-#include "sensor_msgs/msg/image.hpp"
 
 namespace dai {
 class Pipeline;
@@ -47,7 +43,7 @@ class ImagePublisher;
 class RGB : public BaseNode {
    public:
     explicit RGB(const std::string& daiNodeName,
-                 rclcpp::Node* node,
+                 std::shared_ptr<rclcpp::Node> node,
                  std::shared_ptr<dai::Pipeline> pipeline,
                  dai::CameraBoardSocket socket,
                  sensor_helpers::ImageSensor sensor,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -58,13 +58,10 @@ class RGB : public BaseNode {
 	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
-    std::shared_ptr<dai::ros::ImageConverter> imageConverter;
 	std::shared_ptr<sensor_helpers::ImagePublisher> rgbPub, previewPub;
-    std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager, previewInfoManager;
     std::shared_ptr<dai::node::ColorCamera> colorCamNode;
     std::shared_ptr<dai::node::VideoEncoder> videoEnc;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
-    std::shared_ptr<dai::DataOutputQueue> colorQ, previewQ;
     std::shared_ptr<dai::DataInputQueue> controlQ;
     std::shared_ptr<dai::node::XLinkOut> xoutColor, xoutPreview;
     std::shared_ptr<dai::node::XLinkIn> xinControl;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -41,6 +41,7 @@ namespace dai_nodes {
 
 namespace sensor_helpers {
 struct ImageSensor;
+class ImagePublisher;
 }
 
 class RGB : public BaseNode {
@@ -60,10 +61,8 @@ class RGB : public BaseNode {
     void closeQueues() override;
 
    private:
-    std::unique_ptr<dai::ros::ImageConverter> imageConverter;
-    image_transport::CameraPublisher rgbPubIT, previewPubIT;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr rgbPub, previewPub;
-    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr rgbInfoPub, previewInfoPub;
+    std::shared_ptr<dai::ros::ImageConverter> imageConverter;
+	std::shared_ptr<sensor_helpers::ImagePublisher> rgbPub, previewPub;
     std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager, previewInfoManager;
     std::shared_ptr<dai::node::ColorCamera> colorCamNode;
     std::shared_ptr<dai::node::VideoEncoder> videoEnc;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -55,6 +55,7 @@ class RGB : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
+	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
 
    private:
     std::shared_ptr<dai::ros::ImageConverter> imageConverter;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -5,29 +5,19 @@
 namespace dai {
 class Pipeline;
 class Device;
-class DataOutputQueue;
 class DataInputQueue;
 enum class CameraBoardSocket;
 class ADatatype;
 namespace node {
 class ColorCamera;
 class XLinkIn;
-class XLinkOut;
-class VideoEncoder;
 }  // namespace node
-namespace ros {
-class ImageConverter;
-}
 }  // namespace dai
 
 namespace rclcpp {
 class Node;
 class Parameter;
 }  // namespace rclcpp
-
-namespace camera_info_manager {
-class CameraInfoManager;
-}
 
 namespace depthai_ros_driver {
 namespace param_handlers {
@@ -38,7 +28,7 @@ namespace dai_nodes {
 namespace sensor_helpers {
 struct ImageSensor;
 class ImagePublisher;
-}
+}  // namespace sensor_helpers
 
 class RGB : public BaseNode {
    public:
@@ -55,15 +45,13 @@ class RGB : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
+    std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
-	std::shared_ptr<sensor_helpers::ImagePublisher> rgbPub, previewPub;
+    std::shared_ptr<sensor_helpers::ImagePublisher> rgbPub, previewPub;
     std::shared_ptr<dai::node::ColorCamera> colorCamNode;
-    std::shared_ptr<dai::node::VideoEncoder> videoEnc;
     std::unique_ptr<param_handlers::SensorParamHandler> ph;
     std::shared_ptr<dai::DataInputQueue> controlQ;
-    std::shared_ptr<dai::node::XLinkOut> xoutColor, xoutPreview;
     std::shared_ptr<dai::node::XLinkIn> xinControl;
     std::string ispQName, previewQName, controlQName;
 };

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/rgb.hpp
@@ -55,7 +55,7 @@ class RGB : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
+	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     std::shared_ptr<dai::ros::ImageConverter> imageConverter;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -42,17 +42,23 @@ enum class RGBLinkType { video, isp, preview };
 namespace sensor_helpers {
 class ImagePublisher {
    public:
-    ImagePublisher(std::shared_ptr<rclcpp::Node> node,
-                   const std::string& name,
-                   bool lazyPub,
-                   bool ipcEnabled,
-                   std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
-                   std::shared_ptr<dai::ros::ImageConverter> converter,
-				   const std::string& topicSuffix = "/image_raw");
+	ImagePublisher(){};
     ~ImagePublisher();
+	void setup(std::shared_ptr<rclcpp::Node> node,
+				   const std::string& name,
+				   bool lazyPub,
+				   bool ipcEnabled,
+				   std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
+				   std::shared_ptr<dai::ros::ImageConverter> converter,
+				   const std::string& topicSuffix = "/image_raw");
     void addQueueCB(const std::shared_ptr<dai::DataOutputQueue>& queue);
     void removeQueueCB();
     void publish(const std::shared_ptr<dai::ADatatype>& data);
+	void setQueueName(const std::string& name);
+	void setSynced(bool sync);
+    std::string getQueueName();
+    void publish(std::pair<sensor_msgs::msg::Image::UniquePtr, sensor_msgs::msg::CameraInfo::UniquePtr> data);
+    std::pair<sensor_msgs::msg::Image::UniquePtr, sensor_msgs::msg::CameraInfo::UniquePtr> convertData(const std::shared_ptr<dai::ADatatype> data);
 
    private:
     std::string name;
@@ -65,6 +71,8 @@ class ImagePublisher {
     image_transport::CameraPublisher imgPubIT;
     std::shared_ptr<dai::DataOutputQueue> dataQ;
     int cbID;
+	std::string qName;
+	bool synced;
 };
 enum class NodeNameEnum { RGB, Left, Right, Stereo, IMU, NN };
 struct ImageSensor {

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -76,6 +76,11 @@ struct ImgPublisherConfig {
 };
 class ImagePublisher {
    public:
+	/**
+	 * @brief Construct a new Image Publisher object
+	 *
+	 * Creates XLinkOut if synced and VideoEncoder if lowBandwidth is enabled. linkFunc is stored and returned when link is called.
+	 */
     ImagePublisher(std::shared_ptr<rclcpp::Node> node,
                    std::shared_ptr<dai::Pipeline> pipeline,
                    const std::string& qName,
@@ -86,17 +91,20 @@ class ImagePublisher {
                    int lowBandwidthQuality = 50);
 
     ~ImagePublisher();
+	/**
+	 * @brief Setup the image publisher
+	 *	
+	 * Creates Publishers, ImageConverter and CameraInfoManager. Creates a Queue and adds a callback if not synced.
+	 */
     void setup(std::shared_ptr<dai::Device> device, const ImgConverterConfig& convConf, const ImgPublisherConfig& pubConf);
     void createImageConverter(std::shared_ptr<dai::Device> device);
     void createInfoManager(std::shared_ptr<dai::Device> device);
     void addQueueCB(const std::shared_ptr<dai::DataOutputQueue>& queue);
     void closeQueue();
     std::shared_ptr<dai::DataOutputQueue> getQueue();
-    void publish(const std::shared_ptr<dai::ADatatype>& data);
-    void setQueueName(const std::string& name);
-    void setSynced(bool sync);
     void link(dai::Node::Input in);
     std::string getQueueName();
+    void publish(const std::shared_ptr<dai::ADatatype>& data);
     void publish(std::pair<sensor_msgs::msg::Image::UniquePtr, sensor_msgs::msg::CameraInfo::UniquePtr> data);
     std::pair<sensor_msgs::msg::Image::UniquePtr, sensor_msgs::msg::CameraInfo::UniquePtr> convertData(const std::shared_ptr<dai::ADatatype> data);
 

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -54,6 +54,7 @@ extern const std::unordered_map<std::string, dai::MonoCameraProperties::SensorRe
 extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
+bool rsCompabilityMode(rclcpp::Node* node);
 std::string getSocketName(rclcpp::Node* node, dai::CameraBoardSocket socket);
 std::string getNodeName(rclcpp::Node* node, NodeNameEnum name);
 void basicCameraPub(const std::string& /*name*/,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -76,11 +76,11 @@ struct ImgPublisherConfig {
 };
 class ImagePublisher {
    public:
-	/**
-	 * @brief Construct a new Image Publisher object
-	 *
-	 * Creates XLinkOut if synced and VideoEncoder if lowBandwidth is enabled. linkFunc is stored and returned when link is called.
-	 */
+    /**
+     * @brief Construct a new Image Publisher object
+     *
+     * Creates XLinkOut if synced and VideoEncoder if lowBandwidth is enabled. linkFunc is stored and returned when link is called.
+     */
     ImagePublisher(std::shared_ptr<rclcpp::Node> node,
                    std::shared_ptr<dai::Pipeline> pipeline,
                    const std::string& qName,
@@ -91,11 +91,11 @@ class ImagePublisher {
                    int lowBandwidthQuality = 50);
 
     ~ImagePublisher();
-	/**
-	 * @brief Setup the image publisher
-	 *	
-	 * Creates Publishers, ImageConverter and CameraInfoManager. Creates a Queue and adds a callback if not synced.
-	 */
+    /**
+     * @brief Setup the image publisher
+     *
+     * Creates Publishers, ImageConverter and CameraInfoManager. Creates a Queue and adds a callback if not synced.
+     */
     void setup(std::shared_ptr<dai::Device> device, const ImgConverterConfig& convConf, const ImgPublisherConfig& pubConf);
     void createImageConverter(std::shared_ptr<dai::Device> device);
     void createInfoManager(std::shared_ptr<dai::Device> device);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -38,6 +38,7 @@ namespace link_types {
 enum class RGBLinkType { video, isp, preview };
 };
 namespace sensor_helpers {
+enum class NodeNameEnum { RGB, Left, Right, Stereo, IMU, NN };
 struct ImageSensor {
     std::string name;
     std::string defaultResolution;
@@ -46,10 +47,15 @@ struct ImageSensor {
 };
 extern std::vector<ImageSensor> availableSensors;
 extern const std::unordered_map<dai::CameraBoardSocket, std::string> socketNameMap;
+extern const std::unordered_map<dai::CameraBoardSocket, std::string> rsSocketNameMap;
+extern const std::unordered_map<NodeNameEnum, std::string> rsNodeNameMap;
+extern const std::unordered_map<NodeNameEnum, std::string> NodeNameMap;
 extern const std::unordered_map<std::string, dai::MonoCameraProperties::SensorResolution> monoResolutionMap;
 extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
+std::string getSocketName(rclcpp::Node* node, dai::CameraBoardSocket socket);
+std::string getNodeName(rclcpp::Node* node, NodeNameEnum name);
 void basicCameraPub(const std::string& /*name*/,
                     const std::shared_ptr<dai::ADatatype>& data,
                     dai::ros::ImageConverter& converter,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -42,12 +42,13 @@ enum class RGBLinkType { video, isp, preview };
 namespace sensor_helpers {
 class ImagePublisher {
    public:
-    ImagePublisher(rclcpp::Node* node,
+    ImagePublisher(std::shared_ptr<rclcpp::Node> node,
                    const std::string& name,
                    bool lazyPub,
                    bool ipcEnabled,
                    std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager,
-                   std::shared_ptr<dai::ros::ImageConverter> converter);
+                   std::shared_ptr<dai::ros::ImageConverter> converter,
+				   const std::string& topicSuffix = "/image_raw");
     ~ImagePublisher();
     void addQueueCB(const std::shared_ptr<dai::DataOutputQueue>& queue);
     void removeQueueCB();
@@ -81,9 +82,9 @@ extern const std::unordered_map<std::string, dai::MonoCameraProperties::SensorRe
 extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
-bool rsCompabilityMode(rclcpp::Node* node);
-std::string getSocketName(rclcpp::Node* node, dai::CameraBoardSocket socket);
-std::string getNodeName(rclcpp::Node* node, NodeNameEnum name);
+bool rsCompabilityMode(std::shared_ptr<rclcpp::Node> node);
+std::string getSocketName(std::shared_ptr<rclcpp::Node> node, dai::CameraBoardSocket socket);
+std::string getNodeName(std::shared_ptr<rclcpp::Node> node, NodeNameEnum name);
 void basicCameraPub(const std::string& /*name*/,
                     const std::shared_ptr<dai::ADatatype>& data,
                     dai::ros::ImageConverter& converter,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -50,7 +50,7 @@ class SensorWrapper : public BaseNode {
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
     sensor_helpers::ImageSensor getSensorData();
-	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
+	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     void subCB(const sensor_msgs::msg::Image& img);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -50,6 +50,7 @@ class SensorWrapper : public BaseNode {
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
     sensor_helpers::ImageSensor getSensorData();
+	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
 
    private:
     void subCB(const sensor_msgs::msg::Image& img);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -37,7 +37,7 @@ namespace dai_nodes {
 class SensorWrapper : public BaseNode {
    public:
     explicit SensorWrapper(const std::string& daiNodeName,
-                           rclcpp::Node* node,
+                           std::shared_ptr<rclcpp::Node> node,
                            std::shared_ptr<dai::Pipeline> pipeline,
                            std::shared_ptr<dai::Device> device,
                            dai::CameraBoardSocket socket,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp
@@ -50,7 +50,7 @@ class SensorWrapper : public BaseNode {
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
     sensor_helpers::ImageSensor getSensorData();
-	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
+    std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     void subCB(const sensor_msgs::msg::Image& img);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
@@ -40,7 +40,6 @@ class Sync : public BaseNode {
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
     void addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publisher);
-    std::vector<std::string> getSyncNames();
 
    private:
     std::unique_ptr<param_handlers::SyncParamHandler> paramHandler;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
@@ -16,11 +16,7 @@ class ImgFrame;
 namespace node {
 class Sync;
 class XLinkOut;
-class VideoEncoder;
 }  // namespace node
-namespace ros {
-class ImageConverter;
-}
 }  // namespace dai
 
 namespace rclcpp {
@@ -29,12 +25,14 @@ class Parameter;
 }  // namespace rclcpp
 
 namespace depthai_ros_driver {
+namespace param_handlers {
+class SyncParamHandler;
+}
 namespace dai_nodes {
 class Sync : public BaseNode {
    public:
     explicit Sync(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline);
     ~Sync();
-    void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;
     void link(dai::Node::Input in, int linkType = 0) override;
     dai::Node::Input getInputByName(const std::string& name = "") override;
@@ -45,6 +43,7 @@ class Sync : public BaseNode {
 	std::vector<std::string> getSyncNames();
 
    private:
+	std::unique_ptr<param_handlers::SyncParamHandler> paramHandler;
     std::shared_ptr<dai::node::Sync> syncNode;
 	std::string syncOutputName;
     std::shared_ptr<dai::node::XLinkOut> xoutFrame;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include <memory>
@@ -5,13 +6,27 @@
 #include <vector>
 
 #include "depthai-shared/common/CameraBoardSocket.hpp"
-#include "depthai_ros_driver/dai_nodes/base_node.hpp"
+#include "depthai-shared/common/CameraFeatures.hpp"
+#include "depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp"
+#include "image_transport/camera_publisher.hpp"
+#include "image_transport/image_transport.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
+#include "sensor_msgs/msg/image.hpp"
 
 namespace dai {
 class Pipeline;
 class Device;
 class DataOutputQueue;
 class ADatatype;
+class ImgFrame;
+namespace node {
+class Sync;
+class XLinkOut;
+class VideoEncoder;
+}  // namespace node
+namespace ros {
+class ImageConverter;
+}
 }  // namespace dai
 
 namespace rclcpp {
@@ -20,18 +35,11 @@ class Parameter;
 }  // namespace rclcpp
 
 namespace depthai_ros_driver {
-namespace param_handlers {
-class NNParamHandler;
-}
 namespace dai_nodes {
-
-class SpatialNNWrapper : public BaseNode {
+class Sync : public BaseNode {
    public:
-    explicit SpatialNNWrapper(const std::string& daiNodeName,
-                              std::shared_ptr<rclcpp::Node> node,
-                              std::shared_ptr<dai::Pipeline> pipeline,
-                              const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
-    ~SpatialNNWrapper();
+    explicit Sync(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline);
+    ~Sync();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;
     void link(dai::Node::Input in, int linkType = 0) override;
@@ -41,9 +49,9 @@ class SpatialNNWrapper : public BaseNode {
     void closeQueues() override;
 
    private:
-    std::unique_ptr<param_handlers::NNParamHandler> ph;
-    std::unique_ptr<BaseNode> nnNode;
+    std::shared_ptr<dai::node::Sync> syncNode;
+    std::shared_ptr<dai::node::XLinkOut> xoutFrame;
+    void publishOutputs();
 };
-
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
@@ -5,13 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "depthai-shared/common/CameraBoardSocket.hpp"
-#include "depthai-shared/common/CameraFeatures.hpp"
-#include "depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp"
-#include "image_transport/camera_publisher.hpp"
-#include "image_transport/image_transport.hpp"
-#include "sensor_msgs/msg/camera_info.hpp"
-#include "sensor_msgs/msg/image.hpp"
+#include "depthai_ros_driver/dai_nodes/base_node.hpp"
 
 namespace dai {
 class Pipeline;
@@ -43,15 +37,21 @@ class Sync : public BaseNode {
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> device) override;
     void link(dai::Node::Input in, int linkType = 0) override;
-    dai::Node::Input getInput(int linkType = 0) override;
+    dai::Node::Input getInputByName(const std::string& name = "") override;
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
+	void addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publisher);
+	std::vector<std::string> getSyncNames();
 
    private:
     std::shared_ptr<dai::node::Sync> syncNode;
+	std::string syncOutputName;
     std::shared_ptr<dai::node::XLinkOut> xoutFrame;
+	std::shared_ptr<dai::DataOutputQueue> outQueue;
     void publishOutputs();
+	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> publishers;
+	std::vector<std::string> syncNames;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sync.hpp
@@ -39,18 +39,18 @@ class Sync : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	void addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publisher);
-	std::vector<std::string> getSyncNames();
+    void addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publisher);
+    std::vector<std::string> getSyncNames();
 
    private:
-	std::unique_ptr<param_handlers::SyncParamHandler> paramHandler;
+    std::unique_ptr<param_handlers::SyncParamHandler> paramHandler;
     std::shared_ptr<dai::node::Sync> syncNode;
-	std::string syncOutputName;
+    std::string syncOutputName;
     std::shared_ptr<dai::node::XLinkOut> xoutFrame;
-	std::shared_ptr<dai::DataOutputQueue> outQueue;
+    std::shared_ptr<dai::DataOutputQueue> outQueue;
     void publishOutputs();
-	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> publishers;
-	std::vector<std::string> syncNames;
+    std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> publishers;
+    std::vector<std::string> syncNames;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai-shared/common/CameraFeatures.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp"
@@ -20,19 +19,12 @@ class StereoDepth;
 class XLinkOut;
 class VideoEncoder;
 }  // namespace node
-namespace ros {
-class ImageConverter;
-}
 }  // namespace dai
 
 namespace rclcpp {
 class Node;
 class Parameter;
 }  // namespace rclcpp
-
-namespace camera_info_manager {
-class CameraInfoManager;
-}
 
 namespace depthai_ros_driver {
 namespace param_handlers {
@@ -63,23 +55,20 @@ class Stereo : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
+    std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     void setupStereoQueue(std::shared_ptr<dai::Device> device);
     void setupLeftRectQueue(std::shared_ptr<dai::Device> device);
     void setupRightRectQueue(std::shared_ptr<dai::Device> device);
-    void setupRectQueue(std::shared_ptr<dai::Device> device,
-                        dai::CameraFeatures& sensorInfo,
-                        std::shared_ptr<sensor_helpers::ImagePublisher> pub,
-                        bool isLeft);
+    void setupRectQueue(std::shared_ptr<dai::Device> device, dai::CameraFeatures& sensorInfo, std::shared_ptr<sensor_helpers::ImagePublisher> pub, bool isLeft);
     /*
      * This callback is used to synchronize left and right rectified frames
      * It is called every 10ms and it publishes the frames if they are synchronized
      * If they are not synchronized, it prints a warning message
      */
     void syncTimerCB();
-	std::shared_ptr<sensor_helpers::ImagePublisher> stereoPub, leftRectPub, rightRectPub;
+    std::shared_ptr<sensor_helpers::ImagePublisher> stereoPub, leftRectPub, rightRectPub;
     std::shared_ptr<dai::node::StereoDepth> stereoCamNode;
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;
     std::unique_ptr<SensorWrapper> left;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -41,7 +41,7 @@ class StereoParamHandler;
 
 namespace dai_nodes {
 namespace link_types {
-enum class StereoLinkType { left, right };
+enum class StereoLinkType { stereo, left, right };
 };
 
 namespace sensor_helpers {
@@ -58,11 +58,12 @@ class Stereo : public BaseNode {
     ~Stereo();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
     void setupQueues(std::shared_ptr<dai::Device> dvice) override;
-    void link(dai::Node::Input in, int linkType = 0) override;
+    void link(dai::Node::Input in, int linkType = 1) override;
     dai::Node::Input getInput(int linkType = 0) override;
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
+	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
 
    private:
     void setupStereoQueue(std::shared_ptr<dai::Device> device);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -71,10 +71,6 @@ class Stereo : public BaseNode {
     void setupRightRectQueue(std::shared_ptr<dai::Device> device);
     void setupRectQueue(std::shared_ptr<dai::Device> device,
                         dai::CameraFeatures& sensorInfo,
-                        const std::string& queueName,
-                        std::shared_ptr<dai::ros::ImageConverter> conv,
-                        std::shared_ptr<camera_info_manager::CameraInfoManager> im,
-                        std::shared_ptr<dai::DataOutputQueue> q,
                         std::shared_ptr<sensor_helpers::ImagePublisher> pub,
                         bool isLeft);
     /*
@@ -83,16 +79,14 @@ class Stereo : public BaseNode {
      * If they are not synchronized, it prints a warning message
      */
     void syncTimerCB();
-    std::shared_ptr<dai::ros::ImageConverter> stereoConv, leftRectConv, rightRectConv;
 	std::shared_ptr<sensor_helpers::ImagePublisher> stereoPub, leftRectPub, rightRectPub;
-    std::shared_ptr<camera_info_manager::CameraInfoManager> stereoIM, leftRectIM, rightRectIM;
     std::shared_ptr<dai::node::StereoDepth> stereoCamNode;
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;
     std::unique_ptr<SensorWrapper> left;
     std::unique_ptr<SensorWrapper> right;
     std::unique_ptr<BaseNode> featureTrackerLeftR, featureTrackerRightR, nnNode;
     std::unique_ptr<param_handlers::StereoParamHandler> ph;
-    std::shared_ptr<dai::DataOutputQueue> stereoQ, leftRectQ, rightRectQ;
+    std::shared_ptr<dai::DataOutputQueue> leftRectQ, rightRectQ;
     std::shared_ptr<dai::node::XLinkOut> xoutStereo, xoutLeftRect, xoutRightRect;
     std::string stereoQName, leftRectQName, rightRectQName;
     dai::CameraFeatures leftSensInfo, rightSensInfo;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -4,13 +4,10 @@
 #include <string>
 #include <vector>
 
+
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai-shared/common/CameraFeatures.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_wrapper.hpp"
-#include "image_transport/camera_publisher.hpp"
-#include "image_transport/image_transport.hpp"
-#include "sensor_msgs/msg/camera_info.hpp"
-#include "sensor_msgs/msg/image.hpp"
 
 namespace dai {
 class Pipeline;
@@ -47,6 +44,9 @@ namespace link_types {
 enum class StereoLinkType { left, right };
 };
 
+namespace sensor_helpers {
+class ImagePubliser;
+}
 class Stereo : public BaseNode {
    public:
     explicit Stereo(const std::string& daiNodeName,
@@ -57,7 +57,7 @@ class Stereo : public BaseNode {
                     dai::CameraBoardSocket rightSocket = dai::CameraBoardSocket::CAM_C);
     ~Stereo();
     void updateParams(const std::vector<rclcpp::Parameter>& params) override;
-    void setupQueues(std::shared_ptr<dai::Device> device) override;
+    void setupQueues(std::shared_ptr<dai::Device> dvice) override;
     void link(dai::Node::Input in, int linkType = 0) override;
     dai::Node::Input getInput(int linkType = 0) override;
     void setNames() override;
@@ -71,12 +71,10 @@ class Stereo : public BaseNode {
     void setupRectQueue(std::shared_ptr<dai::Device> device,
                         dai::CameraFeatures& sensorInfo,
                         const std::string& queueName,
-                        std::unique_ptr<dai::ros::ImageConverter>& conv,
-                        std::shared_ptr<camera_info_manager::CameraInfoManager>& im,
-                        std::shared_ptr<dai::DataOutputQueue>& q,
-                        rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub,
-                        rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub,
-                        image_transport::CameraPublisher& pubIT,
+                        std::shared_ptr<dai::ros::ImageConverter> conv,
+                        std::shared_ptr<camera_info_manager::CameraInfoManager> im,
+                        std::shared_ptr<dai::DataOutputQueue> q,
+                        std::shared_ptr<sensor_helpers::ImagePublisher> pub,
                         bool isLeft);
     /*
      * This callback is used to synchronize left and right rectified frames
@@ -84,10 +82,8 @@ class Stereo : public BaseNode {
      * If they are not synchronized, it prints a warning message
      */
     void syncTimerCB();
-    std::unique_ptr<dai::ros::ImageConverter> stereoConv, leftRectConv, rightRectConv;
-    image_transport::CameraPublisher stereoPubIT, leftRectPubIT, rightRectPubIT;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr stereoPub, leftRectPub, rightRectPub;
-    rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr stereoInfoPub, leftRectInfoPub, rightRectInfoPub;
+    std::shared_ptr<dai::ros::ImageConverter> stereoConv, leftRectConv, rightRectConv;
+	std::shared_ptr<sensor_helpers::ImagePublisher> stereoPub, leftRectPub, rightRectPub;
     std::shared_ptr<camera_info_manager::CameraInfoManager> stereoIM, leftRectIM, rightRectIM;
     std::shared_ptr<dai::node::StereoDepth> stereoCamNode;
     std::shared_ptr<dai::node::VideoEncoder> stereoEnc, leftRectEnc, rightRectEnc;

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -63,7 +63,7 @@ class Stereo : public BaseNode {
     void setNames() override;
     void setXinXout(std::shared_ptr<dai::Pipeline> pipeline) override;
     void closeQueues() override;
-	std::shared_ptr<sensor_helpers::ImagePublisher> getPublisher(int linkType=0) override;
+	std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> getPublishers() override;
 
    private:
     void setupStereoQueue(std::shared_ptr<dai::Device> device);

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/stereo.hpp
@@ -50,7 +50,7 @@ class ImagePubliser;
 class Stereo : public BaseNode {
    public:
     explicit Stereo(const std::string& daiNodeName,
-                    rclcpp::Node* node,
+                    std::shared_ptr<rclcpp::Node> node,
                     std::shared_ptr<dai::Pipeline> pipeline,
                     std::shared_ptr<dai::Device> device,
                     dai::CameraBoardSocket leftSocket = dai::CameraBoardSocket::CAM_B,

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sys_logger.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sys_logger.hpp
@@ -22,7 +22,7 @@ namespace depthai_ros_driver {
 namespace dai_nodes {
 class SysLogger : public BaseNode {
    public:
-    SysLogger(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline);
+    SysLogger(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline);
     ~SysLogger();
     void setupQueues(std::shared_ptr<dai::Device> device) override;
     void setNames() override;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
@@ -18,7 +18,7 @@ inline rcl_interfaces::msg::ParameterDescriptor getRangedIntDescriptor(uint16_t 
 }
 class BaseParamHandler {
    public:
-    BaseParamHandler(rclcpp::Node* node, const std::string& name) : baseName(name), baseNode(node){};
+    BaseParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : baseName(name), baseNode(node){};
     virtual ~BaseParamHandler() = default;
     virtual dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) = 0;
     std::string getName() {
@@ -50,7 +50,7 @@ class BaseParamHandler {
     }
 
    protected:
-    rclcpp::Node* getROSNode() {
+    std::shared_ptr<rclcpp::Node> getROSNode() {
         return baseNode;
     }
     template <typename T>
@@ -114,7 +114,7 @@ class BaseParamHandler {
         RCLCPP_DEBUG(baseNode->get_logger(), "Setting param %s with value %s", name.c_str(), ss.str().c_str());
     }
     std::string baseName;
-    rclcpp::Node* baseNode;
+    std::shared_ptr<rclcpp::Node> baseNode;
 };
 }  // namespace param_handlers
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include <depthai-shared/common/CameraBoardSocket.hpp>
+
 #include "depthai/pipeline/datatype/CameraControl.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rclcpp/node.hpp"
@@ -15,10 +18,7 @@ inline rcl_interfaces::msg::ParameterDescriptor getRangedIntDescriptor(uint16_t 
 }
 class BaseParamHandler {
    public:
-    BaseParamHandler(rclcpp::Node* node, const std::string& name) {
-        baseName = name;
-        baseNode = node;
-    };
+    BaseParamHandler(rclcpp::Node* node, const std::string& name) : baseName(name), baseNode(node){};
     virtual ~BaseParamHandler() = default;
     virtual dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) = 0;
     std::string getName() {
@@ -43,6 +43,10 @@ class BaseParamHandler {
     std::string getFullParamName(const std::string& daiNodeName, const std::string& paramName) {
         std::string name = daiNodeName + "." + paramName;
         return name;
+    }
+
+    std::string getSocketName(dai::CameraBoardSocket socket) {
+        return dai_nodes::sensor_helpers::getSocketName(getROSNode(), socket);
     }
 
    protected:

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include <depthai-shared/common/CameraBoardSocket.hpp>
 
 #include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rclcpp/node.hpp"
 namespace depthai_ros_driver {

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/base_param_handler.hpp
@@ -25,7 +25,7 @@ class BaseParamHandler {
         return baseName;
     }
     template <typename T>
-    T getParam(const std::string paramName) {
+    T getParam(const std::string& paramName) {
         T value;
         baseNode->get_parameter<T>(getFullParamName(paramName), value);
         return value;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/camera_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/camera_param_handler.hpp
@@ -19,7 +19,7 @@ namespace param_handlers {
 
 class CameraParamHandler : public BaseParamHandler {
    public:
-    explicit CameraParamHandler(rclcpp::Node* node, const std::string& name);
+    explicit CameraParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
     ~CameraParamHandler();
     void declareParams();
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/feature_tracker_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/feature_tracker_param_handler.hpp
@@ -24,7 +24,7 @@ namespace param_handlers {
 
 class FeatureTrackerParamHandler : public BaseParamHandler {
    public:
-    explicit FeatureTrackerParamHandler(rclcpp::Node* node, const std::string& name);
+    explicit FeatureTrackerParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
     ~FeatureTrackerParamHandler();
     void declareParams(std::shared_ptr<dai::node::FeatureTracker> featureTracker);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/imu_param_handler.hpp
@@ -27,7 +27,7 @@ enum class ImuMsgType { IMU, IMU_WITH_MAG, IMU_WITH_MAG_SPLIT };
 }
 class ImuParamHandler : public BaseParamHandler {
    public:
-    explicit ImuParamHandler(rclcpp::Node* node, const std::string& name);
+    explicit ImuParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
     ~ImuParamHandler();
     void declareParams(std::shared_ptr<dai::node::IMU> imu, const std::string& imuType);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -34,7 +34,7 @@ enum class NNFamily { Segmentation, Mobilenet, Yolo };
 }
 class NNParamHandler : public BaseParamHandler {
    public:
-    explicit NNParamHandler(rclcpp::Node* node, const std::string& name, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
+    explicit NNParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, const dai::CameraBoardSocket& socket = dai::CameraBoardSocket::CAM_A);
     ~NNParamHandler();
     nn::NNFamily getNNFamily();
     template <typename T>

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp
@@ -18,13 +18,12 @@ class Parameter;
 namespace depthai_ros_driver {
 namespace param_handlers {
 
-class PipelineGenParamHandler: public BaseParamHandler {
+class PipelineGenParamHandler : public BaseParamHandler {
    public:
     explicit PipelineGenParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
     ~PipelineGenParamHandler();
     void declareParams();
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
-
 };
 }  // namespace param_handlers
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp
@@ -1,0 +1,30 @@
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
+
+namespace dai {
+enum class UsbSpeed;
+}
+
+namespace rclcpp {
+class Node;
+class Parameter;
+}  // namespace rclcpp
+
+namespace depthai_ros_driver {
+namespace param_handlers {
+
+class PipelineGenParamHandler: public BaseParamHandler {
+   public:
+    explicit PipelineGenParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
+    ~PipelineGenParamHandler();
+    void declareParams();
+    dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
+
+};
+}  // namespace param_handlers
+}  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sensor_param_handler.hpp
@@ -24,7 +24,7 @@ namespace depthai_ros_driver {
 namespace param_handlers {
 class SensorParamHandler : public BaseParamHandler {
    public:
-    explicit SensorParamHandler(rclcpp::Node* node, const std::string& name, dai::CameraBoardSocket socket);
+    explicit SensorParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, dai::CameraBoardSocket socket);
     ~SensorParamHandler();
     void declareCommonParams(dai::CameraBoardSocket socket);
     void declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish);

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/stereo_param_handler.hpp
@@ -22,7 +22,7 @@ namespace depthai_ros_driver {
 namespace param_handlers {
 class StereoParamHandler : public BaseParamHandler {
    public:
-    explicit StereoParamHandler(rclcpp::Node* node, const std::string& name);
+    explicit StereoParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
     ~StereoParamHandler();
     void declareParams(std::shared_ptr<dai::node::StereoDepth> stereo);
     dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sync_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/sync_param_handler.hpp
@@ -1,0 +1,32 @@
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "depthai/pipeline/datatype/CameraControl.hpp"
+#include "depthai_ros_driver/param_handlers/base_param_handler.hpp"
+
+namespace dai {
+namespace node {
+class Sync;
+}
+}  // namespace dai
+
+namespace rclcpp {
+class Node;
+class Parameter;
+}  // namespace rclcpp
+
+namespace depthai_ros_driver {
+namespace param_handlers {
+class SyncParamHandler : public BaseParamHandler {
+   public:
+    explicit SyncParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name);
+    ~SyncParamHandler();
+    void declareParams(std::shared_ptr<dai::node::Sync> sync);
+    dai::CameraControl setRuntimeParams(const std::vector<rclcpp::Parameter>& params) override;
+};
+}  // namespace param_handlers
+}  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_pipeline.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_pipeline.hpp
@@ -27,13 +27,13 @@ enum class NNType { None, RGB, Spatial };
 class BasePipeline {
    public:
     ~BasePipeline() = default;
-    std::unique_ptr<dai_nodes::BaseNode> createNN(rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, dai_nodes::BaseNode& daiNode) {
+    std::unique_ptr<dai_nodes::BaseNode> createNN(std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, dai_nodes::BaseNode& daiNode) {
         using namespace dai_nodes::sensor_helpers;
         auto nn = std::make_unique<dai_nodes::NNWrapper>(getNodeName(node, NodeNameEnum::NN), node, pipeline);
         daiNode.link(nn->getInput(), static_cast<int>(dai_nodes::link_types::RGBLinkType::preview));
         return nn;
     }
-    std::unique_ptr<dai_nodes::BaseNode> createSpatialNN(rclcpp::Node* node,
+    std::unique_ptr<dai_nodes::BaseNode> createSpatialNN(std::shared_ptr<rclcpp::Node> node,
                                                          std::shared_ptr<dai::Pipeline> pipeline,
                                                          dai_nodes::BaseNode& daiNode,
                                                          dai_nodes::BaseNode& daiStereoNode) {
@@ -45,7 +45,7 @@ class BasePipeline {
         return nn;
     }
 
-    virtual std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    virtual std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                              std::shared_ptr<dai::Device> device,
                                                                              std::shared_ptr<dai::Pipeline> pipeline,
                                                                              const std::string& nnType) = 0;

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_pipeline.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_pipeline.hpp
@@ -28,7 +28,8 @@ class BasePipeline {
    public:
     ~BasePipeline() = default;
     std::unique_ptr<dai_nodes::BaseNode> createNN(rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, dai_nodes::BaseNode& daiNode) {
-        auto nn = std::make_unique<dai_nodes::NNWrapper>("nn", node, pipeline);
+        using namespace dai_nodes::sensor_helpers;
+        auto nn = std::make_unique<dai_nodes::NNWrapper>(getNodeName(node, NodeNameEnum::NN), node, pipeline);
         daiNode.link(nn->getInput(), static_cast<int>(dai_nodes::link_types::RGBLinkType::preview));
         return nn;
     }
@@ -36,7 +37,8 @@ class BasePipeline {
                                                          std::shared_ptr<dai::Pipeline> pipeline,
                                                          dai_nodes::BaseNode& daiNode,
                                                          dai_nodes::BaseNode& daiStereoNode) {
-        auto nn = std::make_unique<dai_nodes::SpatialNNWrapper>("nn", node, pipeline);
+        using namespace dai_nodes::sensor_helpers;
+        auto nn = std::make_unique<dai_nodes::SpatialNNWrapper>(getNodeName(node, NodeNameEnum::NN), node, pipeline);
         daiNode.link(nn->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::input)),
                      static_cast<int>(dai_nodes::link_types::RGBLinkType::preview));
         daiStereoNode.link(nn->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::inputDepth)));

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_types.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/base_types.hpp
@@ -21,42 +21,42 @@ namespace depthai_ros_driver {
 namespace pipeline_gen {
 class RGB : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;
 };
 class RGBD : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;
 };
 class RGBStereo : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;
 };
 class Stereo : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;
 };
 class Depth : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;
 };
 class CamArray : public BasePipeline {
    public:
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& nnType) override;

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
@@ -25,7 +25,7 @@ enum class PipelineType { RGB, RGBD, RGBStereo, Stereo, Depth, CamArray };
 
 class PipelineGenerator {
    public:
-	PipelineGenerator();
+    PipelineGenerator();
     ~PipelineGenerator();
     /**
      * @brief      Validates the pipeline type. If the pipeline type is not valid for the number of sensors, it will be changed to the default type.
@@ -58,6 +58,7 @@ class PipelineGenerator {
    protected:
     std::unordered_map<std::string, std::string> pluginTypeMap;
     std::unordered_map<std::string, PipelineType> pipelineTypeMap;
+
    private:
     std::unique_ptr<param_handlers::PipelineGenParamHandler> ph;
 };

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
@@ -17,12 +17,16 @@ class Node;
 }
 
 namespace depthai_ros_driver {
+namespace param_handlers {
+class PipelineGenParamHandler;
+}  // namespace param_handlers
 namespace pipeline_gen {
 enum class PipelineType { RGB, RGBD, RGBStereo, Stereo, Depth, CamArray };
 
 class PipelineGenerator {
    public:
-    ~PipelineGenerator() = default;
+	PipelineGenerator();
+    ~PipelineGenerator();
     /**
      * @brief      Validates the pipeline type. If the pipeline type is not valid for the number of sensors, it will be changed to the default type.
      *
@@ -49,22 +53,13 @@ class PipelineGenerator {
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& pipelineType,
-                                                                     const std::string& nnType,
-                                                                     bool enableImu);
+                                                                     const std::string& nnType);
 
    protected:
-    std::unordered_map<std::string, std::string> pluginTypeMap{{"RGB", "depthai_ros_driver::pipeline_gen::RGB"},
-                                                               {"RGBD", "depthai_ros_driver::pipeline_gen::RGBD"},
-                                                               {"RGBSTEREO", "depthai_ros_driver::pipeline_gen::RGBStereo"},
-                                                               {"STEREO", "depthai_ros_driver::pipeline_gen::Stereo"},
-                                                               {"DEPTH", "depthai_ros_driver::pipeline_gen::Depth"},
-                                                               {"CAMARRAY", "depthai_ros_driver::pipeline_gen::CamArray"}};
-    std::unordered_map<std::string, PipelineType> pipelineTypeMap{{"RGB", PipelineType::RGB},
-                                                                  {"RGBD", PipelineType::RGBD},
-                                                                  {"RGBSTEREO", PipelineType::RGBStereo},
-                                                                  {"STEREO", PipelineType::Stereo},
-                                                                  {"DEPTH", PipelineType::Depth},
-                                                                  {"CAMARRAY", PipelineType::CamArray}};
+    std::unordered_map<std::string, std::string> pluginTypeMap;
+    std::unordered_map<std::string, PipelineType> pipelineTypeMap;
+   private:
+    std::unique_ptr<param_handlers::PipelineGenParamHandler> ph;
 };
 }  // namespace pipeline_gen
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/pipeline/pipeline_generator.hpp
@@ -32,7 +32,7 @@ class PipelineGenerator {
      *
      * @return     The validated pipeline type.
      */
-    std::string validatePipeline(rclcpp::Node* node, const std::string& typeStr, int sensorNum);
+    std::string validatePipeline(std::shared_ptr<rclcpp::Node> node, const std::string& typeStr, int sensorNum);
     /**
      * @brief      Creates the pipeline by using a plugin. Plugin types need to be of type depthai_ros_driver::pipeline_gen::BasePipeline.
      *
@@ -45,7 +45,7 @@ class PipelineGenerator {
      *
      * @return     Vector BaseNodes created.
      */
-    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(rclcpp::Node* node,
+    std::vector<std::unique_ptr<dai_nodes::BaseNode>> createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                      std::shared_ptr<dai::Device> device,
                                                                      std::shared_ptr<dai::Pipeline> pipeline,
                                                                      const std::string& pipelineType,

--- a/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
@@ -1,15 +1,9 @@
 #pragma once
 
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
-#include <vector>
-
-namespace dai {
-enum class CameraBoardSocket;
-}  // namespace dai
 
 namespace depthai_ros_driver {
 namespace utils {
@@ -28,6 +22,5 @@ T getValFromMap(const std::string& name, const std::unordered_map<std::string, T
     }
 }
 std::string getUpperCaseStr(const std::string& string);
-std::string getSocketName(dai::CameraBoardSocket socket);
 }  // namespace utils
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/launch/calibration.launch.py
+++ b/depthai_ros_driver/launch/calibration.launch.py
@@ -2,7 +2,11 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction, IncludeLaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -13,25 +17,39 @@ def launch_setup(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file")
     name = LaunchConfiguration("name").perform(context)
     type = LaunchConfiguration("type").perform(context)
-    print("#########")
-    print(type)
     size = LaunchConfiguration("size").perform(context)
     square = LaunchConfiguration("square").perform(context)
-    mono_args = ["--size", size,
-                 "--square", square,
-                 "--camera_name", "oak/rgb",
-                 "--no-service-check"]
-    stereo_args = ["--size", size,
-                   "--square", square,
-                   "--camera_name", "/rgb",
-                   "--approximate", "0.1",
-                   "--camera_name", "oak",
-                   "left_camera", "left",
-                   "right_camera", "right",
-                   "--no-service-check"]
-    mono_remappings = [('/image', '{}/rgb/image_raw'.format(name))]
-    stereo_remappings = [('/left', '{}/left/image_raw'.format(name)),
-                         ('/right', '{}/right/image_raw'.format(name))]
+    mono_args = [
+        "--size",
+        size,
+        "--square",
+        square,
+        "--camera_name",
+        "oak/rgb",
+        "--no-service-check",
+    ]
+    stereo_args = [
+        "--size",
+        size,
+        "--square",
+        square,
+        "--camera_name",
+        "/rgb",
+        "--approximate",
+        "0.1",
+        "--camera_name",
+        "oak",
+        "left_camera",
+        "left",
+        "right_camera",
+        "right",
+        "--no-service-check",
+    ]
+    mono_remappings = [("/image", "{}/rgb/image_raw".format(name))]
+    stereo_remappings = [
+        ("/left", "{}/left/image_raw".format(name)),
+        ("/right", "{}/right/image_raw".format(name)),
+    ]
     args = []
     remappings = []
     if type == "mono":
@@ -44,9 +62,9 @@ def launch_setup(context, *args, **kwargs):
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file}.items()
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={"name": name, "params_file": params_file}.items(),
         ),
         Node(
             name="calibrator",
@@ -54,8 +72,8 @@ def launch_setup(context, *args, **kwargs):
             package="camera_calibration",
             executable="cameracalibrator",
             arguments=args,
-            remappings=remappings
-        )
+            remappings=remappings,
+        ),
     ]
 
 
@@ -66,7 +84,10 @@ def generate_launch_description():
         DeclareLaunchArgument("size", default_value="8x6"),
         DeclareLaunchArgument("square", default_value="0.108"),
         DeclareLaunchArgument("type", default_value="mono"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'calibration.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "calibration.yaml"),
+        ),
     ]
 
     return LaunchDescription(

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -26,7 +26,7 @@ def setup_launch_prefix(context, *args, **kwargs):
     launch_prefix = ""
 
     if use_gdb.perform(context) == "true":
-        launch_prefix += "gdb -ex run --args "
+        launch_prefix += "xterm -e gdb -ex run --args"
     if use_valgrind.perform(context) == "true":
         launch_prefix += "valgrind --tool=callgrind"
     if use_perf.perform(context) == "true":

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -65,7 +65,7 @@ def launch_setup(context, *args, **kwargs):
     camera_model = LaunchConfiguration("camera_model", default="OAK-D")
     rs_compat = LaunchConfiguration("rs_compat", default="false")
     pointcloud_enable = LaunchConfiguration("pointcloud.enable", default="false")
-    namespace = LaunchConfiguration("namespace", default="")
+    namespace = LaunchConfiguration("namespace", default="").perform(context)
     name = LaunchConfiguration("name").perform(context)
 
     # If RealSense compatibility is enabled, we need to override some parameters, topics and node names
@@ -79,7 +79,7 @@ def launch_setup(context, *args, **kwargs):
         if name == "oak":
             name = "camera"
         points_topic_name = f"{name}/depth/color/points"
-        if namespace.perform(context) == "":
+        if namespace== "":
             namespace = "camera"
         if parent_frame == "oak-d-base-frame":
             parent_frame = f"{name}_link"
@@ -196,12 +196,18 @@ def launch_setup(context, *args, **kwargs):
                         ("image", f"{name}/{color_sens_name}/image_raw"),
                         ("camera_info", f"{name}/{color_sens_name}/camera_info"),
                         ("image_rect", f"{name}/{color_sens_name}/image_rect"),
-                        ("image_rect/compressed", f"{name}/{color_sens_name}/image_rect/compressed"),
+                        (
+                            "image_rect/compressed",
+                            f"{name}/{color_sens_name}/image_rect/compressed",
+                        ),
                         (
                             "image_rect/compressedDepth",
                             f"{name}/{color_sens_name}/image_rect/compressedDepth",
                         ),
-                        ("image_rect/theora", f"{name}/{color_sens_name}/image_rect/theora"),
+                        (
+                            "image_rect/theora",
+                            f"{name}/{color_sens_name}/image_rect/theora",
+                        ),
                     ],
                 )
             ],
@@ -216,8 +222,14 @@ def launch_setup(context, *args, **kwargs):
                     name="point_cloud_xyzrgb_node",
                     namespace=namespace,
                     remappings=[
-                        ("depth_registered/image_rect", f"{name}/{stereo_sens_name}/image_raw"),
-                        ("rgb/image_rect_color", f"{name}/{color_sens_name}/image_rect"),
+                        (
+                            "depth_registered/image_rect",
+                            f"{name}/{stereo_sens_name}/image_raw",
+                        ),
+                        (
+                            "rgb/image_rect_color",
+                            f"{name}/{color_sens_name}/image_rect",
+                        ),
                         ("rgb/camera_info", f"{name}/{color_sens_name}/camera_info"),
                         ("points", points_topic_name),
                     ],

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -94,18 +94,9 @@ def launch_setup(context, *args, **kwargs):
                 "i_publish_topic": is_launch_config_true(context, "enable_depth"),
             },
         }
-        if is_launch_config_true(context, "enable_infra1") and is_launch_config_true(
-            context, "enable_infra2"
-        ):
-            parameter_overrides["depth"] = {
-                "i_publish_synced_rect_pair": True,
-            }
-        else:
-            parameter_overrides["infra1"] = {
-                "i_publish_topic": is_launch_config_true(context, "enable_infra1"),
-            }
-            parameter_overrides["infra2"] = {
-                "i_publish_topic": is_launch_config_true(context, "enable_infra2"),
+        parameter_overrides["depth"] = {
+                "i_publish_left_rect": True,
+                "i_publish_right_rect": True,
             }
 
     tf_params = {}

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -22,7 +22,14 @@ def launch_setup(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file")
     camera_model = LaunchConfiguration('camera_model',  default = 'OAK-D')
 
+    real_sense_compat = LaunchConfiguration('rs_compat', default='false')
+
+    namespace = LaunchConfiguration('namespace', default='')
     name = LaunchConfiguration('name').perform(context)
+    print(real_sense_compat.perform(context))
+    if real_sense_compat.perform(context) == 'true':
+        name = 'camera'
+        namespace = 'camera'
 
     parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
     cam_pos_x    = LaunchConfiguration('cam_pos_x',     default = '0.0')
@@ -96,7 +103,7 @@ def launch_setup(context, *args, **kwargs):
 
         ComposableNodeContainer(
             name=name+"_container",
-            namespace="",
+            namespace=namespace,
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
@@ -104,7 +111,7 @@ def launch_setup(context, *args, **kwargs):
                         package="depthai_ros_driver",
                         plugin="depthai_ros_driver::Camera",
                         name=name,
-                        parameters=[params_file, tf_params],
+                    parameters=[params_file, tf_params, {"rs_compat": real_sense_compat.perform(context)}],
                     )
             ],
             arguments=['--ros-args', '--log-level', log_level],
@@ -120,6 +127,7 @@ def generate_launch_description():
 
     declared_arguments = [
         DeclareLaunchArgument("name", default_value="oak"),
+        DeclareLaunchArgument("namespace", default_value=""),
         DeclareLaunchArgument("parent_frame", default_value="oak-d-base-frame"),
         DeclareLaunchArgument("camera_model", default_value="OAK-D"),
         DeclareLaunchArgument("cam_pos_x", default_value="0.0"),
@@ -137,7 +145,8 @@ def generate_launch_description():
         DeclareLaunchArgument("override_cam_model", default_value='false', description='Overrides camera model from calibration file.'),
         DeclareLaunchArgument("use_gdb", default_value='false'),
         DeclareLaunchArgument("use_valgrind", default_value='false'),
-        DeclareLaunchArgument("use_perf", default_value='false')
+        DeclareLaunchArgument("use_perf", default_value='false'),
+        DeclareLaunchArgument("rs_compat", default_value='false', description='Enables compatibility with RealSense nodes.')
     ]
 
     return LaunchDescription(

--- a/depthai_ros_driver/launch/camera.launch.py
+++ b/depthai_ros_driver/launch/camera.launch.py
@@ -111,7 +111,7 @@ def launch_setup(context, *args, **kwargs):
                         package="depthai_ros_driver",
                         plugin="depthai_ros_driver::Camera",
                         name=name,
-                    parameters=[params_file, tf_params, {"rs_compat": real_sense_compat.perform(context)}],
+                    parameters=[params_file, tf_params, {"camera.i_rs_compat": real_sense_compat.perform(context)== 'true'}],
                     )
             ],
             arguments=['--ros-args', '--log-level', log_level],

--- a/depthai_ros_driver/launch/camera_as_part_of_a_robot.launch.py
+++ b/depthai_ros_driver/launch/camera_as_part_of_a_robot.launch.py
@@ -2,107 +2,120 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
-from launch.conditions import IfCondition
 
 
 def launch_setup(context, *args, **kwargs):
-    log_level = 'info'
-    if(context.environment.get('DEPTHAI_DEBUG')=='1'):
-        log_level='debug'
+    log_level = "info"
+    if context.environment.get("DEPTHAI_DEBUG") == "1":
+        log_level = "debug"
 
     params_file = LaunchConfiguration("params_file")
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
 
-    name = LaunchConfiguration('name').perform(context)
-    rgb_topic_name = name+'/rgb/image_raw'
-    if LaunchConfiguration('rectify_rgb').perform(context)=='true':
-        rgb_topic_name = name +'/rgb/image_rect'
+    name = LaunchConfiguration("name").perform(context)
+    rgb_topic_name = name + "/rgb/image_raw"
+    if LaunchConfiguration("rectify_rgb").perform(context) == "true":
+        rgb_topic_name = name + "/rgb/image_rect"
 
-    parent_frame = LaunchConfiguration('parent_frame',  default = 'oak-d-base-frame')
-    cam_pos_x    = LaunchConfiguration('cam_pos_x',     default = '0.0')
-    cam_pos_y    = LaunchConfiguration('cam_pos_y',     default = '0.0')
-    cam_pos_z    = LaunchConfiguration('cam_pos_z',     default = '0.0')
-    cam_roll     = LaunchConfiguration('cam_roll',      default = '0.0')
-    cam_pitch    = LaunchConfiguration('cam_pitch',     default = '0.0')
-    cam_yaw      = LaunchConfiguration('cam_yaw',       default = '0.0')
-    use_composition = LaunchConfiguration('rsp_use_composition', default='true')
-    imu_from_descr = LaunchConfiguration('imu_from_descr', default='false')
-    publish_tf_from_calibration = LaunchConfiguration('publish_tf_from_calibration', default='false')
-    override_cam_model = LaunchConfiguration('override_cam_model', default='false')
+    parent_frame = LaunchConfiguration("parent_frame", default="oak-d-base-frame")
+    cam_pos_x = LaunchConfiguration("cam_pos_x", default="0.0")
+    cam_pos_y = LaunchConfiguration("cam_pos_y", default="0.0")
+    cam_pos_z = LaunchConfiguration("cam_pos_z", default="0.0")
+    cam_roll = LaunchConfiguration("cam_roll", default="0.0")
+    cam_pitch = LaunchConfiguration("cam_pitch", default="0.0")
+    cam_yaw = LaunchConfiguration("cam_yaw", default="0.0")
+    use_composition = LaunchConfiguration("rsp_use_composition", default="true")
+    imu_from_descr = LaunchConfiguration("imu_from_descr", default="false")
+    publish_tf_from_calibration = LaunchConfiguration(
+        "publish_tf_from_calibration", default="false"
+    )
+    override_cam_model = LaunchConfiguration("override_cam_model", default="false")
 
     tf_params = {}
-    if(publish_tf_from_calibration.perform(context) == 'true'):
-        cam_model = ''
-        if override_cam_model.perform(context) == 'true':
+    if publish_tf_from_calibration.perform(context) == "true":
+        cam_model = ""
+        if override_cam_model.perform(context) == "true":
             cam_model = camera_model.perform(context)
-        tf_params = {'camera': {
-            'i_publish_tf_from_calibration': True,
-            'i_tf_tf_prefix': name,
-            'i_tf_camera_model': cam_model,
-            'i_tf_base_frame': name,
-            'i_tf_parent_frame': parent_frame.perform(context),
-            'i_tf_cam_pos_x': cam_pos_x.perform(context),
-            'i_tf_cam_pos_y': cam_pos_y.perform(context),
-            'i_tf_cam_pos_z': cam_pos_z.perform(context),
-            'i_tf_cam_roll': cam_roll.perform(context),
-            'i_tf_cam_pitch': cam_pitch.perform(context),
-            'i_tf_cam_yaw': cam_yaw.perform(context),
-            'i_tf_imu_from_descr': imu_from_descr.perform(context),
+        tf_params = {
+            "camera": {
+                "i_publish_tf_from_calibration": True,
+                "i_tf_tf_prefix": name,
+                "i_tf_camera_model": cam_model,
+                "i_tf_base_frame": name,
+                "i_tf_parent_frame": parent_frame.perform(context),
+                "i_tf_cam_pos_x": cam_pos_x.perform(context),
+                "i_tf_cam_pos_y": cam_pos_y.perform(context),
+                "i_tf_cam_pos_z": cam_pos_z.perform(context),
+                "i_tf_cam_roll": cam_roll.perform(context),
+                "i_tf_cam_pitch": cam_pitch.perform(context),
+                "i_tf_cam_yaw": cam_yaw.perform(context),
+                "i_tf_imu_from_descr": imu_from_descr.perform(context),
+            }
         }
-        }
-
 
     return [
         ComposableNodeContainer(
-            name=name+"_container",
+            name=name + "_container",
             namespace="",
             package="rclcpp_components",
             executable="component_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                        package="depthai_ros_driver",
-                        plugin="depthai_ros_driver::Camera",
-                        name=name,
-                        parameters=[params_file, tf_params],
-                    )
+                ComposableNode(
+                    package="depthai_ros_driver",
+                    plugin="depthai_ros_driver::Camera",
+                    name=name,
+                    parameters=[params_file, tf_params],
+                )
             ],
-            arguments=['--ros-args', '--log-level', log_level],
+            arguments=["--ros-args", "--log-level", log_level],
             output="both",
         ),
-
         LoadComposableNodes(
             condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                        package="image_proc",
-                        plugin="image_proc::RectifyNode",
-                        name=name+"_rectify_color_node",
-                        remappings=[('image', name+'/rgb/image_raw'),
-                                    ('camera_info', name+'/rgb/camera_info'),
-                                    ('image_rect', name+'/rgb/image_rect'),
-                                    ('image_rect/compressed', name+'/rgb/image_rect/compressed'),
-                                    ('image_rect/compressedDepth', name+'/rgb/image_rect/compressedDepth'),
-                                    ('image_rect/theora', name+'/rgb/image_rect/theora')]
-                    )
-            ]),
+                ComposableNode(
+                    package="image_proc",
+                    plugin="image_proc::RectifyNode",
+                    name=name + "_rectify_color_node",
+                    remappings=[
+                        ("image", name + "/rgb/image_raw"),
+                        ("camera_info", name + "/rgb/camera_info"),
+                        ("image_rect", name + "/rgb/image_rect"),
+                        ("image_rect/compressed", name + "/rgb/image_rect/compressed"),
+                        (
+                            "image_rect/compressedDepth",
+                            name + "/rgb/image_rect/compressedDepth",
+                        ),
+                        ("image_rect/theora", name + "/rgb/image_rect/theora"),
+                    ],
+                )
+            ],
+        ),
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzrgbNode',
-                    name=name+'_point_cloud_xyzrgb_node',
-                    remappings=[('depth_registered/image_rect', name+'/stereo/image_raw'),
-                                ('rgb/image_rect_color', rgb_topic_name),
-                                ('rgb/camera_info', name+'/rgb/camera_info'),
-                                ('points', name+'/points')]
-                    ),
+                ComposableNode(
+                    package="depth_image_proc",
+                    plugin="depth_image_proc::PointCloudXyzrgbNode",
+                    name=name + "_point_cloud_xyzrgb_node",
+                    remappings=[
+                        ("depth_registered/image_rect", name + "/stereo/image_raw"),
+                        ("rgb/image_rect_color", rgb_topic_name),
+                        ("rgb/camera_info", name + "/rgb/camera_info"),
+                        ("points", name + "/points"),
+                    ],
+                ),
             ],
         ),
     ]
@@ -120,12 +133,27 @@ def generate_launch_description():
         DeclareLaunchArgument("cam_roll", default_value="0.0"),
         DeclareLaunchArgument("cam_pitch", default_value="0.0"),
         DeclareLaunchArgument("cam_yaw", default_value="0.0"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'rgbd.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "rgbd.yaml"),
+        ),
         DeclareLaunchArgument("rectify_rgb", default_value="False"),
-        DeclareLaunchArgument("rsp_use_composition", default_value='true'),
-        DeclareLaunchArgument("publish_tf_from_calibration", default_value='false', description='Enables TF publishing from camera calibration file.'),
-        DeclareLaunchArgument("imu_from_descr", default_value='false', description='Enables IMU publishing from URDF.'),
-        DeclareLaunchArgument("override_cam_model", default_value='false', description='Overrides camera model from calibration file.'),
+        DeclareLaunchArgument("rsp_use_composition", default_value="true"),
+        DeclareLaunchArgument(
+            "publish_tf_from_calibration",
+            default_value="false",
+            description="Enables TF publishing from camera calibration file.",
+        ),
+        DeclareLaunchArgument(
+            "imu_from_descr",
+            default_value="false",
+            description="Enables IMU publishing from URDF.",
+        ),
+        DeclareLaunchArgument(
+            "override_cam_model",
+            default_value="false",
+            description="Overrides camera model from calibration file.",
+        ),
     ]
 
     return LaunchDescription(

--- a/depthai_ros_driver/launch/example_multicam.launch.py
+++ b/depthai_ros_driver/launch/example_multicam.launch.py
@@ -3,13 +3,12 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import (
-    IncludeLaunchDescription,
     DeclareLaunchArgument,
+    IncludeLaunchDescription,
     OpaqueFunction,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-
 
 
 def launch_setup(context, *args, **kwargs):
@@ -18,32 +17,40 @@ def launch_setup(context, *args, **kwargs):
     params_file = os.path.join(depthai_prefix, "config", "multicam_example.yaml")
     cams = ["oak_d_w", "oak_d_lite"]
     nodes = []
-    i=0.0
+    i = 0.0
     for cam_name in cams:
         node = IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": cam_name,
-                              "parent_frame": "map",
-                              "params_file": params_file,
-                              "cam_pos_y": str(i)}.items())
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": cam_name,
+                "parent_frame": "map",
+                "params_file": params_file,
+                "cam_pos_y": str(i),
+            }.items(),
+        )
         nodes.append(node)
-        i=i+0.1
+        i = i + 0.1
     spatial_rgbd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(depthai_prefix, 'launch',
-                         'rgbd_pcl.launch.py')
+            os.path.join(depthai_prefix, "launch", "rgbd_pcl.launch.py")
         ),
-        launch_arguments={"name": "oak_d_pro",
-                          "parent_frame": "map",
-                          "params_file": params_file,
-                          "cam_pos_y": str(-0.1)}.items())
+        launch_arguments={
+            "name": "oak_d_pro",
+            "parent_frame": "map",
+            "params_file": params_file,
+            "cam_pos_y": str(-0.1),
+        }.items(),
+    )
 
     obj_det = Node(
         package="depthai_ros_driver",
         executable="obj_pub.py",
-        remappings=[("/oak/nn/detections", "/oak_d_pro/nn/detections"),
-        ("/oak/nn/detection_markers", "/oak_d_pro/nn/detection_markers")]
+        remappings=[
+            ("/oak/nn/detections", "/oak_d_pro/nn/detections"),
+            ("/oak/nn/detection_markers", "/oak_d_pro/nn/detection_markers"),
+        ],
     )
 
     nodes.append(spatial_rgbd)

--- a/depthai_ros_driver/launch/example_segmentation.launch.py
+++ b/depthai_ros_driver/launch/example_segmentation.launch.py
@@ -2,13 +2,17 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 
 def launch_setup(context, *args, **kwargs):
-    name = LaunchConfiguration('name').perform(context)
+    name = LaunchConfiguration("name").perform(context)
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     rviz_config = os.path.join(depthai_prefix, "config", "rviz", "segmentation.rviz")
 
@@ -17,11 +21,15 @@ def launch_setup(context, *args, **kwargs):
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file,
-                              "use_rviz": LaunchConfiguration("use_rviz"),
-                              "rviz_config": rviz_config}.items())
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": name,
+                "params_file": params_file,
+                "use_rviz": LaunchConfiguration("use_rviz"),
+                "rviz_config": rviz_config,
+            }.items(),
+        )
     ]
 
 
@@ -29,7 +37,10 @@ def generate_launch_description():
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     declared_arguments = [
         DeclareLaunchArgument("name", default_value="oak"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'segmentation.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "segmentation.yaml"),
+        ),
         DeclareLaunchArgument("use_rviz", default_value="False"),
     ]
 

--- a/depthai_ros_driver/launch/pointcloud.launch.py
+++ b/depthai_ros_driver/launch/pointcloud.launch.py
@@ -2,7 +2,11 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
@@ -13,37 +17,40 @@ def launch_setup(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file")
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
 
-    name = LaunchConfiguration('name').perform(context)
-    
-    return [
+    name = LaunchConfiguration("name").perform(context)
 
+    return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file,
-                              "parent_frame": LaunchConfiguration("parent_frame"),
-                               "cam_pos_x": LaunchConfiguration("cam_pos_x"),
-                               "cam_pos_y": LaunchConfiguration("cam_pos_y"),
-                               "cam_pos_z": LaunchConfiguration("cam_pos_z"),
-                               "cam_roll": LaunchConfiguration("cam_roll"),
-                               "cam_pitch": LaunchConfiguration("cam_pitch"),
-                               "cam_yaw": LaunchConfiguration("cam_yaw"),
-                               "use_rviz": LaunchConfiguration("use_rviz")
-                               }.items()),
-
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": name,
+                "params_file": params_file,
+                "parent_frame": LaunchConfiguration("parent_frame"),
+                "cam_pos_x": LaunchConfiguration("cam_pos_x"),
+                "cam_pos_y": LaunchConfiguration("cam_pos_y"),
+                "cam_pos_z": LaunchConfiguration("cam_pos_z"),
+                "cam_roll": LaunchConfiguration("cam_roll"),
+                "cam_pitch": LaunchConfiguration("cam_pitch"),
+                "cam_yaw": LaunchConfiguration("cam_yaw"),
+                "use_rviz": LaunchConfiguration("use_rviz"),
+            }.items(),
+        ),
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyziNode',
-                    name='point_cloud_xyzi',
-                    remappings=[('depth/image_rect', name+'/stereo/image_raw'),
-                                ('intensity/image_rect', name+'/right/image_rect'),
-                                ('intensity/camera_info', name+'/stereo/camera_info'),
-                                ('points', name+'/points')
-                                ]),
+                ComposableNode(
+                    package="depth_image_proc",
+                    plugin="depth_image_proc::PointCloudXyziNode",
+                    name="point_cloud_xyzi",
+                    remappings=[
+                        ("depth/image_rect", name + "/stereo/image_raw"),
+                        ("intensity/image_rect", name + "/right/image_rect"),
+                        ("intensity/camera_info", name + "/stereo/camera_info"),
+                        ("points", name + "/points"),
+                    ],
+                ),
             ],
         ),
     ]
@@ -60,7 +67,10 @@ def generate_launch_description():
         DeclareLaunchArgument("cam_roll", default_value="0.0"),
         DeclareLaunchArgument("cam_pitch", default_value="0.0"),
         DeclareLaunchArgument("cam_yaw", default_value="0.0"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'pcl.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "pcl.yaml"),
+        ),
         DeclareLaunchArgument("use_rviz", default_value="False"),
     ]
 

--- a/depthai_ros_driver/launch/rgbd_pcl.launch.py
+++ b/depthai_ros_driver/launch/rgbd_pcl.launch.py
@@ -2,66 +2,80 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
-from launch.conditions import IfCondition
 
 
 def launch_setup(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file")
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
 
-    name = LaunchConfiguration('name').perform(context)
-    rgb_topic_name = name+'/rgb/image_raw'
-    if LaunchConfiguration('rectify_rgb').perform(context)=='true':
-        rgb_topic_name = name +'/rgb/image_rect'
+    name = LaunchConfiguration("name").perform(context)
+    rgb_topic_name = name + "/rgb/image_raw"
+    if LaunchConfiguration("rectify_rgb").perform(context) == "true":
+        rgb_topic_name = name + "/rgb/image_rect"
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file,
-                              "parent_frame": LaunchConfiguration("parent_frame"),
-                               "cam_pos_x": LaunchConfiguration("cam_pos_x"),
-                               "cam_pos_y": LaunchConfiguration("cam_pos_y"),
-                               "cam_pos_z": LaunchConfiguration("cam_pos_z"),
-                               "cam_roll": LaunchConfiguration("cam_roll"),
-                               "cam_pitch": LaunchConfiguration("cam_pitch"),
-                               "cam_yaw": LaunchConfiguration("cam_yaw"),
-                               "use_rviz": LaunchConfiguration("use_rviz")
-                               }.items()),
-
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": name,
+                "params_file": params_file,
+                "parent_frame": LaunchConfiguration("parent_frame"),
+                "cam_pos_x": LaunchConfiguration("cam_pos_x"),
+                "cam_pos_y": LaunchConfiguration("cam_pos_y"),
+                "cam_pos_z": LaunchConfiguration("cam_pos_z"),
+                "cam_roll": LaunchConfiguration("cam_roll"),
+                "cam_pitch": LaunchConfiguration("cam_pitch"),
+                "cam_yaw": LaunchConfiguration("cam_yaw"),
+                "use_rviz": LaunchConfiguration("use_rviz"),
+            }.items(),
+        ),
         LoadComposableNodes(
             condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                        package="image_proc",
-                        plugin="image_proc::RectifyNode",
-                        name="rectify_color_node",
-                        remappings=[('image', name+'/rgb/image_raw'),
-                                    ('camera_info', name+'/rgb/camera_info'),
-                                    ('image_rect', name+'/rgb/image_rect'),
-                                    ('image_rect/compressed', name+'/rgb/image_rect/compressed'),
-                                    ('image_rect/compressedDepth', name+'/rgb/image_rect/compressedDepth'),
-                                    ('image_rect/theora', name+'/rgb/image_rect/theora')]
-                    )
-            ]),
+                ComposableNode(
+                    package="image_proc",
+                    plugin="image_proc::RectifyNode",
+                    name="rectify_color_node",
+                    remappings=[
+                        ("image", name + "/rgb/image_raw"),
+                        ("camera_info", name + "/rgb/camera_info"),
+                        ("image_rect", name + "/rgb/image_rect"),
+                        ("image_rect/compressed", name + "/rgb/image_rect/compressed"),
+                        (
+                            "image_rect/compressedDepth",
+                            name + "/rgb/image_rect/compressedDepth",
+                        ),
+                        ("image_rect/theora", name + "/rgb/image_rect/theora"),
+                    ],
+                )
+            ],
+        ),
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzrgbNode',
-                    name='point_cloud_xyzrgb_node',
-                    remappings=[('depth_registered/image_rect', name+'/stereo/image_raw'),
-                                ('rgb/image_rect_color', rgb_topic_name),
-                                ('rgb/camera_info', name+'/rgb/camera_info'),
-                                ('points', name+'/points')]
-                    ),
+                ComposableNode(
+                    package="depth_image_proc",
+                    plugin="depth_image_proc::PointCloudXyzrgbNode",
+                    name="point_cloud_xyzrgb_node",
+                    remappings=[
+                        ("depth_registered/image_rect", name + "/stereo/image_raw"),
+                        ("rgb/image_rect_color", rgb_topic_name),
+                        ("rgb/camera_info", name + "/rgb/camera_info"),
+                        ("points", name + "/points"),
+                    ],
+                ),
             ],
         ),
     ]
@@ -79,7 +93,10 @@ def generate_launch_description():
         DeclareLaunchArgument("cam_roll", default_value="0.0"),
         DeclareLaunchArgument("cam_pitch", default_value="0.0"),
         DeclareLaunchArgument("cam_yaw", default_value="0.0"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'rgbd.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "rgbd.yaml"),
+        ),
         DeclareLaunchArgument("use_rviz", default_value="False"),
         DeclareLaunchArgument("rectify_rgb", default_value="False"),
     ]

--- a/depthai_ros_driver/launch/rtabmap.launch.py
+++ b/depthai_ros_driver/launch/rtabmap.launch.py
@@ -2,18 +2,23 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
 
+
 def launch_setup(context, *args, **kwargs):
-    name = LaunchConfiguration('name').perform(context)
+    name = LaunchConfiguration("name").perform(context)
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
 
-    params_file= LaunchConfiguration("params_file")
+    params_file = LaunchConfiguration("params_file")
     parameters = [
         {
             "frame_id": name,
@@ -26,61 +31,64 @@ def launch_setup(context, *args, **kwargs):
     ]
 
     remappings = [
-        ("rgb/image", name+"/rgb/image_rect"),
-        ("rgb/camera_info", name+"/rgb/camera_info"),
-        ("depth/image", name+"/stereo/image_raw"),
+        ("rgb/image", name + "/rgb/image_rect"),
+        ("rgb/camera_info", name + "/rgb/camera_info"),
+        ("depth/image", name + "/stereo/image_raw"),
     ]
 
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file}.items()),
-
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={"name": name, "params_file": params_file}.items(),
+        ),
         LoadComposableNodes(
             condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
                 ComposableNode(
                     package="image_proc",
                     plugin="image_proc::RectifyNode",
                     name="rectify_color_node",
-                    remappings=[('image', name+'/rgb/image_raw'),
-                                ('camera_info', name+'/rgb/camera_info'),
-                                ('image_rect', name+'/rgb/image_rect'),
-                                ('image_rect/compressed', name+'/rgb/image_rect/compressed'),
-                                ('image_rect/compressedDepth', name+'/rgb/image_rect/compressedDepth'),
-                                ('image_rect/theora', name+'/rgb/image_rect/theora')]
+                    remappings=[
+                        ("image", name + "/rgb/image_raw"),
+                        ("camera_info", name + "/rgb/camera_info"),
+                        ("image_rect", name + "/rgb/image_rect"),
+                        ("image_rect/compressed", name + "/rgb/image_rect/compressed"),
+                        (
+                            "image_rect/compressedDepth",
+                            name + "/rgb/image_rect/compressedDepth",
+                        ),
+                        ("image_rect/theora", name + "/rgb/image_rect/theora"),
+                    ],
                 )
-            ]),
-        
+            ],
+        ),
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
                 ComposableNode(
-                    package='rtabmap_odom',
-                    plugin='rtabmap_odom::RGBDOdometry',
-                    name='rgbd_odometry',
+                    package="rtabmap_odom",
+                    plugin="rtabmap_odom::RGBDOdometry",
+                    name="rgbd_odometry",
                     parameters=parameters,
                     remappings=remappings,
                 ),
             ],
         ),
-
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
                 ComposableNode(
-                    package='rtabmap_slam',
-                    plugin='rtabmap_slam::CoreWrapper',
-                    name='rtabmap',
+                    package="rtabmap_slam",
+                    plugin="rtabmap_slam::CoreWrapper",
+                    name="rtabmap",
                     parameters=parameters,
                     remappings=remappings,
                 ),
             ],
         ),
-
         Node(
             package="rtabmap_viz",
             executable="rtabmap_viz",
@@ -95,7 +103,10 @@ def generate_launch_description():
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     declared_arguments = [
         DeclareLaunchArgument("name", default_value="oak"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'rgbd.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "rgbd.yaml"),
+        ),
         DeclareLaunchArgument("rectify_rgb", default_value="True"),
     ]
 

--- a/depthai_ros_driver/launch/sr_rgbd_pcl.launch.py
+++ b/depthai_ros_driver/launch/sr_rgbd_pcl.launch.py
@@ -2,66 +2,83 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
-from launch.conditions import IfCondition
 
 
 def launch_setup(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file")
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
 
-    name = LaunchConfiguration('name').perform(context)
-    rgb_topic_name = name+'/right/image_raw'
-    if LaunchConfiguration('rectify_rgb').perform(context)=='true':
-        rgb_topic_name = name +'/right/image_rect'
+    name = LaunchConfiguration("name").perform(context)
+    rgb_topic_name = name + "/right/image_raw"
+    if LaunchConfiguration("rectify_rgb").perform(context) == "true":
+        rgb_topic_name = name + "/right/image_rect"
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file,
-                              "parent_frame": LaunchConfiguration("parent_frame"),
-                               "cam_pos_x": LaunchConfiguration("cam_pos_x"),
-                               "cam_pos_y": LaunchConfiguration("cam_pos_y"),
-                               "cam_pos_z": LaunchConfiguration("cam_pos_z"),
-                               "cam_roll": LaunchConfiguration("cam_roll"),
-                               "cam_pitch": LaunchConfiguration("cam_pitch"),
-                               "cam_yaw": LaunchConfiguration("cam_yaw"),
-                               "use_rviz": LaunchConfiguration("use_rviz")
-                               }.items()),
-
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": name,
+                "params_file": params_file,
+                "parent_frame": LaunchConfiguration("parent_frame"),
+                "cam_pos_x": LaunchConfiguration("cam_pos_x"),
+                "cam_pos_y": LaunchConfiguration("cam_pos_y"),
+                "cam_pos_z": LaunchConfiguration("cam_pos_z"),
+                "cam_roll": LaunchConfiguration("cam_roll"),
+                "cam_pitch": LaunchConfiguration("cam_pitch"),
+                "cam_yaw": LaunchConfiguration("cam_yaw"),
+                "use_rviz": LaunchConfiguration("use_rviz"),
+            }.items(),
+        ),
         LoadComposableNodes(
             condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                        package="image_proc",
-                        plugin="image_proc::RectifyNode",
-                        name="rectify_color_node",
-                        remappings=[('image', name+'/right/image_raw'),
-                                    ('camera_info', name+'/right/camera_info'),
-                                    ('image_rect', name+'/right/image_rect'),
-                                    ('image_rect/compressed', name+'/right/image_rect/compressed'),
-                                    ('image_rect/compressedDepth', name+'/right/image_rect/compressedDepth'),
-                                    ('image_rect/theora', name+'/right/image_rect/theora')]
-                    )
-            ]),
+                ComposableNode(
+                    package="image_proc",
+                    plugin="image_proc::RectifyNode",
+                    name="rectify_color_node",
+                    remappings=[
+                        ("image", name + "/right/image_raw"),
+                        ("camera_info", name + "/right/camera_info"),
+                        ("image_rect", name + "/right/image_rect"),
+                        (
+                            "image_rect/compressed",
+                            name + "/right/image_rect/compressed",
+                        ),
+                        (
+                            "image_rect/compressedDepth",
+                            name + "/right/image_rect/compressedDepth",
+                        ),
+                        ("image_rect/theora", name + "/right/image_rect/theora"),
+                    ],
+                )
+            ],
+        ),
         LoadComposableNodes(
-            target_container=name+"_container",
+            target_container=name + "_container",
             composable_node_descriptions=[
-                    ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzrgbNode',
-                    name='point_cloud_xyzrgb_node',
-                    remappings=[('depth_registered/image_rect', name+'/stereo/image_raw'),
-                                ('rgb/image_rect_color', rgb_topic_name),
-                                ('rgb/camera_info', name+'/right/camera_info'),
-                                ('points', name+'/points')]
-                    ),
+                ComposableNode(
+                    package="depth_image_proc",
+                    plugin="depth_image_proc::PointCloudXyzrgbNode",
+                    name="point_cloud_xyzrgb_node",
+                    remappings=[
+                        ("depth_registered/image_rect", name + "/stereo/image_raw"),
+                        ("rgb/image_rect_color", rgb_topic_name),
+                        ("rgb/camera_info", name + "/right/camera_info"),
+                        ("points", name + "/points"),
+                    ],
+                ),
             ],
         ),
     ]
@@ -79,7 +96,10 @@ def generate_launch_description():
         DeclareLaunchArgument("cam_roll", default_value="0.0"),
         DeclareLaunchArgument("cam_pitch", default_value="0.0"),
         DeclareLaunchArgument("cam_yaw", default_value="0.0"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'sr_rgbd.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(depthai_prefix, "config", "sr_rgbd.yaml"),
+        ),
         DeclareLaunchArgument("use_rviz", default_value="False"),
         DeclareLaunchArgument("rectify_rgb", default_value="False"),
     ]

--- a/depthai_ros_driver/launch/stereo_from_rosbag.launch.py
+++ b/depthai_ros_driver/launch/stereo_from_rosbag.launch.py
@@ -2,31 +2,37 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, ExecuteProcess
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
 
 def launch_setup(context, *args, **kwargs):
-    name = LaunchConfiguration('name').perform(context)
+    name = LaunchConfiguration("name").perform(context)
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     rosbag_path = LaunchConfiguration("rosbag_path").perform(context)
     rviz_config = os.path.join(depthai_prefix, "config", "rviz", "rgbd.rviz")
 
-    params_file= LaunchConfiguration("params_file")
+    params_file = LaunchConfiguration("params_file")
 
     return [
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(depthai_prefix, 'launch', 'camera.launch.py')),
-            launch_arguments={"name": name,
-                              "params_file": params_file,
-                              "use_rviz": LaunchConfiguration("use_rviz"),
-                              "rviz_config": rviz_config}.items()),
-        ExecuteProcess(
-            cmd=['ros2', 'bag', 'play', '-l', rosbag_path],
-            output='screen'
-        )
+                os.path.join(depthai_prefix, "launch", "camera.launch.py")
+            ),
+            launch_arguments={
+                "name": name,
+                "params_file": params_file,
+                "use_rviz": LaunchConfiguration("use_rviz"),
+                "rviz_config": rviz_config,
+            }.items(),
+        ),
+        ExecuteProcess(cmd=["ros2", "bag", "play", "-l", rosbag_path], output="screen"),
     ]
 
 
@@ -34,9 +40,14 @@ def generate_launch_description():
     depthai_prefix = get_package_share_directory("depthai_ros_driver")
     declared_arguments = [
         DeclareLaunchArgument("name", default_value="oak"),
-        DeclareLaunchArgument("params_file", default_value=os.path.join(depthai_prefix, 'config', 'stereo_from_rosbag.yaml')),
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=os.path.join(
+                depthai_prefix, "config", "stereo_from_rosbag.yaml"
+            ),
+        ),
         DeclareLaunchArgument("use_rviz", default_value="True"),
-        DeclareLaunchArgument("rosbag_path", default_value="")
+        DeclareLaunchArgument("rosbag_path", default_value=""),
     ]
 
     return LaunchDescription(

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -175,12 +175,8 @@ void Camera::createPipeline() {
     if(!ph->getParam<std::string>("i_external_calibration_path").empty()) {
         loadCalib(ph->getParam<std::string>("i_external_calibration_path"));
     }
-    daiNodes = generator->createPipeline(shared_from_this(),
-                                         device,
-                                         pipeline,
-                                         ph->getParam<std::string>("i_pipeline_type"),
-                                         ph->getParam<std::string>("i_nn_type"),
-                                         ph->getParam<bool>("i_enable_imu"));
+    daiNodes =
+        generator->createPipeline(shared_from_this(), device, pipeline, ph->getParam<std::string>("i_pipeline_type"), ph->getParam<std::string>("i_nn_type"));
     if(ph->getParam<bool>("i_pipeline_dump")) {
         savePipeline();
     }

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -19,9 +19,7 @@ Camera::Camera(const rclcpp::NodeOptions& options) : rclcpp::Node("camera", opti
         onConfigure();
         startTimer->cancel();
     });
-	rclcpp::on_shutdown([this]() {
-		stop();
-	});
+    rclcpp::on_shutdown([this]() { stop(); });
 }
 Camera::~Camera() {
     stop();

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -53,7 +53,8 @@ void Camera::onConfigure() {
                                                         ph->getParam<std::string>("i_tf_cam_yaw"),
                                                         ph->getParam<std::string>("i_tf_imu_from_descr"),
                                                         ph->getParam<std::string>("i_tf_custom_urdf_location"),
-                                                        ph->getParam<std::string>("i_tf_custom_xacro_args"));
+                                                        ph->getParam<std::string>("i_tf_custom_xacro_args"),
+														ph->getParam<bool>("i_rs_compat"));
     }
     diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
     RCLCPP_INFO(this->get_logger(), "Camera ready!");

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -204,7 +204,7 @@ void Camera::startDevice() {
                 for(const auto& info : availableDevices) {
                     if(!mxid.empty() && info.getMxId() == mxid) {
                         RCLCPP_INFO(this->get_logger(), "Connecting to the camera using mxid: %s", mxid.c_str());
-                        if(info.state == X_LINK_UNBOOTED || info.state == X_LINK_BOOTLOADER) {
+                       if(info.state == X_LINK_UNBOOTED || info.state == X_LINK_BOOTLOADER) {
                             device = std::make_shared<dai::Device>(info, speed);
                             camRunning = true;
                         } else if(info.state == X_LINK_BOOTED) {
@@ -252,8 +252,18 @@ void Camera::startDevice() {
 
 void Camera::setIR() {
     if(ph->getParam<bool>("i_enable_ir") && !device->getIrDrivers().empty()) {
-        device->setIrLaserDotProjectorBrightness(ph->getParam<int>("i_laser_dot_brightness"));
-        device->setIrFloodLightBrightness(ph->getParam<int>("i_floodlight_brightness"));
+		// Normalize laserdot brightness to 0-1 range, max value can be 1200mA
+		float laserdotBrightness = float(ph->getParam<int>("i_laser_dot_brightness"));
+		if(laserdotBrightness > 1.0) {
+			laserdotBrightness = 1200.0 / laserdotBrightness;
+		}
+		// Normalize floodlight brightness to 0-1 range, max value can be 1500mA
+		float floodlightBrightness = float(ph->getParam<int>("i_floodlight_brightness"));
+		if(floodlightBrightness > 1.0) {
+			floodlightBrightness = 1500.0 / floodlightBrightness;
+		}
+        device->setIrFloodLightIntensity(laserdotBrightness);
+        device->setIrFloodLightIntensity(floodlightBrightness);
     }
 }
 
@@ -261,9 +271,17 @@ rcl_interfaces::msg::SetParametersResult Camera::parameterCB(const std::vector<r
     for(const auto& p : params) {
         if(ph->getParam<bool>("i_enable_ir") && !device->getIrDrivers().empty()) {
             if(p.get_name() == ph->getFullParamName("i_laser_dot_brightness")) {
-                device->setIrLaserDotProjectorBrightness(p.get_value<int>());
+				float laserdotBrightness = float(p.get_value<int>());
+				if(laserdotBrightness > 1.0) {
+					laserdotBrightness = 1200.0 / laserdotBrightness;
+				}
+                device->setIrLaserDotProjectorIntensity(laserdotBrightness);
             } else if(p.get_name() == ph->getFullParamName("i_floodlight_brightness")) {
-                device->setIrFloodLightBrightness(p.get_value<int>());
+				float floodlightBrightness = float(p.get_value<int>());
+				if(floodlightBrightness > 1.0) {
+					floodlightBrightness = 1500.0 / floodlightBrightness;
+				}
+                device->setIrFloodLightIntensity(floodlightBrightness);
             }
         }
     }

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -3,6 +3,8 @@
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/Device.hpp"
 #include "depthai/pipeline/Pipeline.hpp"
+#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include "depthai_ros_driver/utils.hpp"
 #include "rclcpp/node.hpp"
 
 namespace depthai_ros_driver {
@@ -28,6 +30,10 @@ std::string BaseNode::getName() {
 
 bool BaseNode::ipcEnabled() {
     return intraProcessEnabled;
+}
+
+std::string BaseNode::getSocketName(dai::CameraBoardSocket socket) {
+    return sensor_helpers::getSocketName(getROSNode(), socket);
 }
 
 std::string BaseNode::getTFPrefix(const std::string& frameName) {

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -9,19 +9,17 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-BaseNode::BaseNode(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> /*pipeline*/) {
-    setNodeName(daiNodeName);
-    setROSNodePointer(node);
+BaseNode::BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> /*pipeline*/) : baseNode(node), baseDAINodeName(daiNodeName), logger(node->get_logger()) {
     intraProcessEnabled = node->get_node_options().use_intra_process_comms();
 };
 BaseNode::~BaseNode() = default;
 void BaseNode::setNodeName(const std::string& daiNodeName) {
     baseDAINodeName = daiNodeName;
 };
-void BaseNode::setROSNodePointer(rclcpp::Node* node) {
+void BaseNode::setROSNodePointer(std::shared_ptr<rclcpp::Node> node) {
     baseNode = node;
 };
-rclcpp::Node* BaseNode::getROSNode() {
+std::shared_ptr<rclcpp::Node> BaseNode::getROSNode() {
     return baseNode;
 };
 std::string BaseNode::getName() {
@@ -30,6 +28,9 @@ std::string BaseNode::getName() {
 
 bool BaseNode::ipcEnabled() {
     return intraProcessEnabled;
+}
+rclcpp::Logger BaseNode::getLogger() {
+	return logger;
 }
 
 bool BaseNode::rsCompabilityMode() {

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -32,6 +32,10 @@ bool BaseNode::ipcEnabled() {
     return intraProcessEnabled;
 }
 
+bool BaseNode::rsCompabilityMode() {
+    return sensor_helpers::rsCompabilityMode(getROSNode());
+}
+
 std::string BaseNode::getSocketName(dai::CameraBoardSocket socket) {
     return sensor_helpers::getSocketName(getROSNode(), socket);
 }
@@ -40,6 +44,13 @@ std::string BaseNode::getTFPrefix(const std::string& frameName) {
     return std::string(getROSNode()->get_name()) + "_" + frameName;
 }
 
+std::string BaseNode::getOpticalTFPrefix(const std::string& frameName) {
+	std::string suffix = "_camera_optical_frame";
+	if(sensor_helpers::rsCompabilityMode(getROSNode())) {
+		suffix = "_optical_frame";
+	}
+    return getTFPrefix(frameName) + suffix;
+}
 dai::Node::Input BaseNode::getInput(int /*linkType = 0*/) {
     throw(std::runtime_error("getInput() not implemented"));
 };

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -59,7 +59,7 @@ dai::Node::Input BaseNode::getInput(int /*linkType = 0*/) {
 };
 
 dai::Node::Input BaseNode::getInputByName(const std::string& /*name*/) {
-    throw(std::runtime_error("getInput() not implemented"));
+    throw(std::runtime_error("getInputByName() not implemented"));
 };
 
 void BaseNode::closeQueues() {
@@ -91,7 +91,7 @@ void BaseNode::link(dai::Node::Input /*in*/, int /*linkType = 0*/) {
     throw(std::runtime_error("link() not implemented"));
 };
 
-std::shared_ptr<sensor_helpers::ImagePublisher> BaseNode::getPublisher(int /*linkType = 0*/) {
+std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> BaseNode::getPublishers() {
     throw(std::runtime_error("getPublisher() not implemented"));
 };
 void BaseNode::updateParams(const std::vector<rclcpp::Parameter>& /*params*/) {

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -100,9 +100,7 @@ void BaseNode::setupOutput(std::shared_ptr<dai::Pipeline> pipeline,
             nodeLink(xout->input);
         }
     }
-	pub = std::make_shared<sensor_helpers::ImagePublisher>();
-	pub->setQueueName(qName);
-	pub->setSynced(isSynced);
+	pub = std::make_shared<sensor_helpers::ImagePublisher>(getROSNode(), qName, isSynced, ipcEnabled());
 };
 
 void BaseNode::setNames() {

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -1,4 +1,5 @@
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
 
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/device/Device.hpp"
@@ -9,7 +10,8 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-BaseNode::BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> /*pipeline*/) : baseNode(node), baseDAINodeName(daiNodeName), logger(node->get_logger()) {
+BaseNode::BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> /*pipeline*/)
+    : baseNode(node), baseDAINodeName(daiNodeName), logger(node->get_logger()) {
     intraProcessEnabled = node->get_node_options().use_intra_process_comms();
 };
 BaseNode::~BaseNode() = default;
@@ -30,7 +32,7 @@ bool BaseNode::ipcEnabled() {
     return intraProcessEnabled;
 }
 rclcpp::Logger BaseNode::getLogger() {
-	return logger;
+    return logger;
 }
 
 bool BaseNode::rsCompabilityMode() {
@@ -46,18 +48,31 @@ std::string BaseNode::getTFPrefix(const std::string& frameName) {
 }
 
 std::string BaseNode::getOpticalTFPrefix(const std::string& frameName) {
-	std::string suffix = "_camera_optical_frame";
-	if(sensor_helpers::rsCompabilityMode(getROSNode())) {
-		suffix = "_optical_frame";
-	}
+    std::string suffix = "_camera_optical_frame";
+    if(sensor_helpers::rsCompabilityMode(getROSNode())) {
+        suffix = "_optical_frame";
+    }
     return getTFPrefix(frameName) + suffix;
 }
 dai::Node::Input BaseNode::getInput(int /*linkType = 0*/) {
     throw(std::runtime_error("getInput() not implemented"));
 };
 
+dai::Node::Input BaseNode::getInputByName(const std::string& /*name*/) {
+    throw(std::runtime_error("getInput() not implemented"));
+};
+
 void BaseNode::closeQueues() {
     throw(std::runtime_error("closeQueues() not implemented"));
+};
+
+std::shared_ptr<dai::node::XLinkOut> BaseNode::setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name) {
+	auto xout = pipeline->create<dai::node::XLinkOut>();
+	xout->setStreamName(name);
+	xout->input.setBlocking(false);
+	xout->input.setWaitForMessage(false);
+	xout->input.setQueueSize(0);
+	return xout;
 };
 
 void BaseNode::setNames() {
@@ -76,6 +91,9 @@ void BaseNode::link(dai::Node::Input /*in*/, int /*linkType = 0*/) {
     throw(std::runtime_error("link() not implemented"));
 };
 
+std::shared_ptr<sensor_helpers::ImagePublisher> BaseNode::getPublisher(int /*linkType = 0*/) {
+    throw(std::runtime_error("getPublisher() not implemented"));
+};
 void BaseNode::updateParams(const std::vector<rclcpp::Parameter>& /*params*/) {
     return;
 };

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,7 +10,7 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+NNWrapper::NNWrapper(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);

--- a/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/nn_wrapper.cpp
@@ -10,7 +10,10 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-NNWrapper::NNWrapper(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+NNWrapper::NNWrapper(const std::string& daiNodeName,
+                     std::shared_ptr<rclcpp::Node> node,
+                     std::shared_ptr<dai::Pipeline> pipeline,
+                     const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s base", daiNodeName.c_str());
     ph = std::make_unique<param_handlers::NNParamHandler>(node, daiNodeName, socket);

--- a/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
@@ -65,7 +65,7 @@ void Segmentation::setupQueues(std::shared_ptr<dai::Device> device) {
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
         infoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
-                                                                *imageConverter,
+                                                                imageConverter,
                                                                 device,
                                                                 dai::CameraBoardSocket::CAM_A,
                                                                 imageManip->initialConfig.getResizeWidth(),

--- a/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
@@ -59,7 +59,7 @@ void Segmentation::setupQueues(std::shared_ptr<dai::Device> device) {
     nnPub = image_transport::create_camera_publisher(getROSNode(), "~/" + getName() + "/image_raw");
     nnQ->addCallback(std::bind(&Segmentation::segmentationCB, this, std::placeholders::_1, std::placeholders::_2));
     if(ph->getParam<bool>("i_enable_passthrough")) {
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         ptQ = device->getOutputQueue(ptQName, ph->getParam<int>("i_max_q_size"), false);
         imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(

--- a/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/segmentation.cpp
@@ -23,7 +23,10 @@ namespace depthai_ros_driver {
 namespace dai_nodes {
 namespace nn {
 
-Segmentation::Segmentation(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, const dai::CameraBoardSocket& socket)
+Segmentation::Segmentation(const std::string& daiNodeName,
+                           std::shared_ptr<rclcpp::Node> node,
+                           std::shared_ptr<dai::Pipeline> pipeline,
+                           const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     setNames();
@@ -94,7 +97,7 @@ void Segmentation::segmentationCB(const std::string& /*name*/, const std::shared
     sensor_msgs::msg::Image img_msg;
     std_msgs::msg::Header header;
     header.stamp = getROSNode()->get_clock()->now();
-	auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+    auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
     header.frame_id = tfPrefix;
     nnInfo.header = header;
     imgBridge = cv_bridge::CvImage(header, sensor_msgs::image_encodings::BGR8, cv_frame);

--- a/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/nn/spatial_nn_wrapper.cpp
@@ -10,7 +10,7 @@
 namespace depthai_ros_driver {
 namespace dai_nodes {
 SpatialNNWrapper::SpatialNNWrapper(const std::string& daiNodeName,
-                                   rclcpp::Node* node,
+                                   std::shared_ptr<rclcpp::Node> node,
                                    std::shared_ptr<dai::Pipeline> pipeline,
                                    const dai::CameraBoardSocket& socket)
     : BaseNode(daiNodeName, node, pipeline) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/feature_tracker.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/feature_tracker.cpp
@@ -13,16 +13,16 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-FeatureTracker::FeatureTracker(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline)
+FeatureTracker::FeatureTracker(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline)
     : BaseNode(daiNodeName, node, pipeline) {
-    RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     getParentName(daiNodeName);
     setNames();
     featureNode = pipeline->create<dai::node::FeatureTracker>();
     ph = std::make_unique<param_handlers::FeatureTrackerParamHandler>(node, daiNodeName);
     ph->declareParams(featureNode);
     setXinXout(pipeline);
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Node %s created", daiNodeName.c_str());
 }
 FeatureTracker::~FeatureTracker() = default;
 

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -52,19 +52,23 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
                                                             enableMagn,
                                                             ph->getParam<bool>("i_get_base_device_timestamp"));
     imuConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
+	std::string topicSuffix = "/data";
+	if(rsCompabilityMode()) {
+		topicSuffix = "";
+	}
     switch(msgType) {
         case param_handlers::imu::ImuMsgType::IMU: {
-            rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + "/data", 10, options);
+            rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + topicSuffix, 10, options);
             imuQ->addCallback(std::bind(&Imu::imuRosQCB, this, std::placeholders::_1, std::placeholders::_2));
             break;
         }
         case param_handlers::imu::ImuMsgType::IMU_WITH_MAG: {
-            daiImuPub = getROSNode()->create_publisher<depthai_ros_msgs::msg::ImuWithMagneticField>("~/" + getName() + "/data", 10, options);
+            daiImuPub = getROSNode()->create_publisher<depthai_ros_msgs::msg::ImuWithMagneticField>("~/" + getName() + topicSuffix, 10, options);
             imuQ->addCallback(std::bind(&Imu::imuDaiRosQCB, this, std::placeholders::_1, std::placeholders::_2));
             break;
         }
         case param_handlers::imu::ImuMsgType::IMU_WITH_MAG_SPLIT: {
-            rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + "/data", 10, options);
+            rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + topicSuffix, 10, options);
             magPub = getROSNode()->create_publisher<sensor_msgs::msg::MagneticField>("~/" + getName() + "/mag", 10, options);
             imuQ->addCallback(std::bind(&Imu::imuMagQCB, this, std::placeholders::_1, std::placeholders::_2));
             break;

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -52,10 +52,10 @@ void Imu::setupQueues(std::shared_ptr<dai::Device> device) {
                                                             enableMagn,
                                                             ph->getParam<bool>("i_get_base_device_timestamp"));
     imuConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-	std::string topicSuffix = "/data";
-	if(rsCompabilityMode()) {
-		topicSuffix = "";
-	}
+    std::string topicSuffix = "/data";
+    if(rsCompabilityMode()) {
+        topicSuffix = "";
+    }
     switch(msgType) {
         case param_handlers::imu::ImuMsgType::IMU: {
             rosImuPub = getROSNode()->create_publisher<sensor_msgs::msg::Imu>("~/" + getName() + topicSuffix, 10, options);

--- a/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/imu.cpp
@@ -13,15 +13,15 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-Imu::Imu(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline, std::shared_ptr<dai::Device> device)
+Imu::Imu(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline, std::shared_ptr<dai::Device> device)
     : BaseNode(daiNodeName, node, pipeline) {
-    RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     imuNode = pipeline->create<dai::node::IMU>();
     ph = std::make_unique<param_handlers::ImuParamHandler>(node, daiNodeName);
     ph->declareParams(imuNode, device->getConnectedIMU());
     setXinXout(pipeline);
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Node %s created", daiNodeName.c_str());
 }
 Imu::~Imu() = default;
 void Imu::setNames() {

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -58,7 +58,7 @@ void Mono::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 
 void Mono::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         imageConverter =
             std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
         imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -51,6 +51,7 @@ void Mono::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     xinControl->setStreamName(controlQName);
     xinControl->out.link(monoCamNode->inputControl);
     imagePublisher = std::make_shared<sensor_helpers::ImagePublisher>();
+	imagePublisher->setQueueName(monoQName);
 }
 
 void Mono::setupQueues(std::shared_ptr<dai::Device> device) {
@@ -97,8 +98,9 @@ void Mono::link(dai::Node::Input in, int /*linkType*/) {
     monoCamNode->out.link(in);
 }
 
-std::shared_ptr<sensor_helpers::ImagePublisher> Mono::getPublisher(int linkType) {
-    return imagePublisher;
+std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> Mono::getPublishers() {
+	imagePublisher->setSynced(true);
+    return std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>>{imagePublisher};
 }
 
 void Mono::updateParams(const std::vector<rclcpp::Parameter>& params) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -38,13 +38,10 @@ void Mono::setNames() {
 
 void Mono::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     if(ph->getParam<bool>("i_publish_topic")) {
-        setupOutput(
+        imagePublisher = setupOutput(
             pipeline,
             monoQName,
-            xoutMono,
-            videoEnc,
-            imagePublisher,
-            [&](auto& input) { monoCamNode->out.link(input); },
+            [&](auto input) { monoCamNode->out.link(input); },
             ph->getParam<bool>("i_synced"),
             ph->getParam<bool>("i_low_bandwidth"),
             ph->getParam<int>("i_low_bandwidth_quality"));
@@ -57,34 +54,34 @@ void Mono::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 void Mono::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
         auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
-		sensor_helpers::ImgConverterConfig convConf;
-		convConf.tfPrefix = tfPrefix;
-		convConf.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
-		convConf.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
-		convConf.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
-		convConf.encoding = dai::RawImgFrame::Type::GRAY8;
-		convConf.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
-		convConf.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
-		convConf.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");
+        sensor_helpers::ImgConverterConfig convConf;
+        convConf.tfPrefix = tfPrefix;
+        convConf.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
+        convConf.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
+        convConf.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
+        convConf.encoding = dai::RawImgFrame::Type::GRAY8;
+        convConf.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
+        convConf.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
+        convConf.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");
 
-		sensor_helpers::ImgPublisherConfig pubConf;
-		pubConf.daiNodeName = getName();
-		pubConf.topicName = "~/"+ getName();
-		pubConf.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
-		pubConf.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
-		pubConf.calibrationFile = ph->getParam<std::string>("i_calibration_file");
-		pubConf.rectified = false;
-		pubConf.width = ph->getParam<int>("i_width");
-		pubConf.height = ph->getParam<int>("i_height");
-		pubConf.maxQSize = ph->getParam<int>("i_max_q_size");
-		
-		imagePublisher->setup(device, convConf, pubConf);
+        sensor_helpers::ImgPublisherConfig pubConf;
+        pubConf.daiNodeName = getName();
+        pubConf.topicName = "~/" + getName();
+        pubConf.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
+        pubConf.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
+        pubConf.calibrationFile = ph->getParam<std::string>("i_calibration_file");
+        pubConf.rectified = false;
+        pubConf.width = ph->getParam<int>("i_width");
+        pubConf.height = ph->getParam<int>("i_height");
+        pubConf.maxQSize = ph->getParam<int>("i_max_q_size");
+
+        imagePublisher->setup(device, convConf, pubConf);
     }
     controlQ = device->getInputQueue(controlQName);
 }
 void Mono::closeQueues() {
     if(ph->getParam<bool>("i_publish_topic")) {
-        monoQ->close();
+        imagePublisher->closeQueue();
     }
     controlQ->close();
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -16,19 +16,19 @@
 namespace depthai_ros_driver {
 namespace dai_nodes {
 Mono::Mono(const std::string& daiNodeName,
-           rclcpp::Node* node,
+           std::shared_ptr<rclcpp::Node> node,
            std::shared_ptr<dai::Pipeline> pipeline,
            dai::CameraBoardSocket socket,
            dai_nodes::sensor_helpers::ImageSensor sensor,
            bool publish = true)
     : BaseNode(daiNodeName, node, pipeline) {
-    RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     monoCamNode = pipeline->create<dai::node::MonoCamera>();
     ph = std::make_unique<param_handlers::SensorParamHandler>(node, daiNodeName, socket);
     ph->declareParams(monoCamNode, sensor, publish);
     setXinXout(pipeline);
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Node %s created", daiNodeName.c_str());
 }
 Mono::~Mono() = default;
 void Mono::setNames() {

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -58,9 +58,9 @@ void Mono::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 
 void Mono::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
-        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         imageConverter =
-            std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
+            std::make_unique<dai::ros::ImageConverter>(tfPrefix , false, ph->getParam<bool>("i_get_base_device_timestamp"));
         imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         if(ph->getParam<bool>("i_low_bandwidth")) {
             imageConverter->convertFromBitstream(dai::RawImgFrame::Type::GRAY8);

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -69,7 +69,7 @@ void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 
 void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
         imageConverter =
@@ -126,7 +126,7 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
 
         previewInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + previewQName).get(), previewQName);
-        auto tfPrefix = getTFPrefix(utils::getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
         imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         if(ph->getParam<std::string>("i_calibration_file").empty()) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -69,7 +69,7 @@ void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 
 void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
-        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
         imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false, ph->getParam<bool>("i_get_base_device_timestamp"));

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -59,6 +59,7 @@ void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     xinControl->out.link(colorCamNode->inputControl);
     previewPub = std::make_shared<sensor_helpers::ImagePublisher>();
     rgbPub = std::make_shared<sensor_helpers::ImagePublisher>();
+    rgbPub->setQueueName(ispQName);
 }
 
 void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
@@ -140,10 +141,9 @@ void RGB::link(dai::Node::Input in, int linkType) {
     }
 }
 
-std::shared_ptr<sensor_helpers::ImagePublisher> RGB::getPublisher(int linkType) {
-    rgbPub->setQueueName(ispQName);
+std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> RGB::getPublishers() {
 	rgbPub->setSynced(true);
-    return rgbPub;
+    return std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>>{rgbPub};
 }
 
 void RGB::updateParams(const std::vector<rclcpp::Parameter>& params) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -72,8 +72,7 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
         infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
-        imageConverter =
-            std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
+        imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false, ph->getParam<bool>("i_get_base_device_timestamp"));
         imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         if(ph->getParam<bool>("i_low_bandwidth")) {
             imageConverter->convertFromBitstream(dai::RawImgFrame::Type::BGR888i);
@@ -126,8 +125,8 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
 
         previewInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
             getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + previewQName).get(), previewQName);
-        auto tfPrefix = getTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
-        imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false);
+        auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
+        imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false);
         imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
         if(ph->getParam<std::string>("i_calibration_file").empty()) {
             previewInfoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -69,67 +69,58 @@ void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_topic")) {
         auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
-        infoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
-            getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
-        imageConverter = std::make_shared<dai::ros::ImageConverter>(tfPrefix, false, ph->getParam<bool>("i_get_base_device_timestamp"));
-        imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-        if(ph->getParam<bool>("i_low_bandwidth")) {
-            imageConverter->convertFromBitstream(dai::RawImgFrame::Type::BGR888i);
-        }
-        if(ph->getParam<bool>("i_add_exposure_offset")) {
-            auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
-            imageConverter->addExposureOffset(offset);
-        }
+		sensor_helpers::ImgConverterConfig convConfig;
+		convConfig.tfPrefix = tfPrefix;
+		convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
+		convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
+		convConfig.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
+		convConfig.encoding = dai::RawImgFrame::Type::BGR888i;
+		convConfig.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
+		convConfig.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
+		convConfig.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");
 
-        if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
-            imageConverter->reverseStereoSocketOrder();
-        }
+		sensor_helpers::ImgPublisherConfig pubConfig;
+		pubConfig.daiNodeName = getName();
+		pubConfig.topicName = "~/" + getName();
+		pubConfig.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
+		pubConfig.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
+		pubConfig.calibrationFile = ph->getParam<std::string>("i_calibration_file");
+		pubConfig.rectified = false;
+		pubConfig.width = ph->getParam<int>("i_width");
+		pubConfig.height = ph->getParam<int>("i_height");
+		pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
 
-        if(ph->getParam<std::string>("i_calibration_file").empty()) {
-            infoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
-                                                                    *imageConverter,
-                                                                    device,
-                                                                    static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")),
-                                                                    ph->getParam<int>("i_width"),
-                                                                    ph->getParam<int>("i_height")));
-        } else {
-            infoManager->loadCameraInfo(ph->getParam<std::string>("i_calibration_file"));
-        }
-
-        rgbPub->setup(getROSNode(), "~/" + getName(), ph->getParam<bool>("i_enable_lazy_publisher"), ipcEnabled(), infoManager, imageConverter);
-        if(!ph->getParam<bool>("i_synced")) {
-            colorQ = device->getOutputQueue(ispQName, ph->getParam<int>("i_max_q_size"), false);
-            rgbPub->addQueueCB(colorQ);
-        }
+		rgbPub->setup(device, convConfig, pubConfig);
     }
     if(ph->getParam<bool>("i_enable_preview")) {
-        previewInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(
-            getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + previewQName).get(), previewQName);
         auto tfPrefix = getOpticalTFPrefix(getSocketName(static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"))));
-        imageConverter = std::make_unique<dai::ros::ImageConverter>(tfPrefix, false);
-        imageConverter->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-        if(ph->getParam<std::string>("i_calibration_file").empty()) {
-            previewInfoManager->setCameraInfo(sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
-                                                                           *imageConverter,
-                                                                           device,
-                                                                           static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")),
-                                                                           ph->getParam<int>("i_preview_size"),
-                                                                           ph->getParam<int>("i_preview_size")));
-        } else {
-            previewInfoManager->loadCameraInfo(ph->getParam<std::string>("i_calibration_file"));
-        }
-        previewPub->setup(getROSNode(), "~/" + getName(), ph->getParam<bool>("i_enable_lazy_publisher"), ipcEnabled(), previewInfoManager, imageConverter);
-        previewQ = device->getOutputQueue(previewQName, ph->getParam<int>("i_max_q_size"), false);
-        previewPub->addQueueCB(previewQ);
+		sensor_helpers::ImgConverterConfig convConfig;
+		convConfig.tfPrefix = tfPrefix;
+		convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
+		convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
+
+		sensor_helpers::ImgPublisherConfig pubConfig;
+		pubConfig.daiNodeName = getName();
+		pubConfig.topicName = "~/" + getName();
+		pubConfig.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
+		pubConfig.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
+		pubConfig.calibrationFile = ph->getParam<std::string>("i_calibration_file");
+		pubConfig.rectified = false;
+		pubConfig.width = ph->getParam<int>("i_preview_width");
+		pubConfig.height = ph->getParam<int>("i_preview_height");
+		pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
+		pubConfig.topicSuffix = "/preview/image_raw";
+
+		previewPub->setup(device, convConfig, pubConfig);
     };
     controlQ = device->getInputQueue(controlQName);
 }
 
 void RGB::closeQueues() {
     if(ph->getParam<bool>("i_publish_topic")) {
-        colorQ->close();
+        rgbPub->closeQueue();
         if(ph->getParam<bool>("i_enable_preview")) {
-            previewQ->close();
+			previewPub->closeQueue();
         }
     }
     controlQ->close();

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -39,13 +39,12 @@ void RGB::setNames() {
 void RGB::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     bool outputIsp = ph->getParam<bool>("i_output_isp");
     bool lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
-    auto rgbLinkChoice = [&](auto input) {
-        if(outputIsp && !lowBandwidth) {
-            colorCamNode->isp.link(input);
-        } else {
-            colorCamNode->video.link(input);
-        }
-    };
+    std::function<void(dai::Node::Input)> rgbLinkChoice;
+    if(outputIsp && !lowBandwidth) {
+        rgbLinkChoice = [&](auto input) { colorCamNode->isp.link(input); };
+    } else {
+        rgbLinkChoice = [&](auto input) { colorCamNode->video.link(input); };
+    }
     if(ph->getParam<bool>("i_publish_topic")) {
         rgbPub = setupOutput(pipeline, ispQName, rgbLinkChoice, ph->getParam<bool>("i_synced"), lowBandwidth, ph->getParam<int>("i_low_bandwidth_quality"));
     }

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -15,19 +15,19 @@
 namespace depthai_ros_driver {
 namespace dai_nodes {
 RGB::RGB(const std::string& daiNodeName,
-         rclcpp::Node* node,
+         std::shared_ptr<rclcpp::Node> node,
          std::shared_ptr<dai::Pipeline> pipeline,
          dai::CameraBoardSocket socket = dai::CameraBoardSocket::CAM_A,
          sensor_helpers::ImageSensor sensor = {"IMX378", "4k", {"12mp", "4k"}, true},
          bool publish = true)
     : BaseNode(daiNodeName, node, pipeline) {
-    RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     colorCamNode = pipeline->create<dai::node::ColorCamera>();
     ph = std::make_unique<param_handlers::SensorParamHandler>(node, daiNodeName, socket);
     ph->declareParams(colorCamNode, sensor, publish);
     setXinXout(pipeline);
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Node %s created", daiNodeName.c_str());
 }
 RGB::~RGB() = default;
 void RGB::setNames() {

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -31,6 +31,45 @@ const std::unordered_map<dai::CameraBoardSocket, std::string> socketNameMap = {
     {dai::CameraBoardSocket::CAM_D, "left_back"},
     {dai::CameraBoardSocket::CAM_E, "right_back"},
 };
+const std::unordered_map<dai::CameraBoardSocket, std::string> rsSocketNameMap = {
+    {dai::CameraBoardSocket::AUTO, "color"},
+    {dai::CameraBoardSocket::CAM_A, "color"},
+    {dai::CameraBoardSocket::CAM_B, "infra2"},
+    {dai::CameraBoardSocket::CAM_C, "infra1"},
+    {dai::CameraBoardSocket::CAM_D, "infra4"},
+    {dai::CameraBoardSocket::CAM_E, "infra3"},
+};
+const std::unordered_map<NodeNameEnum, std::string> rsNodeNameMap = {
+    {NodeNameEnum::RGB, "color"},
+    {NodeNameEnum::Left, "infra2"},
+    {NodeNameEnum::Right, "infra1"},
+    {NodeNameEnum::Stereo, "stereo"},
+    {NodeNameEnum::IMU, "imu"},
+    {NodeNameEnum::NN, "nn"},
+};
+
+const std::unordered_map<NodeNameEnum, std::string> NodeNameMap = {
+    {NodeNameEnum::RGB, "rgb"},
+    {NodeNameEnum::Left, "left"},
+    {NodeNameEnum::Right, "right"},
+    {NodeNameEnum::Stereo, "stereo"},
+    {NodeNameEnum::IMU, "imu"},
+    {NodeNameEnum::NN, "nn"},
+};
+
+bool rsCompabilityMode(rclcpp::Node* node) {
+    return node->get_parameter("camera.i_rs_compat").as_bool();
+}
+std::string getNodeName(rclcpp::Node* node, NodeNameEnum name) {
+    if(rsCompabilityMode(node)) {
+        return rsNodeNameMap.at(name);
+    }
+    return NodeNameMap.at(name);
+}
+
+std::string getSocketName(rclcpp::Node, dai::CameraBoardSocket socket) {
+    return socketNameMap.at(socket);
+}
 const std::unordered_map<std::string, dai::MonoCameraProperties::SensorResolution> monoResolutionMap = {
     {"400P", dai::MonoCameraProperties::SensorResolution::THE_400_P},
     {"480P", dai::MonoCameraProperties::SensorResolution::THE_480_P},

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -67,7 +67,10 @@ std::string getNodeName(rclcpp::Node* node, NodeNameEnum name) {
     return NodeNameMap.at(name);
 }
 
-std::string getSocketName(rclcpp::Node, dai::CameraBoardSocket socket) {
+std::string getSocketName(rclcpp::Node* node, dai::CameraBoardSocket socket) {
+    if(rsCompabilityMode(node)) {
+        return rsSocketNameMap.at(socket);
+    }
     return socketNameMap.at(socket);
 }
 const std::unordered_map<std::string, dai::MonoCameraProperties::SensorResolution> monoResolutionMap = {

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -126,12 +126,6 @@ void ImagePublisher::addQueueCB(const std::shared_ptr<dai::DataOutputQueue>& que
 std::string ImagePublisher::getQueueName() {
     return qName;
 }
-void ImagePublisher::setQueueName(const std::string& name) {
-    qName = name;
-}
-void ImagePublisher::setSynced(bool sync) {
-    synced = sync;
-}
 std::pair<sensor_msgs::msg::Image::UniquePtr, sensor_msgs::msg::CameraInfo::UniquePtr> ImagePublisher::convertData(const std::shared_ptr<dai::ADatatype> data) {
     auto img = std::dynamic_pointer_cast<dai::ImgFrame>(data);
     auto info = infoManager->getCameraInfo();

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -1,4 +1,5 @@
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include <depthai/pipeline/node/XLinkOut.hpp>
 
 #include "camera_info_manager/camera_info_manager.hpp"
 #include "depthai/pipeline/Pipeline.hpp"

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -43,7 +43,7 @@ const std::unordered_map<NodeNameEnum, std::string> rsNodeNameMap = {
     {NodeNameEnum::RGB, "color"},
     {NodeNameEnum::Left, "infra2"},
     {NodeNameEnum::Right, "infra1"},
-    {NodeNameEnum::Stereo, "stereo"},
+    {NodeNameEnum::Stereo, "depth"},
     {NodeNameEnum::IMU, "imu"},
     {NodeNameEnum::NN, "nn"},
 };

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -15,7 +15,7 @@
 namespace depthai_ros_driver {
 namespace dai_nodes {
 SensorWrapper::SensorWrapper(const std::string& daiNodeName,
-                             rclcpp::Node* node,
+                             std::shared_ptr<rclcpp::Node> node,
                              std::shared_ptr<dai::Pipeline> pipeline,
                              std::shared_ptr<dai::Device> device,
                              dai::CameraBoardSocket socket,

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -131,6 +131,13 @@ void SensorWrapper::link(dai::Node::Input in, int linkType) {
     }
 }
 
+std::shared_ptr<sensor_helpers::ImagePublisher> SensorWrapper::getPublisher(int linkType) {
+	if(ph->getParam<bool>("i_disable_node")) {
+		return nullptr;
+	}
+	return sensorNode->getPublisher(linkType);
+}
+
 void SensorWrapper::updateParams(const std::vector<rclcpp::Parameter>& params) {
     sensorNode->updateParams(params);
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -132,10 +132,10 @@ void SensorWrapper::link(dai::Node::Input in, int linkType) {
 }
 
 std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> SensorWrapper::getPublishers() {
-	if(ph->getParam<bool>("i_disable_node")) {
-		return std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>>();
-	}
-	return sensorNode->getPublishers();
+    if(ph->getParam<bool>("i_disable_node")) {
+        return std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>>();
+    }
+    return sensorNode->getPublishers();
 }
 
 void SensorWrapper::updateParams(const std::vector<rclcpp::Parameter>& params) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_wrapper.cpp
@@ -131,11 +131,11 @@ void SensorWrapper::link(dai::Node::Input in, int linkType) {
     }
 }
 
-std::shared_ptr<sensor_helpers::ImagePublisher> SensorWrapper::getPublisher(int linkType) {
+std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>> SensorWrapper::getPublishers() {
 	if(ph->getParam<bool>("i_disable_node")) {
-		return nullptr;
+		return std::vector<std::shared_ptr<sensor_helpers::ImagePublisher>>();
 	}
-	return sensorNode->getPublisher(linkType);
+	return sensorNode->getPublishers();
 }
 
 void SensorWrapper::updateParams(const std::vector<rclcpp::Parameter>& params) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
@@ -1,0 +1,86 @@
+#include "depthai_ros_driver/dai_nodes/sensors/sync.hpp"
+
+#include <chrono>
+
+#include "depthai/pipeline/Pipeline.hpp"
+#include "depthai/pipeline/datatype/MessageGroup.hpp"
+#include "depthai/pipeline/node/Sync.hpp"
+#include "depthai/pipeline/node/XLinkOut.hpp"
+#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+
+namespace depthai_ros_driver {
+namespace dai_nodes {
+
+Sync::Sync(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline)
+    : BaseNode(daiNodeName, node, pipeline) {
+    syncNode = pipeline->create<dai::node::Sync>();
+    syncNode->setSyncThreshold(std::chrono::milliseconds(10));
+    syncNames = {"rgb", "stereo"};
+    setNames();
+    setXinXout(pipeline);
+}
+
+Sync::~Sync() = default;
+
+void Sync::setNames() {
+    syncOutputName = getName() + "_out";
+}
+void Sync::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
+    xoutFrame = pipeline->create<dai::node::XLinkOut>();
+    xoutFrame->setStreamName(syncOutputName);
+	xoutFrame->input.setBlocking(false);
+    syncNode->out.link(xoutFrame->input);
+}
+
+std::vector<std::string> Sync::getSyncNames() {
+    return syncNames;
+}
+
+void Sync::setupQueues(std::shared_ptr<dai::Device> device) {
+    outQueue = device->getOutputQueue(syncOutputName, 8, false);
+    outQueue->addCallback([this](const std::shared_ptr<dai::ADatatype>& in) {
+        auto group = std::dynamic_pointer_cast<dai::MessageGroup>(in);
+        if(group) {
+            bool firstMsg = true;
+            rclcpp::Time timestamp;
+            for(auto& msg : *group) {
+                // find publisher by message namespace
+                for(auto& pub : publishers) {
+                    if(pub->getQueueName() == msg.first) {
+                        auto data = pub->convertData(msg.second);
+                        if(firstMsg) {
+                            timestamp = data.first->header.stamp;
+                            firstMsg = false;
+                        }
+                        data.first->header.stamp = timestamp;
+                        data.second->header.stamp = timestamp;
+                        pub->publish(std::move(data));
+                    }
+                }
+            }
+        }
+    });
+}
+
+void Sync::link(dai::Node::Input in, int linkType) {
+    syncNode->out.link(in);
+}
+
+dai::Node::Input Sync::getInputByName(const std::string& name) {
+	syncNode->inputs[name].setBlocking(false);
+    return syncNode->inputs[name];
+}
+
+void Sync::closeQueues() {
+    outQueue->close();
+}
+
+void Sync::addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publisher) {
+    publishers.push_back(publisher);
+}
+
+void Sync::updateParams(const std::vector<rclcpp::Parameter>& params) {
+    return;
+}
+}  // namespace dai_nodes
+}  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
@@ -7,6 +7,7 @@
 #include "depthai/pipeline/node/Sync.hpp"
 #include "depthai/pipeline/node/XLinkOut.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
+#include "depthai_ros_driver/param_handlers/sync_param_handler.hpp"
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
@@ -14,7 +15,8 @@ namespace dai_nodes {
 Sync::Sync(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline)
     : BaseNode(daiNodeName, node, pipeline) {
     syncNode = pipeline->create<dai::node::Sync>();
-    syncNode->setSyncThreshold(std::chrono::milliseconds(10));
+    paramHandler = std::make_unique<param_handlers::SyncParamHandler>(node, daiNodeName);
+    paramHandler->declareParams(syncNode);
     syncNames = {"rgb", "stereo"};
     setNames();
     setXinXout(pipeline);
@@ -28,7 +30,7 @@ void Sync::setNames() {
 void Sync::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     xoutFrame = pipeline->create<dai::node::XLinkOut>();
     xoutFrame->setStreamName(syncOutputName);
-	xoutFrame->input.setBlocking(false);
+    xoutFrame->input.setBlocking(false);
     syncNode->out.link(xoutFrame->input);
 }
 
@@ -67,7 +69,7 @@ void Sync::link(dai::Node::Input in, int linkType) {
 }
 
 dai::Node::Input Sync::getInputByName(const std::string& name) {
-	syncNode->inputs[name].setBlocking(false);
+    syncNode->inputs[name].setBlocking(false);
     return syncNode->inputs[name];
 }
 
@@ -79,8 +81,5 @@ void Sync::addPublisher(std::shared_ptr<sensor_helpers::ImagePublisher> publishe
     publishers.push_back(publisher);
 }
 
-void Sync::updateParams(const std::vector<rclcpp::Parameter>& params) {
-    return;
-}
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
@@ -64,7 +64,7 @@ void Sync::setupQueues(std::shared_ptr<dai::Device> device) {
     });
 }
 
-void Sync::link(dai::Node::Input in, int linkType) {
+void Sync::link(dai::Node::Input in, int /* linkType */) {
     syncNode->out.link(in);
 }
 

--- a/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
@@ -17,7 +17,6 @@ Sync::Sync(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, s
     syncNode = pipeline->create<dai::node::Sync>();
     paramHandler = std::make_unique<param_handlers::SyncParamHandler>(node, daiNodeName);
     paramHandler->declareParams(syncNode);
-    syncNames = {"rgb", "stereo"};
     setNames();
     setXinXout(pipeline);
 }
@@ -34,9 +33,6 @@ void Sync::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     syncNode->out.link(xoutFrame->input);
 }
 
-std::vector<std::string> Sync::getSyncNames() {
-    return syncNames;
-}
 
 void Sync::setupQueues(std::shared_ptr<dai::Device> device) {
     outQueue = device->getOutputQueue(syncOutputName, 8, false);

--- a/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sync.cpp
@@ -33,7 +33,6 @@ void Sync::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
     syncNode->out.link(xoutFrame->input);
 }
 
-
 void Sync::setupQueues(std::shared_ptr<dai::Device> device) {
     outQueue = device->getOutputQueue(syncOutputName, 8, false);
     outQueue->addCallback([this](const std::shared_ptr<dai::ADatatype>& in) {

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -144,6 +144,7 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
     pubConfig.width = ph->getOtherNodeParam<int>(sensorName, "i_width");
     pubConfig.height = ph->getOtherNodeParam<int>(sensorName, "i_height");
     pubConfig.topicName = "~/" + sensorName;
+	pubConfig.topicSuffix = "/image_rect";
     pubConfig.maxQSize = ph->getOtherNodeParam<int>(sensorName, "i_max_q_size");
     pubConfig.socket = sensorInfo.socket;
     pubConfig.infoMgrSuffix = "rect";

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -144,7 +144,7 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
     pubConfig.width = ph->getOtherNodeParam<int>(sensorName, "i_width");
     pubConfig.height = ph->getOtherNodeParam<int>(sensorName, "i_height");
     pubConfig.topicName = "~/" + sensorName;
-	pubConfig.topicSuffix = "/image_rect";
+    pubConfig.topicSuffix = "/image_rect";
     pubConfig.maxQSize = ph->getOtherNodeParam<int>(sensorName, "i_max_q_size");
     pubConfig.socket = sensorInfo.socket;
     pubConfig.infoMgrSuffix = "rect";

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -41,8 +41,10 @@ Stereo::Stereo(const std::string& daiNodeName,
     for(auto f : features) {
         if(f.socket == leftSocket) {
             leftSensInfo = f;
+			leftSensInfo.name = getSocketName(leftSocket);
         } else if(f.socket == rightSocket) {
             rightSensInfo = f;
+			rightSensInfo.name = getSocketName(rightSocket);
         } else {
             continue;
         }

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -141,64 +141,40 @@ void Stereo::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 
 void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
                             dai::CameraFeatures& sensorInfo,
-                            const std::string& queueName,
-                            std::shared_ptr<dai::ros::ImageConverter> conv,
-                            std::shared_ptr<camera_info_manager::CameraInfoManager> im,
-                            std::shared_ptr<dai::DataOutputQueue> q,
                             std::shared_ptr<sensor_helpers::ImagePublisher> pub,
                             bool isLeft) {
     auto sensorName = getSocketName(sensorInfo.socket);
     auto tfPrefix = getOpticalTFPrefix(sensorName);
-    conv = std::make_shared<dai::ros::ImageConverter>(tfPrefix, false, ph->getParam<bool>("i_get_base_device_timestamp"));
-    conv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-    bool lowBandwidth = ph->getParam<bool>(isLeft ? "i_left_rect_low_bandwidth" : "i_right_rect_low_bandwidth");
-    if(lowBandwidth) {
-        conv->convertFromBitstream(dai::RawImgFrame::Type::GRAY8);
-    }
-    bool addOffset = ph->getParam<bool>(isLeft ? "i_left_rect_add_exposure_offset" : "i_right_rect_add_exposure_offset");
-    if(addOffset) {
-        auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>(isLeft ? "i_left_rect_exposure_offset" : "i_right_rect_exposure_offset"));
-        conv->addExposureOffset(offset);
-    }
-    im = std::make_shared<camera_info_manager::CameraInfoManager>(getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + sensorName).get(),
-                                                                  "/rect");
-    if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
-        conv->reverseStereoSocketOrder();
-    }
-    auto info = sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
-                                             *conv,
-                                             device,
-                                             sensorInfo.socket,
-                                             ph->getOtherNodeParam<int>(sensorName, "i_width"),
-                                             ph->getOtherNodeParam<int>(sensorName, "i_height"));
-    for(auto& d : info.d) {
-        d = 0.0;
-    }
+    sensor_helpers::ImgConverterConfig convConfig;
+    convConfig.tfPrefix = tfPrefix;
+    convConfig.interleaved = false;
+    convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
+    convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
+    convConfig.lowBandwidth = ph->getParam<bool>(isLeft ? "i_left_rect_low_bandwidth" : "i_right_rect_low_bandwidth");
+    convConfig.encoding = dai::RawImgFrame::Type::GRAY8;
+    convConfig.addExposureOffset = ph->getParam<bool>(isLeft ? "i_left_rect_add_exposure_offset" : "i_right_rect_add_exposure_offset");
+    convConfig.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>(isLeft ? "i_left_rect_exposure_offset" : "i_right_rect_exposure_offset"));
+    convConfig.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");
 
-    for(auto& r : info.r) {
-        r = 0.0;
-    }
-    info.r[0] = info.r[4] = info.r[8] = 1.0;
+	sensor_helpers::ImgPublisherConfig pubConfig;
+	pubConfig.daiNodeName = sensorName;
+	pubConfig.rectified = true;
+	pubConfig.width =ph->getOtherNodeParam<int>(sensorName, "i_width");
+	pubConfig.height = ph->getOtherNodeParam<int>(sensorName, "i_height");
+	pubConfig.topicName = "~/" + sensorName; 
+	pubConfig.maxQSize = ph->getOtherNodeParam<int>(sensorName, "i_max_q_size");
+	pubConfig.socket = sensorInfo.socket;	
+	pubConfig.infoMgrSuffix = "rect";
 
-    im->setCameraInfo(info);
-
-    q = device->getOutputQueue(queueName, ph->getOtherNodeParam<int>(sensorName, "i_max_q_size"), false);
-
-    // if publish synced pair is set to true then we skip individual publishing of left and right rectified frames
-    bool addCallback = !ph->getParam<bool>("i_publish_synced_rect_pair");
-
-    pub->setup(getROSNode(), "~/" + sensorName, ph->getParam<bool>("i_enable_lazy_publisher"), ipcEnabled(), im, conv);
-    if(addCallback) {
-        pub->addQueueCB(q);
-    }
+	pub->setup(device, convConfig, pubConfig);
 }
 
 void Stereo::setupLeftRectQueue(std::shared_ptr<dai::Device> device) {
-    setupRectQueue(device, leftSensInfo, leftRectQName, leftRectConv, leftRectIM, leftRectQ, leftRectPub, true);
+    setupRectQueue(device, leftSensInfo,  leftRectPub, true);
 }
 
 void Stereo::setupRightRectQueue(std::shared_ptr<dai::Device> device) {
-    setupRectQueue(device, rightSensInfo, rightRectQName, rightRectConv, rightRectIM, rightRectQ, rightRectPub, false);
+    setupRectQueue(device, rightSensInfo, rightRectPub, false);
 }
 
 void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
@@ -208,55 +184,33 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     } else {
         tfPrefix = getOpticalTFPrefix(getSocketName(rightSensInfo.socket).c_str());
     }
-    stereoConv = std::make_shared<dai::ros::ImageConverter>(tfPrefix, false, ph->getParam<bool>("i_get_base_device_timestamp"));
-    stereoConv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
-    if(ph->getParam<bool>("i_low_bandwidth")) {
-        stereoConv->convertFromBitstream(dai::RawImgFrame::Type::RAW8);
-    }
+	sensor_helpers::ImgConverterConfig convConfig;
+	convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
+	convConfig.tfPrefix = tfPrefix;
+	convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
+	convConfig.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
+	convConfig.encoding = dai::RawImgFrame::Type::RAW8;
+	convConfig.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
+	convConfig.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
+	convConfig.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");
+	convConfig.alphaScalingEnabled = ph->getParam<bool>("i_enable_alpha_scaling");
+	convConfig.alphaScaling = ph->getParam<double>("i_alpha_scaling");
+	convConfig.outputDisparity = ph->getParam<bool>("i_output_disparity");
+	
+	sensor_helpers::ImgPublisherConfig pubConf;
+	pubConf.rectified = !convConfig.alphaScalingEnabled;
+	pubConf.width = ph->getParam<int>("i_width");
+	pubConf.height = ph->getParam<int>("i_height");
+	pubConf.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
+	pubConf.calibrationFile = ph->getParam<std::string>("i_calibration_file");
+	pubConf.leftSocket = leftSensInfo.socket;
+	pubConf.rightSocket = rightSensInfo.socket;
+	pubConf.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
+	pubConf.maxQSize = ph->getParam<int>("i_max_q_size");
+	pubConf.daiNodeName = getName();
 
-    if(ph->getParam<bool>("i_add_exposure_offset")) {
-        auto offset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
-        stereoConv->addExposureOffset(offset);
-    }
-    if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
-        stereoConv->reverseStereoSocketOrder();
-    }
-    if(ph->getParam<bool>("i_enable_alpha_scaling")) {
-        stereoConv->setAlphaScaling(ph->getParam<double>("i_alpha_scaling"));
-    }
-    stereoIM = std::make_shared<camera_info_manager::CameraInfoManager>(
-        getROSNode()->create_sub_node(std::string(getROSNode()->get_name()) + "/" + getName()).get(), "/" + getName());
-    auto info = sensor_helpers::getCalibInfo(getROSNode()->get_logger(),
-                                             *stereoConv,
-                                             device,
-                                             static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id")),
-                                             ph->getParam<int>("i_width"),
-                                             ph->getParam<int>("i_height"));
-    auto calibHandler = device->readCalibration();
-    if(!ph->getParam<bool>("i_output_disparity")) {
-        if(ph->getParam<bool>("i_reverse_stereo_socket_order")) {
-            stereoConv->convertDispToDepth(calibHandler.getBaselineDistance(leftSensInfo.socket, rightSensInfo.socket, false));
-        } else {
-            stereoConv->convertDispToDepth(calibHandler.getBaselineDistance(rightSensInfo.socket, leftSensInfo.socket, false));
-        }
-    }
-    // remove distortion if alpha scaling is not enabled
-    if(!ph->getParam<bool>("i_enable_alpha_scaling")) {
-        for(auto& d : info.d) {
-            d = 0.0;
-        }
-        for(auto& r : info.r) {
-            r = 0.0;
-        }
-        info.r[0] = info.r[4] = info.r[8] = 1.0;
-    }
 
-    stereoIM->setCameraInfo(info);
-    stereoPub->setup(getROSNode(), "~/" + getName(), ph->getParam<bool>("i_enable_lazy_publisher"), ipcEnabled(), stereoIM, stereoConv);
-    if(!ph->getParam<bool>("i_synced")) {
-        stereoQ = device->getOutputQueue(stereoQName, ph->getParam<int>("i_max_q_size"), false);
-        stereoPub->addQueueCB(stereoQ);
-    }
+	stereoPub->setup(device, convConfig, pubConf);
 }
 void Stereo::syncTimerCB() {
     auto left = leftRectQ->get<dai::ImgFrame>();
@@ -284,6 +238,8 @@ void Stereo::setupQueues(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_publish_synced_rect_pair")) {
         int timerPeriod = 1000.0 / ph->getOtherNodeParam<double>(leftSensInfo.name, "i_fps");
         RCLCPP_INFO(getROSNode()->get_logger(), "Setting up stereo pair sync timer with period %d ms based on left sensor FPS.", timerPeriod);
+		leftRectQ = leftRectPub->getQueue();
+		rightRectQ = rightRectPub->getQueue();
         syncTimer = getROSNode()->create_wall_timer(std::chrono::milliseconds(timerPeriod), std::bind(&Stereo::syncTimerCB, this));
     }
     if(ph->getParam<bool>("i_left_rect_enable_feature_tracker")) {
@@ -300,18 +256,18 @@ void Stereo::closeQueues() {
     left->closeQueues();
     right->closeQueues();
     if(ph->getParam<bool>("i_publish_topic")) {
-        stereoQ->close();
+        stereoPub->closeQueue();
     }
     if(ph->getParam<bool>("i_publish_left_rect")) {
-        leftRectQ->close();
+        leftRectPub->closeQueue();
     }
     if(ph->getParam<bool>("i_publish_right_rect")) {
-        rightRectQ->close();
+        rightRectPub->closeQueue();
     }
     if(ph->getParam<bool>("i_publish_synced_rect_pair")) {
         syncTimer->cancel();
-        leftRectQ->close();
-        rightRectQ->close();
+		leftRectPub->closeQueue();
+        rightRectPub->closeQueue();
     }
     if(ph->getParam<bool>("i_left_rect_enable_feature_tracker")) {
         featureTrackerLeftR->closeQueues();

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -49,10 +49,10 @@ Stereo::Stereo(const std::string& daiNodeName,
     }
     RCLCPP_DEBUG(node->get_logger(),
                  "Creating stereo node with left sensor %s and right sensor %s",
-                 utils::getSocketName(leftSensInfo.socket).c_str(),
-                 utils::getSocketName(rightSensInfo.socket).c_str());
-    left = std::make_unique<SensorWrapper>(utils::getSocketName(leftSensInfo.socket), node, pipeline, device, leftSensInfo.socket, false);
-    right = std::make_unique<SensorWrapper>(utils::getSocketName(rightSensInfo.socket), node, pipeline, device, rightSensInfo.socket, false);
+                 getSocketName(leftSensInfo.socket).c_str(),
+                 getSocketName(rightSensInfo.socket).c_str());
+    left = std::make_unique<SensorWrapper>(getSocketName(leftSensInfo.socket), node, pipeline, device, leftSensInfo.socket, false);
+    right = std::make_unique<SensorWrapper>(getSocketName(rightSensInfo.socket), node, pipeline, device, rightSensInfo.socket, false);
     stereoCamNode = pipeline->create<dai::node::StereoDepth>();
     ph->declareParams(stereoCamNode);
     setXinXout(pipeline);
@@ -143,7 +143,7 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
                             rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub,
                             image_transport::CameraPublisher& pubIT,
                             bool isLeft) {
-    auto sensorName = utils::getSocketName(sensorInfo.socket);
+    auto sensorName = getSocketName(sensorInfo.socket);
     auto tfPrefix = getTFPrefix(sensorName);
     conv = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
     conv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
@@ -218,7 +218,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     if(ph->getParam<bool>("i_align_depth")) {
         tfPrefix = getTFPrefix(ph->getParam<std::string>("i_socket_name"));
     } else {
-        tfPrefix = getTFPrefix(utils::getSocketName(rightSensInfo.socket).c_str());
+        tfPrefix = getTFPrefix(getSocketName(rightSensInfo.socket).c_str());
     }
     stereoConv = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
     stereoConv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -19,13 +19,13 @@
 namespace depthai_ros_driver {
 namespace dai_nodes {
 Stereo::Stereo(const std::string& daiNodeName,
-               rclcpp::Node* node,
+               std::shared_ptr<rclcpp::Node> node,
                std::shared_ptr<dai::Pipeline> pipeline,
                std::shared_ptr<dai::Device> device,
                dai::CameraBoardSocket leftSocket,
                dai::CameraBoardSocket rightSocket)
     : BaseNode(daiNodeName, node, pipeline) {
-    RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     ph = std::make_unique<param_handlers::StereoParamHandler>(node, daiNodeName);
     auto alignSocket = dai::CameraBoardSocket::CAM_A;
@@ -45,7 +45,7 @@ Stereo::Stereo(const std::string& daiNodeName,
             continue;
         }
     }
-    RCLCPP_DEBUG(node->get_logger(),
+    RCLCPP_DEBUG(getLogger(),
                  "Creating stereo node with left sensor %s and right sensor %s",
                  getSocketName(leftSensInfo.socket).c_str(),
                  getSocketName(rightSensInfo.socket).c_str());
@@ -70,7 +70,7 @@ Stereo::Stereo(const std::string& daiNodeName,
         stereoCamNode->depth.link(nnNode->getInput(static_cast<int>(dai_nodes::nn_helpers::link_types::SpatialNNLinkType::inputDepth)));
     }
 
-    RCLCPP_DEBUG(node->get_logger(), "Node %s created", daiNodeName.c_str());
+    RCLCPP_DEBUG(getLogger(), "Node %s created", daiNodeName.c_str());
 }
 Stereo::~Stereo() = default;
 void Stereo::setNames() {

--- a/depthai_ros_driver/src/dai_nodes/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/stereo.cpp
@@ -144,8 +144,8 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
                             image_transport::CameraPublisher& pubIT,
                             bool isLeft) {
     auto sensorName = getSocketName(sensorInfo.socket);
-    auto tfPrefix = getTFPrefix(sensorName);
-    conv = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
+    auto tfPrefix = getOpticalTFPrefix(sensorName);
+    conv = std::make_unique<dai::ros::ImageConverter>(tfPrefix , false, ph->getParam<bool>("i_get_base_device_timestamp"));
     conv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
     bool lowBandwidth = ph->getParam<bool>(isLeft ? "i_left_rect_low_bandwidth" : "i_right_rect_low_bandwidth");
     if(lowBandwidth) {
@@ -216,11 +216,11 @@ void Stereo::setupRightRectQueue(std::shared_ptr<dai::Device> device) {
 void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     std::string tfPrefix;
     if(ph->getParam<bool>("i_align_depth")) {
-        tfPrefix = getTFPrefix(ph->getParam<std::string>("i_socket_name"));
+        tfPrefix = getOpticalTFPrefix(ph->getParam<std::string>("i_socket_name"));
     } else {
-        tfPrefix = getTFPrefix(getSocketName(rightSensInfo.socket).c_str());
+        tfPrefix = getOpticalTFPrefix(getSocketName(rightSensInfo.socket).c_str());
     }
-    stereoConv = std::make_unique<dai::ros::ImageConverter>(tfPrefix + "_camera_optical_frame", false, ph->getParam<bool>("i_get_base_device_timestamp"));
+    stereoConv = std::make_unique<dai::ros::ImageConverter>(tfPrefix , false, ph->getParam<bool>("i_get_base_device_timestamp"));
     stereoConv->setUpdateRosBaseTimeOnToRosMsg(ph->getParam<bool>("i_update_ros_base_time_on_ros_msg"));
     if(ph->getParam<bool>("i_low_bandwidth")) {
         stereoConv->convertFromBitstream(dai::RawImgFrame::Type::RAW8);

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -10,7 +10,8 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SysLogger::SysLogger(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+SysLogger::SysLogger(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline)
+    : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     sysNode = pipeline->create<dai::node::SystemLogger>();

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -10,7 +10,7 @@
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
-SysLogger::SysLogger(const std::string& daiNodeName, rclcpp::Node* node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
+SysLogger::SysLogger(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> pipeline) : BaseNode(daiNodeName, node, pipeline) {
     RCLCPP_DEBUG(node->get_logger(), "Creating node %s", daiNodeName.c_str());
     setNames();
     sysNode = pipeline->create<dai::node::SystemLogger>();

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -7,7 +7,7 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-CameraParamHandler::CameraParamHandler(rclcpp::Node* node, const std::string& name) : BaseParamHandler(node, name) {
+CameraParamHandler::CameraParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {
     usbSpeedMap = {
         {"LOW", dai::UsbSpeed::LOW},
         {"FULL", dai::UsbSpeed::FULL},

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -36,6 +36,7 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<int>("i_laser_dot_brightness", 800, getRangedIntDescriptor(0, 1200));
     declareAndLogParam<int>("i_floodlight_brightness", 0, getRangedIntDescriptor(0, 1500));
     declareAndLogParam<bool>("i_restart_on_diagnostics_error", false);
+	declareAndLogParam<bool>("i_rs_compat", false);
 
     declareAndLogParam<bool>("i_publish_tf_from_calibration", false);
     declareAndLogParam<std::string>("i_tf_camera_name", getROSNode()->get_name());

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -25,6 +25,8 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<std::string>("i_pipeline_type", "RGBD");
     declareAndLogParam<std::string>("i_nn_type", "spatial");
     declareAndLogParam<bool>("i_enable_imu", true);
+    declareAndLogParam<bool>("i_enable_diagnostics", true);
+    declareAndLogParam<bool>("i_enable_sync", true);
     declareAndLogParam<bool>("i_enable_ir", true);
     declareAndLogParam<std::string>("i_usb_speed", "SUPER_PLUS");
     declareAndLogParam<std::string>("i_mx_id", "");
@@ -36,7 +38,7 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<int>("i_laser_dot_brightness", 800, getRangedIntDescriptor(0, 1200));
     declareAndLogParam<int>("i_floodlight_brightness", 0, getRangedIntDescriptor(0, 1500));
     declareAndLogParam<bool>("i_restart_on_diagnostics_error", false);
-	declareAndLogParam<bool>("i_rs_compat", false);
+    declareAndLogParam<bool>("i_rs_compat", false);
 
     declareAndLogParam<bool>("i_publish_tf_from_calibration", false);
     declareAndLogParam<std::string>("i_tf_camera_name", getROSNode()->get_name());

--- a/depthai_ros_driver/src/param_handlers/feature_tracker_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/feature_tracker_param_handler.cpp
@@ -7,7 +7,7 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-FeatureTrackerParamHandler::FeatureTrackerParamHandler(rclcpp::Node* node, const std::string& name) : BaseParamHandler(node, name) {}
+FeatureTrackerParamHandler::FeatureTrackerParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {}
 FeatureTrackerParamHandler::~FeatureTrackerParamHandler() = default;
 void FeatureTrackerParamHandler::declareParams(std::shared_ptr<dai::node::FeatureTracker> featureTracker) {
     declareAndLogParam<bool>("i_get_base_device_timestamp", false);

--- a/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/imu_param_handler.cpp
@@ -8,7 +8,7 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-ImuParamHandler::ImuParamHandler(rclcpp::Node* node, const std::string& name) : BaseParamHandler(node, name) {}
+ImuParamHandler::ImuParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {}
 ImuParamHandler::~ImuParamHandler() = default;
 void ImuParamHandler::declareParams(std::shared_ptr<dai::node::IMU> imu, const std::string& imuType) {
     imuSyncMethodMap = {

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -16,7 +16,8 @@
 namespace depthai_ros_driver {
 namespace param_handlers {
 
-NNParamHandler::NNParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, const dai::CameraBoardSocket& socket) : BaseParamHandler(node, name) {
+NNParamHandler::NNParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, const dai::CameraBoardSocket& socket)
+    : BaseParamHandler(node, name) {
     nnFamilyMap = {
         {"segmentation", nn::NNFamily::Segmentation},
         {"mobilenet", nn::NNFamily::Mobilenet},

--- a/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/nn_param_handler.cpp
@@ -16,7 +16,7 @@
 namespace depthai_ros_driver {
 namespace param_handlers {
 
-NNParamHandler::NNParamHandler(rclcpp::Node* node, const std::string& name, const dai::CameraBoardSocket& socket) : BaseParamHandler(node, name) {
+NNParamHandler::NNParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, const dai::CameraBoardSocket& socket) : BaseParamHandler(node, name) {
     nnFamilyMap = {
         {"segmentation", nn::NNFamily::Segmentation},
         {"mobilenet", nn::NNFamily::Mobilenet},

--- a/depthai_ros_driver/src/param_handlers/pipeline_gen_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/pipeline_gen_param_handler.cpp
@@ -1,0 +1,21 @@
+
+#include "depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp"
+
+#include "rclcpp/node.hpp"
+
+namespace depthai_ros_driver {
+namespace param_handlers {
+PipelineGenParamHandler::PipelineGenParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {}
+PipelineGenParamHandler::~PipelineGenParamHandler() = default;
+
+void PipelineGenParamHandler::declareParams() {
+    declareAndLogParam<bool>("i_enable_imu", true);
+    declareAndLogParam<bool>("i_enable_diagnostics", true);
+    declareAndLogParam<bool>("i_enable_sync", true);
+}
+dai::CameraControl PipelineGenParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& /*params*/) {
+    dai::CameraControl ctrl;
+    return ctrl;
+}
+}  // namespace param_handlers
+}  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -11,7 +11,8 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-SensorParamHandler::SensorParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, dai::CameraBoardSocket socket) : BaseParamHandler(node, name) {
+SensorParamHandler::SensorParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, dai::CameraBoardSocket socket)
+    : BaseParamHandler(node, name) {
     declareCommonParams(socket);
 };
 SensorParamHandler::~SensorParamHandler() = default;
@@ -33,7 +34,7 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
     declareAndLogParam<bool>("i_reverse_stereo_socket_order", false);
-	declareAndLogParam<bool>("i_synced", true);
+    declareAndLogParam<bool>("i_synced", true);
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -11,7 +11,7 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-SensorParamHandler::SensorParamHandler(rclcpp::Node* node, const std::string& name, dai::CameraBoardSocket socket) : BaseParamHandler(node, name) {
+SensorParamHandler::SensorParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name, dai::CameraBoardSocket socket) : BaseParamHandler(node, name) {
     declareCommonParams(socket);
 };
 SensorParamHandler::~SensorParamHandler() = default;

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -33,6 +33,7 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
     declareAndLogParam<bool>("i_reverse_stereo_socket_order", false);
+	declareAndLogParam<bool>("i_synced", false);
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -33,7 +33,7 @@ void SensorParamHandler::declareCommonParams(dai::CameraBoardSocket socket) {
     declareAndLogParam<bool>("i_add_exposure_offset", false);
     declareAndLogParam<int>("i_exposure_offset", 0);
     declareAndLogParam<bool>("i_reverse_stereo_socket_order", false);
-	declareAndLogParam<bool>("i_synced", false);
+	declareAndLogParam<bool>("i_synced", true);
 }
 
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> monoCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -120,7 +120,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     stereo->initialConfig.setLeftRightCheckThreshold(declareAndLogParam<int>("i_lrc_threshold", 10));
     stereo->initialConfig.setMedianFilter(static_cast<dai::MedianFilter>(declareAndLogParam<int>("i_depth_filter_size", 5)));
     stereo->initialConfig.setConfidenceThreshold(declareAndLogParam<int>("i_stereo_conf_threshold", 240));
-    if(declareAndLogParam<bool>("i_subpixel", false)) {
+    if(declareAndLogParam<bool>("i_subpixel", true)) {
         stereo->initialConfig.setSubpixel(true);
         stereo->initialConfig.setSubpixelFractionalBits(declareAndLogParam<int>("i_subpixel_fractional_bits", 3));
     }

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -72,6 +72,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_left_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_left_rect_exposure_offset", 0);
     declareAndLogParam<bool>("i_left_rect_enable_feature_tracker", false);
+	declareAndLogParam<bool>("i_left_rect_synced", false);
 
     declareAndLogParam<bool>("i_publish_right_rect", false);
     declareAndLogParam<bool>("i_right_rect_low_bandwidth", false);
@@ -79,8 +80,11 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_right_rect_enable_feature_tracker", false);
     declareAndLogParam<bool>("i_right_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_right_rect_exposure_offset", 0);
+	declareAndLogParam<bool>("i_right_rect_synced", false);
+
     declareAndLogParam<bool>("i_enable_spatial_nn", false);
     declareAndLogParam<std::string>("i_spatial_nn_source", "right");
+	declareAndLogParam<bool>("i_synced", false);
 
     stereo->setLeftRightCheck(declareAndLogParam<bool>("i_lr_check", true));
     int width = 1280;

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -84,7 +84,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
 
     declareAndLogParam<bool>("i_enable_spatial_nn", false);
     declareAndLogParam<std::string>("i_spatial_nn_source", "right");
-	declareAndLogParam<bool>("i_synced", false);
+	declareAndLogParam<bool>("i_synced", true);
 
     stereo->setLeftRightCheck(declareAndLogParam<bool>("i_lr_check", true));
     int width = 1280;

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -87,7 +87,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     int height = 720;
     std::string socketName;
     if(declareAndLogParam<bool>("i_align_depth", true)) {
-        socketName = utils::getSocketName(alignSocket);
+        socketName = getSocketName(alignSocket);
         try {
             width = getROSNode()->get_parameter(socketName + ".i_width").as_int();
             height = getROSNode()->get_parameter(socketName + ".i_height").as_int();

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -72,7 +72,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_left_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_left_rect_exposure_offset", 0);
     declareAndLogParam<bool>("i_left_rect_enable_feature_tracker", false);
-	declareAndLogParam<bool>("i_left_rect_synced", false);
+    declareAndLogParam<bool>("i_left_rect_synced", false);
 
     declareAndLogParam<bool>("i_publish_right_rect", false);
     declareAndLogParam<bool>("i_right_rect_low_bandwidth", false);
@@ -80,11 +80,11 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_right_rect_enable_feature_tracker", false);
     declareAndLogParam<bool>("i_right_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_right_rect_exposure_offset", 0);
-	declareAndLogParam<bool>("i_right_rect_synced", false);
+    declareAndLogParam<bool>("i_right_rect_synced", false);
 
     declareAndLogParam<bool>("i_enable_spatial_nn", false);
     declareAndLogParam<std::string>("i_spatial_nn_source", "right");
-	declareAndLogParam<bool>("i_synced", true);
+    declareAndLogParam<bool>("i_synced", true);
 
     stereo->setLeftRightCheck(declareAndLogParam<bool>("i_lr_check", true));
     int width = 1280;

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -9,7 +9,7 @@
 
 namespace depthai_ros_driver {
 namespace param_handlers {
-StereoParamHandler::StereoParamHandler(rclcpp::Node* node, const std::string& name) : BaseParamHandler(node, name) {
+StereoParamHandler::StereoParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {
     depthPresetMap = {
         {"HIGH_ACCURACY", dai::node::StereoDepth::PresetMode::HIGH_ACCURACY},
         {"HIGH_DENSITY", dai::node::StereoDepth::PresetMode::HIGH_DENSITY},

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -72,7 +72,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_left_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_left_rect_exposure_offset", 0);
     declareAndLogParam<bool>("i_left_rect_enable_feature_tracker", false);
-    declareAndLogParam<bool>("i_left_rect_synced", false);
+    declareAndLogParam<bool>("i_left_rect_synced", true);
 
     declareAndLogParam<bool>("i_publish_right_rect", false);
     declareAndLogParam<bool>("i_right_rect_low_bandwidth", false);
@@ -80,7 +80,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_right_rect_enable_feature_tracker", false);
     declareAndLogParam<bool>("i_right_rect_add_exposure_offset", false);
     declareAndLogParam<int>("i_right_rect_exposure_offset", 0);
-    declareAndLogParam<bool>("i_right_rect_synced", false);
+    declareAndLogParam<bool>("i_right_rect_synced", true);
 
     declareAndLogParam<bool>("i_enable_spatial_nn", false);
     declareAndLogParam<std::string>("i_spatial_nn_source", "right");

--- a/depthai_ros_driver/src/param_handlers/sync_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sync_param_handler.cpp
@@ -8,8 +8,8 @@ namespace param_handlers {
 SyncParamHandler::SyncParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {}
 SyncParamHandler::~SyncParamHandler() = default;
 void SyncParamHandler::declareParams(std::shared_ptr<dai::node::Sync> sync) {
-	sync->setSyncThreshold(std::chrono::milliseconds(declareAndLogParam<int>("sync_threshold", 10)));
-	sync->setSyncAttempts(declareAndLogParam<int>("sync_attempts", 10));
+    sync->setSyncThreshold(std::chrono::milliseconds(declareAndLogParam<int>("sync_threshold", 10)));
+    sync->setSyncAttempts(declareAndLogParam<int>("sync_attempts", 10));
 }
 
 dai::CameraControl SyncParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& /*params*/) {

--- a/depthai_ros_driver/src/param_handlers/sync_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sync_param_handler.cpp
@@ -1,0 +1,20 @@
+#include "depthai_ros_driver/param_handlers/sync_param_handler.hpp"
+
+#include "depthai/pipeline/node/Sync.hpp"
+#include "rclcpp/node.hpp"
+
+namespace depthai_ros_driver {
+namespace param_handlers {
+SyncParamHandler::SyncParamHandler(std::shared_ptr<rclcpp::Node> node, const std::string& name) : BaseParamHandler(node, name) {}
+SyncParamHandler::~SyncParamHandler() = default;
+void SyncParamHandler::declareParams(std::shared_ptr<dai::node::Sync> sync) {
+	sync->setSyncThreshold(std::chrono::milliseconds(declareAndLogParam<int>("sync_threshold", 10)));
+	sync->setSyncAttempts(declareAndLogParam<int>("sync_attempts", 10));
+}
+
+dai::CameraControl SyncParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& /*params*/) {
+    dai::CameraControl ctrl;
+    return ctrl;
+}
+}  // namespace param_handlers
+}  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/pipeline/base_types.cpp
+++ b/depthai_ros_driver/src/pipeline/base_types.cpp
@@ -17,7 +17,7 @@
 namespace depthai_ros_driver {
 namespace pipeline_gen {
 
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGB::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGB::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                       std::shared_ptr<dai::Device> device,
                                                                       std::shared_ptr<dai::Pipeline> pipeline,
                                                                       const std::string& nnType) {
@@ -44,7 +44,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGB::createPipeline(rclcpp::No
     daiNodes.push_back(std::move(rgb));
     return daiNodes;
 }
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBD::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBD::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                        std::shared_ptr<dai::Device> device,
                                                                        std::shared_ptr<dai::Pipeline> pipeline,
                                                                        const std::string& nnType) {
@@ -75,7 +75,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBD::createPipeline(rclcpp::N
     daiNodes.push_back(std::move(stereo));
     return daiNodes;
 }
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBStereo::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBStereo::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                             std::shared_ptr<dai::Device> device,
                                                                             std::shared_ptr<dai::Pipeline> pipeline,
                                                                             const std::string& nnType) {
@@ -106,7 +106,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBStereo::createPipeline(rclc
     daiNodes.push_back(std::move(right));
     return daiNodes;
 }
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> Stereo::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> Stereo::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                          std::shared_ptr<dai::Device> device,
                                                                          std::shared_ptr<dai::Pipeline> pipeline,
                                                                          const std::string& /*nnType*/) {
@@ -118,7 +118,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> Stereo::createPipeline(rclcpp:
     daiNodes.push_back(std::move(right));
     return daiNodes;
 }
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> Depth::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> Depth::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                         std::shared_ptr<dai::Device> device,
                                                                         std::shared_ptr<dai::Pipeline> pipeline,
                                                                         const std::string& /*nnType*/) {
@@ -128,7 +128,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> Depth::createPipeline(rclcpp::
     daiNodes.push_back(std::move(stereo));
     return daiNodes;
 }
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> CamArray::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> CamArray::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                            std::shared_ptr<dai::Device> device,
                                                                            std::shared_ptr<dai::Pipeline> pipeline,
                                                                            const std::string& /*nnType*/) {

--- a/depthai_ros_driver/src/pipeline/base_types.cpp
+++ b/depthai_ros_driver/src/pipeline/base_types.cpp
@@ -21,11 +21,12 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGB::createPipeline(rclcpp::No
                                                                       std::shared_ptr<dai::Device> device,
                                                                       std::shared_ptr<dai::Pipeline> pipeline,
                                                                       const std::string& nnType) {
+    using namespace dai_nodes::sensor_helpers;
     std::string nTypeUpCase = utils::getUpperCaseStr(nnType);
     auto nType = utils::getValFromMap(nTypeUpCase, nnTypeMap);
 
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    auto rgb = std::make_unique<dai_nodes::SensorWrapper>("rgb", node, pipeline, device, dai::CameraBoardSocket::CAM_A);
+    auto rgb = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::RGB), node, pipeline, device, dai::CameraBoardSocket::CAM_A);
     switch(nType) {
         case NNType::None:
             break;
@@ -47,12 +48,13 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBD::createPipeline(rclcpp::N
                                                                        std::shared_ptr<dai::Device> device,
                                                                        std::shared_ptr<dai::Pipeline> pipeline,
                                                                        const std::string& nnType) {
+    using namespace dai_nodes::sensor_helpers;
     std::string nTypeUpCase = utils::getUpperCaseStr(nnType);
     auto nType = utils::getValFromMap(nTypeUpCase, nnTypeMap);
 
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    auto rgb = std::make_unique<dai_nodes::SensorWrapper>("rgb", node, pipeline, device, dai::CameraBoardSocket::CAM_A);
-    auto stereo = std::make_unique<dai_nodes::Stereo>("stereo", node, pipeline, device);
+    auto rgb = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::RGB), node, pipeline, device, dai::CameraBoardSocket::CAM_A);
+    auto stereo = std::make_unique<dai_nodes::Stereo>(getNodeName(node, NodeNameEnum::Stereo), node, pipeline, device);
     switch(nType) {
         case NNType::None:
             break;
@@ -77,13 +79,14 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBStereo::createPipeline(rclc
                                                                             std::shared_ptr<dai::Device> device,
                                                                             std::shared_ptr<dai::Pipeline> pipeline,
                                                                             const std::string& nnType) {
+    using namespace dai_nodes::sensor_helpers;
     std::string nTypeUpCase = utils::getUpperCaseStr(nnType);
     auto nType = utils::getValFromMap(nTypeUpCase, nnTypeMap);
 
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    auto rgb = std::make_unique<dai_nodes::SensorWrapper>("rgb", node, pipeline, device, dai::CameraBoardSocket::CAM_A);
-    auto left = std::make_unique<dai_nodes::SensorWrapper>("left", node, pipeline, device, dai::CameraBoardSocket::CAM_B);
-    auto right = std::make_unique<dai_nodes::SensorWrapper>("right", node, pipeline, device, dai::CameraBoardSocket::CAM_C);
+    auto rgb = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::RGB), node, pipeline, device, dai::CameraBoardSocket::CAM_A);
+    auto left = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::Left), node, pipeline, device, dai::CameraBoardSocket::CAM_B);
+    auto right = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::Right), node, pipeline, device, dai::CameraBoardSocket::CAM_C);
     switch(nType) {
         case NNType::None:
             break;
@@ -107,9 +110,10 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> Stereo::createPipeline(rclcpp:
                                                                          std::shared_ptr<dai::Device> device,
                                                                          std::shared_ptr<dai::Pipeline> pipeline,
                                                                          const std::string& /*nnType*/) {
+    using namespace dai_nodes::sensor_helpers;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    auto left = std::make_unique<dai_nodes::SensorWrapper>("left", node, pipeline, device, dai::CameraBoardSocket::CAM_B);
-    auto right = std::make_unique<dai_nodes::SensorWrapper>("right", node, pipeline, device, dai::CameraBoardSocket::CAM_C);
+    auto left = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::Left), node, pipeline, device, dai::CameraBoardSocket::CAM_B);
+    auto right = std::make_unique<dai_nodes::SensorWrapper>(getNodeName(node, NodeNameEnum::Right), node, pipeline, device, dai::CameraBoardSocket::CAM_C);
     daiNodes.push_back(std::move(left));
     daiNodes.push_back(std::move(right));
     return daiNodes;
@@ -118,8 +122,9 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> Depth::createPipeline(rclcpp::
                                                                         std::shared_ptr<dai::Device> device,
                                                                         std::shared_ptr<dai::Pipeline> pipeline,
                                                                         const std::string& /*nnType*/) {
+    using namespace dai_nodes::sensor_helpers;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    auto stereo = std::make_unique<dai_nodes::Stereo>("stereo", node, pipeline, device);
+    auto stereo = std::make_unique<dai_nodes::Stereo>(getNodeName(node, NodeNameEnum::Stereo), node, pipeline, device);
     daiNodes.push_back(std::move(stereo));
     return daiNodes;
 }
@@ -127,10 +132,11 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> CamArray::createPipeline(rclcp
                                                                            std::shared_ptr<dai::Device> device,
                                                                            std::shared_ptr<dai::Pipeline> pipeline,
                                                                            const std::string& /*nnType*/) {
+    using namespace dai_nodes::sensor_helpers;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
 
     for(auto& feature : device->getConnectedCameraFeatures()) {
-        auto name = utils::getSocketName(feature.socket);
+        auto name = getSocketName(node, feature.socket);
         auto daiNode = std::make_unique<dai_nodes::SensorWrapper>(name, node, pipeline, device, feature.socket);
         daiNodes.push_back(std::move(daiNode));
     };

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -11,7 +11,7 @@
 
 namespace depthai_ros_driver {
 namespace pipeline_gen {
-std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipeline(rclcpp::Node* node,
+std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                                     std::shared_ptr<dai::Device> device,
                                                                                     std::shared_ptr<dai::Pipeline> pipeline,
                                                                                     const std::string& pipelineType,
@@ -51,7 +51,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
     return daiNodes;
 }
 
-std::string PipelineGenerator::validatePipeline(rclcpp::Node* node, const std::string& typeStr, int sensorNum) {
+std::string PipelineGenerator::validatePipeline(std::shared_ptr<rclcpp::Node> node, const std::string& typeStr, int sensorNum) {
     auto pType = utils::getValFromMap(typeStr, pipelineTypeMap);
     if(sensorNum == 1) {
         if(pType != PipelineType::RGB) {

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -49,17 +49,16 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
     auto sysLogger = std::make_unique<dai_nodes::SysLogger>("sys_logger", node, pipeline);
     daiNodes.push_back(std::move(sysLogger));
     auto sync = std::make_unique<dai_nodes::Sync>("sync", node, pipeline);
-        for(auto& daiNode : daiNodes) {
-            auto pubs = daiNode->getPublishers();
-            RCLCPP_INFO(node->get_logger(), "Number of publishers found for %s: %d", daiNode->getName().c_str(), pubs.size());
-            if(pubs.empty()) {
-                RCLCPP_WARN(node->get_logger(), "No publishers found for %s.", daiNode->getName().c_str());
-            } else {
-                std::for_each(pubs.begin(), pubs.end(), [&sync, &daiNode](auto& pub) {
-                    sync->addPublisher(pub);
-                    daiNode->link(sync->getInputByName(pub->getQueueName()));
-                });
-            }
+    for(auto& daiNode : daiNodes) {
+        auto pubs = daiNode->getPublishers();
+        RCLCPP_INFO(node->get_logger(), "Number of synced publishers found for %s: %zu", daiNode->getName().c_str(), pubs.size());
+        if(pubs.empty()) {
+        } else {
+            std::for_each(pubs.begin(), pubs.end(), [&sync](auto& pub) {
+                sync->addPublisher(pub);
+                pub->link(sync->getInputByName(pub->getQueueName()));
+            });
+        }
     }
     daiNodes.push_back(std::move(sync));
     RCLCPP_INFO(node->get_logger(), "Finished setting up pipeline.");

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -5,6 +5,7 @@
 #include "depthai_ros_driver/dai_nodes/sensors/imu.hpp"
 #include "depthai_ros_driver/dai_nodes/sensors/sync.hpp"
 #include "depthai_ros_driver/dai_nodes/sys_logger.hpp"
+#include "depthai_ros_driver/param_handlers/pipeline_gen_param_handler.hpp"
 #include "depthai_ros_driver/pipeline/base_pipeline.hpp"
 #include "depthai_ros_driver/utils.hpp"
 #include "pluginlib/class_loader.hpp"
@@ -12,12 +13,29 @@
 
 namespace depthai_ros_driver {
 namespace pipeline_gen {
+PipelineGenerator::PipelineGenerator() {
+	pluginTypeMap = {{"RGB", "depthai_ros_driver::pipeline_gen::RGB"},
+					 {"RGBD", "depthai_ros_driver::pipeline_gen::RGBD"},
+					 {"RGBSTEREO", "depthai_ros_driver::pipeline_gen::RGBStereo"},
+					 {"STEREO", "depthai_ros_driver::pipeline_gen::Stereo"},
+					 {"DEPTH", "depthai_ros_driver::pipeline_gen::Depth"},
+					 {"CAMARRAY", "depthai_ros_driver::pipeline_gen::CamArray"}};
+	pipelineTypeMap = {{"RGB", PipelineType::RGB},
+					   {"RGBD", PipelineType::RGBD},
+					   {"RGBSTEREO", PipelineType::RGBStereo},
+					   {"STEREO", PipelineType::Stereo},
+					   {"DEPTH", PipelineType::Depth},
+					   {"CAMARRAY", PipelineType::CamArray}};
+}
+
+PipelineGenerator::~PipelineGenerator() = default;
 std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipeline(std::shared_ptr<rclcpp::Node> node,
                                                                                     std::shared_ptr<dai::Device> device,
                                                                                     std::shared_ptr<dai::Pipeline> pipeline,
                                                                                     const std::string& pipelineType,
-                                                                                    const std::string& nnType,
-                                                                                    bool enableImu) {
+                                                                                    const std::string& nnType) {
+    ph = std::make_unique<param_handlers::PipelineGenParamHandler>(node, "pipeline_gen");
+	ph->declareParams();
     RCLCPP_INFO(node->get_logger(), "Pipeline type: %s", pipelineType.c_str());
     std::string pluginType = pipelineType;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
@@ -38,7 +56,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
         RCLCPP_ERROR(node->get_logger(), "The plugin failed to load for some reason. Error: %s\n", ex.what());
     }
 
-    if(enableImu) {
+    if(ph->getParam<bool>("i_enable_imu")) {
         if(device->getConnectedIMU() == "NONE" || device->getConnectedIMU().empty()) {
             RCLCPP_WARN(node->get_logger(), "IMU enabled but not available!");
         } else {
@@ -46,21 +64,25 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
             daiNodes.push_back(std::move(imu));
         }
     }
-    auto sysLogger = std::make_unique<dai_nodes::SysLogger>("sys_logger", node, pipeline);
-    daiNodes.push_back(std::move(sysLogger));
-    auto sync = std::make_unique<dai_nodes::Sync>("sync", node, pipeline);
-    for(auto& daiNode : daiNodes) {
-        auto pubs = daiNode->getPublishers();
-        RCLCPP_INFO(node->get_logger(), "Number of synced publishers found for %s: %zu", daiNode->getName().c_str(), pubs.size());
-        if(pubs.empty()) {
-        } else {
-            std::for_each(pubs.begin(), pubs.end(), [&sync](auto& pub) {
-                sync->addPublisher(pub);
-                pub->link(sync->getInputByName(pub->getQueueName()));
-            });
-        }
+    if(ph->getParam<bool>("i_enable_diagnostics")) {
+        auto sysLogger = std::make_unique<dai_nodes::SysLogger>("sys_logger", node, pipeline);
+        daiNodes.push_back(std::move(sysLogger));
     }
-    daiNodes.push_back(std::move(sync));
+    auto sync = std::make_unique<dai_nodes::Sync>("sync", node, pipeline);
+    if(ph->getParam<bool>("i_enable_sync")) {
+        for(auto& daiNode : daiNodes) {
+            auto pubs = daiNode->getPublishers();
+            RCLCPP_DEBUG(node->get_logger(), "Number of synced publishers found for %s: %zu", daiNode->getName().c_str(), pubs.size());
+            if(pubs.empty()) {
+            } else {
+                std::for_each(pubs.begin(), pubs.end(), [&sync](auto& pub) {
+                    sync->addPublisher(pub);
+                    pub->link(sync->getInputByName(pub->getQueueName()));
+                });
+            }
+        }
+        daiNodes.push_back(std::move(sync));
+    }
     RCLCPP_INFO(node->get_logger(), "Finished setting up pipeline.");
     return daiNodes;
 }

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -53,9 +53,10 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
         for(auto& daiNode : daiNodes) {
             if(daiNode->getName() == syncName) {
 				RCLCPP_INFO(node->get_logger(), "Linking %s to sync node.", syncName.c_str());
-                auto pub = daiNode->getPublisher();
-                sync->addPublisher(pub);
+                auto pubs = daiNode->getPublishers();
+				std::for_each(pubs.begin(), pubs.end(), [&sync, &daiNode](auto& pub) { sync->addPublisher(pub); 
                 daiNode->link(sync->getInputByName(pub->getQueueName()));
+				});
             }
         }
     }

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -14,18 +14,18 @@
 namespace depthai_ros_driver {
 namespace pipeline_gen {
 PipelineGenerator::PipelineGenerator() {
-	pluginTypeMap = {{"RGB", "depthai_ros_driver::pipeline_gen::RGB"},
-					 {"RGBD", "depthai_ros_driver::pipeline_gen::RGBD"},
-					 {"RGBSTEREO", "depthai_ros_driver::pipeline_gen::RGBStereo"},
-					 {"STEREO", "depthai_ros_driver::pipeline_gen::Stereo"},
-					 {"DEPTH", "depthai_ros_driver::pipeline_gen::Depth"},
-					 {"CAMARRAY", "depthai_ros_driver::pipeline_gen::CamArray"}};
-	pipelineTypeMap = {{"RGB", PipelineType::RGB},
-					   {"RGBD", PipelineType::RGBD},
-					   {"RGBSTEREO", PipelineType::RGBStereo},
-					   {"STEREO", PipelineType::Stereo},
-					   {"DEPTH", PipelineType::Depth},
-					   {"CAMARRAY", PipelineType::CamArray}};
+    pluginTypeMap = {{"RGB", "depthai_ros_driver::pipeline_gen::RGB"},
+                     {"RGBD", "depthai_ros_driver::pipeline_gen::RGBD"},
+                     {"RGBSTEREO", "depthai_ros_driver::pipeline_gen::RGBStereo"},
+                     {"STEREO", "depthai_ros_driver::pipeline_gen::Stereo"},
+                     {"DEPTH", "depthai_ros_driver::pipeline_gen::Depth"},
+                     {"CAMARRAY", "depthai_ros_driver::pipeline_gen::CamArray"}};
+    pipelineTypeMap = {{"RGB", PipelineType::RGB},
+                       {"RGBD", PipelineType::RGBD},
+                       {"RGBSTEREO", PipelineType::RGBStereo},
+                       {"STEREO", PipelineType::Stereo},
+                       {"DEPTH", PipelineType::Depth},
+                       {"CAMARRAY", PipelineType::CamArray}};
 }
 
 PipelineGenerator::~PipelineGenerator() = default;
@@ -35,7 +35,7 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> PipelineGenerator::createPipel
                                                                                     const std::string& pipelineType,
                                                                                     const std::string& nnType) {
     ph = std::make_unique<param_handlers::PipelineGenParamHandler>(node, "pipeline_gen");
-	ph->declareParams();
+    ph->declareParams();
     RCLCPP_INFO(node->get_logger(), "Pipeline type: %s", pipelineType.c_str());
     std::string pluginType = pipelineType;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;

--- a/depthai_ros_driver/src/utils.cpp
+++ b/depthai_ros_driver/src/utils.cpp
@@ -1,17 +1,10 @@
 #include "depthai_ros_driver/utils.hpp"
-
-#include "depthai-shared/common/CameraBoardSocket.hpp"
-#include "depthai-shared/common/CameraFeatures.hpp"
-#include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 namespace depthai_ros_driver {
 namespace utils {
 std::string getUpperCaseStr(const std::string& string) {
     std::string upper = string;
     for(auto& c : upper) c = toupper(c);
     return upper;
-}
-std::string getSocketName(dai::CameraBoardSocket socket) {
-    return dai_nodes::sensor_helpers::socketNameMap.at(socket);
 }
 }  // namespace utils
 }  // namespace depthai_ros_driver


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): N/A
Issue description: Adding settings to choose between different ROS interfaces, RS mode publishes topics similar to Realsense cameras. Also, multi topic syncing has been added for image topics.
Related PRs

## Changes
ROS distro: Humble
List of changes:
- Added ImagePublisher class to wrap some redundancy regarding setting up Image publisher, it's a prelude to more common Publisher class which will be added for syncing other topic types.
- Added Sync node which allows syncing multiple image sources (stereo, rgb, left, right)
- Updated Node, topic and frame names to also provide RS equivalent
- Moved RGBD pointcloud and rectify nodes to camera.launch.py for better ease of use
- Updated raw rclcpp::Node definitions with std::shared_ptr<rclcpp::Node>
- Added getLogger() methods for simplification
- Update deprecated IR interfaces
- Removed useless utils
## Testing
Hardware used: OAK-D-PRO
Depthai library version:2.26.1


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
