### PR TITLE
Update setting usb speed - Jazzy

### DIFF
--- a/depthai-ros/CHANGELOG.rst
+++ b/depthai-ros/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package depthai-ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.10.3 (2024-10-14)
+-------------------
+* Allow setting USB speed without specifying device information
+
 2.10.2 (2024-09-26)
 -------------------
 * Fix Stereo K matrix publishing

--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai-ros VERSION 2.10.2 LANGUAGES CXX C)
+project(depthai-ros VERSION 2.10.3 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/depthai-ros/package.xml
+++ b/depthai-ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai-ros</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>The depthai-ros package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-project(depthai_bridge VERSION 2.10.2 LANGUAGES CXX C)
+project(depthai_bridge VERSION 2.10.3 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_bridge</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>The depthai_bridge package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_descriptions VERSION 2.10.2)
+project(depthai_descriptions VERSION 2.10.3)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_descriptions/package.xml
+++ b/depthai_descriptions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_descriptions</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>The depthai_descriptions package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
-project(depthai_examples VERSION 2.10.2 LANGUAGES CXX C)
+project(depthai_examples VERSION 2.10.3 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_examples</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>The depthai_examples package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_filters VERSION 2.10.2 LANGUAGES CXX C)
+project(depthai_filters VERSION 2.10.3 LANGUAGES CXX C)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_filters/package.xml
+++ b/depthai_filters/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_filters</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>Depthai filters package</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
   <license>MIT</license>

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(depthai_ros_driver VERSION 2.10.2)
+project(depthai_ros_driver VERSION 2.10.3)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
 

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -198,7 +198,9 @@ void Camera::startDevice() {
         try {
             if(mxid.empty() && ip.empty() && usb_id.empty()) {
                 RCLCPP_INFO(get_logger(), "No ip/mxid specified, connecting to the next available device.");
-                device = std::make_shared<dai::Device>();
+				auto info = dai::Device::getAnyAvailableDevice();
+				auto speed = ph->getUSBSpeed();
+                device = std::make_shared<dai::Device>(std::get<1>(info), speed);
                 camRunning = true;
             } else {
                 std::vector<dai::DeviceInfo> availableDevices = dai::Device::getAllAvailableDevices();

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -198,8 +198,8 @@ void Camera::startDevice() {
         try {
             if(mxid.empty() && ip.empty() && usb_id.empty()) {
                 RCLCPP_INFO(get_logger(), "No ip/mxid specified, connecting to the next available device.");
-				auto info = dai::Device::getAnyAvailableDevice();
-				auto speed = ph->getUSBSpeed();
+                auto info = dai::Device::getAnyAvailableDevice();
+                auto speed = ph->getUSBSpeed();
                 device = std::make_shared<dai::Device>(std::get<1>(info), speed);
                 camRunning = true;
             } else {

--- a/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/camera_param_handler.cpp
@@ -28,7 +28,7 @@ void CameraParamHandler::declareParams() {
     declareAndLogParam<bool>("i_enable_diagnostics", true);
     declareAndLogParam<bool>("i_enable_sync", true);
     declareAndLogParam<bool>("i_enable_ir", true);
-    declareAndLogParam<std::string>("i_usb_speed", "SUPER_PLUS");
+    declareAndLogParam<std::string>("i_usb_speed", "SUPER");
     declareAndLogParam<std::string>("i_mx_id", "");
     declareAndLogParam<std::string>("i_ip", "");
     declareAndLogParam<std::string>("i_usb_port_id", "");

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai_ros_msgs VERSION 2.10.2)
+project(depthai_ros_msgs VERSION 2.10.3)
 
 if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_ros_msgs</name>
-  <version>2.10.2</version>
+  <version>2.10.3</version>
   <description>Package to keep interface independent of the driver</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): N/A
Issue description: Allows setting USB speed without need for setting device info
Related PRs

## Changes
ROS distro: Jazzy
List of changes:
- Update device start method
- Change default USB speed to SUPER instead of SUPER_PLUS
## Testing
Hardware used: OAK-D PRO
Depthai library version: 2.28.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
