### PR TITLE
Ros2 Diagnostics - Fix for Frame_id naming

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -5,6 +5,7 @@
 
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/pipeline/Node.hpp"
+#include "depthai_ros_driver/param_handlers/camera_param_handler.hpp"
 #include "depthai_ros_driver/utils.hpp"
 #include "rclcpp/logger.hpp"
 
@@ -99,6 +100,8 @@ class BaseNode {
     std::string baseDAINodeName;
     bool intraProcessEnabled;
     rclcpp::Logger logger;
+
+    std::unique_ptr<param_handlers::CameraParamHandler> ph;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -100,8 +100,6 @@ class BaseNode {
     std::string baseDAINodeName;
     bool intraProcessEnabled;
     rclcpp::Logger logger;
-
-    std::unique_ptr<param_handlers::CameraParamHandler> ph;
 };
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/base_node.hpp
@@ -5,7 +5,6 @@
 
 #include "depthai-shared/common/CameraBoardSocket.hpp"
 #include "depthai/pipeline/Node.hpp"
-#include "depthai_ros_driver/param_handlers/camera_param_handler.hpp"
 #include "depthai_ros_driver/utils.hpp"
 #include "rclcpp/logger.hpp"
 

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -56,6 +56,7 @@ extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorR
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
 bool rsCompabilityMode(std::shared_ptr<rclcpp::Node> node);
+std::string tfPrefix(std::shared_ptr<rclcpp::Node> node);
 std::string getSocketName(std::shared_ptr<rclcpp::Node> node, dai::CameraBoardSocket socket);
 std::string getNodeName(std::shared_ptr<rclcpp::Node> node, NodeNameEnum name);
 void basicCameraPub(const std::string& /*name*/,

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -15,6 +15,7 @@ namespace dai_nodes {
 BaseNode::BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> /*pipeline*/)
     : baseNode(node), baseDAINodeName(daiNodeName), logger(node->get_logger()) {
     intraProcessEnabled = node->get_node_options().use_intra_process_comms();
+    ph = std::make_unique<param_handlers::CameraParamHandler>(baseNode, "camera");
 };
 BaseNode::~BaseNode() = default;
 void BaseNode::setNodeName(const std::string& daiNodeName) {
@@ -46,6 +47,10 @@ std::string BaseNode::getSocketName(dai::CameraBoardSocket socket) {
 }
 
 std::string BaseNode::getTFPrefix(const std::string& frameName) {
+    if(ph->getParam<bool>("i_publish_tf_from_calibration")) {
+        return ph->getParam<std::string>("i_tf_base_frame") + "_" + frameName;
+    }
+
     return std::string(getROSNode()->get_name()) + "_" + frameName;
 }
 

--- a/depthai_ros_driver/src/dai_nodes/base_node.cpp
+++ b/depthai_ros_driver/src/dai_nodes/base_node.cpp
@@ -15,7 +15,6 @@ namespace dai_nodes {
 BaseNode::BaseNode(const std::string& daiNodeName, std::shared_ptr<rclcpp::Node> node, std::shared_ptr<dai::Pipeline> /*pipeline*/)
     : baseNode(node), baseDAINodeName(daiNodeName), logger(node->get_logger()) {
     intraProcessEnabled = node->get_node_options().use_intra_process_comms();
-    ph = std::make_unique<param_handlers::CameraParamHandler>(baseNode, "camera");
 };
 BaseNode::~BaseNode() = default;
 void BaseNode::setNodeName(const std::string& daiNodeName) {
@@ -47,11 +46,7 @@ std::string BaseNode::getSocketName(dai::CameraBoardSocket socket) {
 }
 
 std::string BaseNode::getTFPrefix(const std::string& frameName) {
-    if(ph->getParam<bool>("i_publish_tf_from_calibration")) {
-        return ph->getParam<std::string>("i_tf_base_frame") + "_" + frameName;
-    }
-
-    return std::string(getROSNode()->get_name()) + "_" + frameName;
+    return sensor_helpers::tfPrefix(getROSNode()) + "_" + frameName;
 }
 
 std::string BaseNode::getOpticalTFPrefix(const std::string& frameName) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -63,6 +63,13 @@ const std::unordered_map<NodeNameEnum, std::string> NodeNameMap = {
 bool rsCompabilityMode(std::shared_ptr<rclcpp::Node> node) {
     return node->get_parameter("camera.i_rs_compat").as_bool();
 }
+
+std::string tfPrefix(std::shared_ptr<rclcpp::Node> node) {
+    if(node->get_parameter("camera.i_publish_tf_from_calibration").as_bool()) {
+        return node->get_parameter("camera.i_tf_base_frame").as_string();
+    }
+    return node->get_name();
+}
 std::string getNodeName(std::shared_ptr<rclcpp::Node> node, NodeNameEnum name) {
     if(rsCompabilityMode(node)) {
         return rsNodeNameMap.at(name);

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -69,7 +69,21 @@ void SysLogger::produceDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& 
         auto logData = loggerQ->get<dai::SystemInformation>(std::chrono::seconds(5), timeout);
         if(!timeout) {
             stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "System Information");
-            stat.add("System Information", sysInfoToString(*logData));
+            stat.add("Leon CSS CPU Usage", sysInfo.leonCssCpuUsage.average * 100);
+            stat.add("Leon MSS CPU Usage", sysInfo.leonMssCpuUsage.average * 100);
+            stat.add("Ddr Memory Usage", sysInfo.ddrMemoryUsage.used / (1024.0f * 1024.0f));
+            stat.add("Ddr Memory Total", sysInfo.ddrMemoryUsage.total / (1024.0f * 1024.0f));
+            stat.add("Cmx Memory Usage", sysInfo.cmxMemoryUsage.used / (1024.0f * 1024.0f));
+            stat.add("Cmx Memory Total", sysInfo.cmxMemoryUsage.total);
+            stat.add("Leon CSS Memory Usage", sysInfo.leonCssMemoryUsage.used / (1024.0f * 1024.0f));
+            stat.add("Leon CSS Memory Total", sysInfo.leonCssMemoryUsage.total / (1024.0f * 1024.0f));
+            stat.add("Leon MSS Memory Usage", sysInfo.leonMssMemoryUsage.used / (1024.0f * 1024.0f));
+            stat.add("Leon MSS Memory Total", sysInfo.leonMssMemoryUsage.total / (1024.0f * 1024.0f));
+            stat.add("Average Chip Temperature", sysInfo.chipTemperature.average);
+            stat.add("Leon CSS Chip Temperature", sysInfo.chipTemperature.css);
+            stat.add("Leon MSS Chip Temperature", sysInfo.chipTemperature.mss);
+            stat.add("UPA Chip Temperature", sysInfo.chipTemperature.upa);
+            stat.add("DSS Chip Temperature", sysInfo.chipTemperature.dss);
         } else {
             stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No Data");
         }

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -33,7 +33,7 @@ void SysLogger::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
 void SysLogger::setupQueues(std::shared_ptr<dai::Device> device) {
     loggerQ = device->getOutputQueue(loggerQName, 8, false);
     updater = std::make_shared<diagnostic_updater::Updater>(getROSNode());
-    updater->setHardwareID(getROSNode()->get_name() + std::string("_") + device->getMxId() + std::string("_") + device->getDeviceName());
+    updater->setHardwareID(getROSNode()->get_fully_qualified_name() + std::string("_") + device->getMxId() + std::string("_") + device->getDeviceName());
     updater->add("sys_logger", std::bind(&SysLogger::produceDiagnostics, this, std::placeholders::_1));
 }
 

--- a/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sys_logger.cpp
@@ -69,6 +69,7 @@ void SysLogger::produceDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& 
         auto logData = loggerQ->get<dai::SystemInformation>(std::chrono::seconds(5), timeout);
         if(!timeout) {
             stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "System Information");
+            const dai::SystemInformation& sysInfo = *logData;
             stat.add("Leon CSS CPU Usage", sysInfo.leonCssCpuUsage.average * 100);
             stat.add("Leon MSS CPU Usage", sysInfo.leonMssCpuUsage.average * 100);
             stat.add("Ddr Memory Usage", sysInfo.ddrMemoryUsage.used / (1024.0f * 1024.0f));


### PR DESCRIPTION
## Overview
Author: Daan Wijffels 

## Changes
ROS distro: Tested on Iron
List of changes:

- Ros2 Diagnostics uses stats to provide additional information, i fixed so that it conforms to the standards
- When using the camera node to publish tf frames, the frame_id's used in the messages we're not correctly adjusted. this pr fixes this and adds the base_name to the frameNames

## Testing
Hardware used: OAK-D-SR

