### PR TITLE
Fix lowbandwidth & add stereo filters - Humble

### DIFF
--- a/depthai-ros/CHANGELOG.rst
+++ b/depthai-ros/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package depthai-ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.10.5 (2025-01-09)
+-------------------
+* Fix low bandwidth issues
+* New stereo filters
+* Diagnostics update
+* Fix IR calculation
 
 2.10.4 (2024-11-07)
 -------------------

--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai-ros VERSION 2.10.4 LANGUAGES CXX C)
+project(depthai-ros VERSION 2.10.5 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/depthai-ros/package.xml
+++ b/depthai-ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai-ros</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>The depthai-ros package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-project(depthai_bridge VERSION 2.10.4 LANGUAGES CXX C)
+project(depthai_bridge VERSION 2.10.5 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -28,6 +28,7 @@ message(STATUS "------------------------------------------")
 
 set(BUILD_TOOL_INCLUDE_DIRS ${ament_INCLUDE_DIRS})
 
+find_package(ament_index_cpp REQUIRED)
 find_package(camera_info_manager REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(depthai_ros_msgs REQUIRED)
@@ -45,6 +46,7 @@ find_package(composition_interfaces REQUIRED)
 find_package(ffmpeg_image_transport_msgs REQUIRED)
 
 set(dependencies
+  ament_index_cpp
   camera_info_manager
   cv_bridge
   depthai_ros_msgs

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_bridge</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>The depthai_bridge package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_bridge/src/TFPublisher.cpp
+++ b/depthai_bridge/src/TFPublisher.cpp
@@ -242,7 +242,7 @@ std::string TFPublisher::getURDF() {
     RCLCPP_DEBUG(logger, "Xacro command: %s", cmd.c_str());
     std::array<char, 128> buffer;
     std::string result;
-    std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, int (*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
     if(!pipe) {
         throw std::runtime_error("popen() failed!");
     }

--- a/depthai_bridge/src/TFPublisher.cpp
+++ b/depthai_bridge/src/TFPublisher.cpp
@@ -242,7 +242,7 @@ std::string TFPublisher::getURDF() {
     RCLCPP_DEBUG(logger, "Xacro command: %s", cmd.c_str());
     std::array<char, 128> buffer;
     std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
     if(!pipe) {
         throw std::runtime_error("popen() failed!");
     }

--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_descriptions VERSION 2.10.4)
+project(depthai_descriptions VERSION 2.10.5)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_descriptions/package.xml
+++ b/depthai_descriptions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_descriptions</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>The depthai_descriptions package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
-project(depthai_examples VERSION 2.10.4 LANGUAGES CXX C)
+project(depthai_examples VERSION 2.10.5 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_examples</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>The depthai_examples package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_filters VERSION 2.10.4 LANGUAGES CXX C)
+project(depthai_filters VERSION 2.10.5 LANGUAGES CXX C)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_filters/package.xml
+++ b/depthai_filters/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_filters</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>Depthai filters package</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
   <license>MIT</license>

--- a/depthai_filters/src/detection2d_overlay.cpp
+++ b/depthai_filters/src/detection2d_overlay.cpp
@@ -13,8 +13,8 @@ Detection2DOverlay::Detection2DOverlay(const rclcpp::NodeOptions& options) : rcl
 void Detection2DOverlay::onInit() {
     previewSub.subscribe(this, "rgb/preview/image_raw");
     detSub.subscribe(this, "nn/detections");
-    sync = std::make_unique<message_filters::Synchronizer<syncPolicy>>(syncPolicy(10), previewSub,  detSub);
-    sync->registerCallback(std::bind(&Detection2DOverlay::overlayCB, this, std::placeholders::_1, std::placeholders::_2 ));
+    sync = std::make_unique<message_filters::Synchronizer<syncPolicy>>(syncPolicy(10), previewSub, detSub);
+    sync->registerCallback(std::bind(&Detection2DOverlay::overlayCB, this, std::placeholders::_1, std::placeholders::_2));
     overlayPub = this->create_publisher<sensor_msgs::msg::Image>("overlay", 10);
     labelMap = this->declare_parameter<std::vector<std::string>>("label_map", labelMap);
 }

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(depthai_ros_driver VERSION 2.10.4)
+project(depthai_ros_driver VERSION 2.10.5)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/nn/spatial_detection.hpp
@@ -77,7 +77,7 @@ class SpatialDetection : public BaseNode {
             pubConf.height = height;
             pubConf.daiNodeName = getName();
             pubConf.topicName = "~/" + getName() + "/passthrough";
-			pubConf.infoSuffix = "/passthrough";
+            pubConf.infoSuffix = "/passthrough";
             pubConf.socket = static_cast<dai::CameraBoardSocket>(ph->getParam<int>("i_board_socket_id"));
 
             ptPub->setup(device, convConf, pubConf);
@@ -98,7 +98,7 @@ class SpatialDetection : public BaseNode {
             pubConf.height = ph->getOtherNodeParam<int>(sensor_helpers::getNodeName(getROSNode(), sensor_helpers::NodeNameEnum::Stereo), "i_height");
             pubConf.daiNodeName = getName();
             pubConf.topicName = "~/" + getName() + "/passthrough_depth";
-			pubConf.infoSuffix = "/passthrough_depth";
+            pubConf.infoSuffix = "/passthrough_depth";
             pubConf.socket = socket;
 
             ptDepthPub->setup(device, convConf, pubConf);

--- a/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/param_handlers/nn_param_handler.hpp
@@ -40,7 +40,7 @@ class NNParamHandler : public BaseParamHandler {
     template <typename T>
     void declareParams(std::shared_ptr<T> nn, std::shared_ptr<dai::node::ImageManip> imageManip) {
         declareAndLogParam<bool>("i_disable_resize", false);
-		declareAndLogParam<bool>("i_desqueeze_output", false);
+        declareAndLogParam<bool>("i_desqueeze_output", false);
         declareAndLogParam<bool>("i_enable_passthrough", false);
         declareAndLogParam<bool>("i_enable_passthrough_depth", false);
         declareAndLogParam<bool>("i_get_base_device_timestamp", false);

--- a/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
@@ -47,6 +47,7 @@ struct ImgConverterConfig {
     bool getBaseDeviceTimestamp = false;
     bool updateROSBaseTimeOnRosMsg = false;
     bool lowBandwidth = false;
+    bool isStereo = false;
     dai::RawImgFrame::Type encoding = dai::RawImgFrame::Type::BGR888i;
     bool addExposureOffset = false;
     dai::CameraExposureOffset expOffset = dai::CameraExposureOffset::START;

--- a/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
@@ -67,7 +67,7 @@ struct ImgPublisherConfig {
     dai::CameraBoardSocket rightSocket = dai::CameraBoardSocket::CAM_C;
     std::string calibrationFile = "";
     std::string topicSuffix = "/image_raw";
-	std::string infoSuffix = "";
+    std::string infoSuffix = "";
     std::string compressedTopicSuffix = "/image_raw/compressed";
     std::string infoMgrSuffix = "";
     bool rectified = false;

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
 

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -69,10 +69,12 @@ void ImagePublisher::setup(std::shared_ptr<dai::Device> device, const utils::Img
             ffmpegPub = node->create_publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>(
                 pubConfig.topicName + pubConfig.compressedTopicSuffix, rclcpp::QoS(10), pubOptions);
         }
-        infoPub = node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
+        infoPub =
+            node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
     } else if(ipcEnabled) {
         imgPub = node->create_publisher<sensor_msgs::msg::Image>(pubConfig.topicName + pubConfig.topicSuffix, rclcpp::QoS(10), pubOptions);
-        infoPub = node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
+        infoPub =
+            node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
     } else {
         imgPubIT = image_transport::create_camera_publisher(node.get(), pubConfig.topicName + pubConfig.topicSuffix);
     }
@@ -97,7 +99,7 @@ void ImagePublisher::createImageConverter(std::shared_ptr<dai::Device> device) {
     if(convConfig.alphaScalingEnabled) {
         converter->setAlphaScaling(convConfig.alphaScaling);
     }
-    if(!convConfig.outputDisparity) {
+    if(convConfig.isStereo && !convConfig.outputDisparity) {
         auto calHandler = device->readCalibration();
         double baseline = calHandler.getBaselineDistance(pubConfig.leftSocket, pubConfig.rightSocket, false);
         if(convConfig.reverseSocketOrder) {
@@ -113,8 +115,10 @@ std::shared_ptr<dai::node::VideoEncoder> ImagePublisher::createEncoder(std::shar
     auto enc = pipeline->create<dai::node::VideoEncoder>();
     enc->setQuality(encoderConfig.quality);
     enc->setProfile(encoderConfig.profile);
-    enc->setBitrate(encoderConfig.bitrate);
-    enc->setKeyframeFrequency(encoderConfig.frameFreq);
+    if(encoderConfig.profile != dai::VideoEncoderProperties::Profile::MJPEG) {
+        enc->setBitrate(encoderConfig.bitrate);
+        enc->setKeyframeFrequency(encoderConfig.frameFreq);
+    }
     return enc;
 }
 void ImagePublisher::createInfoManager(std::shared_ptr<dai::Device> device) {

--- a/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
@@ -194,6 +194,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
         convConfig.alphaScaling = ph->getParam<double>("i_alpha_scaling");
     }
     convConfig.outputDisparity = ph->getParam<bool>("i_output_disparity");
+    convConfig.isStereo = true;
 
     utils::ImgPublisherConfig pubConf;
     pubConf.daiNodeName = getName();

--- a/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
@@ -199,7 +199,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     utils::ImgPublisherConfig pubConf;
     pubConf.daiNodeName = getName();
     pubConf.topicName = "~/" + getName();
-	pubConf.topicSuffix = rsCompabilityMode() ? "/image_rect_raw" : "/image_raw";
+    pubConf.topicSuffix = rsCompabilityMode() ? "/image_rect_raw" : "/image_raw";
     pubConf.rectified = !convConfig.alphaScalingEnabled;
     pubConf.width = ph->getParam<int>("i_width");
     pubConf.height = ph->getParam<int>("i_height");

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -79,19 +79,19 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
     }
     monoCam->setImageOrientation(
         utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "AUTO"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
-	int expLimit = declareAndLogParam<int>("r_auto_exposure_limit", 1000);
+    int expLimit = declareAndLogParam<int>("r_auto_exposure_limit", 1000);
     if(declareAndLogParam<bool>("r_set_auto_exposure_limit", false)) {
         monoCam->initialControl.setAutoExposureLimit(expLimit);
     }
-	int sharpness = declareAndLogParam<int>("r_sharpness", 1);
+    int sharpness = declareAndLogParam<int>("r_sharpness", 1);
     if(declareAndLogParam("r_set_sharpness", false)) {
         monoCam->initialControl.setSharpness(sharpness);
     }
-	int chromaDenoise = declareAndLogParam<int>("r_chroma_denoise", 1);
+    int chromaDenoise = declareAndLogParam<int>("r_chroma_denoise", 1);
     if(declareAndLogParam("r_set_chroma_denoise", false)) {
         monoCam->initialControl.setChromaDenoise(chromaDenoise);
     }
-	int lumaDenoise = declareAndLogParam<int>("r_luma_denoise", 1);
+    int lumaDenoise = declareAndLogParam<int>("r_luma_denoise", 1);
     if(declareAndLogParam("r_set_luma_denoise", false)) {
         monoCam->initialControl.setLumaDenoise(lumaDenoise);
     }
@@ -194,19 +194,19 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     }
     colorCam->setImageOrientation(
         utils::getValFromMap(declareAndLogParam<std::string>("i_sensor_img_orientation", "AUTO"), dai_nodes::sensor_helpers::cameraImageOrientationMap));
-	int expLimit = declareAndLogParam<int>("r_auto_exposure_limit", 1000);
+    int expLimit = declareAndLogParam<int>("r_auto_exposure_limit", 1000);
     if(declareAndLogParam<bool>("r_set_auto_exposure_limit", false)) {
         colorCam->initialControl.setAutoExposureLimit(expLimit);
     }
-	int sharpness = declareAndLogParam<int>("r_sharpness", 1);
+    int sharpness = declareAndLogParam<int>("r_sharpness", 1);
     if(declareAndLogParam("r_set_sharpness", false)) {
         colorCam->initialControl.setSharpness(sharpness);
     }
-	int chromaDenoise = declareAndLogParam<int>("r_chroma_denoise", 1);
+    int chromaDenoise = declareAndLogParam<int>("r_chroma_denoise", 1);
     if(declareAndLogParam("r_set_chroma_denoise", false)) {
         colorCam->initialControl.setChromaDenoise(chromaDenoise);
     }
-	int lumaDenoise = declareAndLogParam<int>("r_luma_denoise", 1);
+    int lumaDenoise = declareAndLogParam<int>("r_luma_denoise", 1);
     if(declareAndLogParam("r_set_luma_denoise", false)) {
         colorCam->initialControl.setLumaDenoise(lumaDenoise);
     }

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai_ros_msgs VERSION 2.10.4)
+project(depthai_ros_msgs VERSION 2.10.5)
 
 if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_ros_msgs</name>
-  <version>2.10.4</version>
+  <version>2.10.5</version>
   <description>Package to keep interface independent of the driver</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/650
Issue description: Low bandwidth mode not enabled properly for sensors
Related PRs

## Changes
ROS distro: Humble
List of changes: 
- Fixed enabling low bandwidth
- Added stereo filters from v2.29.0

## Testing
Hardware used: OAK-D Pro
Depthai library version: 2.29.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
