### PR TITLE
fix : Ip autodiscovery fix noetic

### DIFF
--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -232,8 +232,14 @@ void Camera::startDevice() {
             } else {
                 std::vector<dai::DeviceInfo> availableDevices = dai::Device::getAllAvailableDevices();
                 if(availableDevices.size() == 0) {
+                    if(!ip.empty()) {
+                        dai::DeviceInfo info(ip);
+                        ROS_INFO("No devices detected by autodiscovery, trying to connect to camera via IP: %s", ip.c_str());
+                        availableDevices.push_back(info);
+                    }else{
                     throw std::runtime_error("No devices detected!");
                 }
+            }
                 dai::UsbSpeed speed = ph->getUSBSpeed();
 
                 for(const auto& info : availableDevices) {

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -236,10 +236,10 @@ void Camera::startDevice() {
                         dai::DeviceInfo info(ip);
                         ROS_INFO("No devices detected by autodiscovery, trying to connect to camera via IP: %s", ip.c_str());
                         availableDevices.push_back(info);
-                    }else{
-                    throw std::runtime_error("No devices detected!");
+                    } else {
+                        throw std::runtime_error("No devices detected!");
+                    }
                 }
-            }
                 dai::UsbSpeed speed = ph->getUSBSpeed();
 
                 for(const auto& info : availableDevices) {


### PR DESCRIPTION
## Overview
Author:  @iam-shanmukha

## Issue 
Issue link (if present):
Issue description:  Cameras on different subnets cannot be found
Related PRs : #561

## Changes
ROS distro: Noetic
List of changes:

- Change startup mechanism to mitigate the issue when IP is used

## Testing
Hardware used: OAK-D-POE
Depthai library version: 2.10.5


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
