### PR TITLE
Fix executor deadlocks when stopping camera on jazzy

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <rclcpp/callback_group.hpp>
 #include <string>
 #include <vector>
 
@@ -9,6 +8,7 @@
 #include "depthai_ros_driver/dai_nodes/base_node.hpp"
 #include "depthai_ros_driver/param_handlers/camera_param_handler.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "rclcpp/callback_group.hpp"
 #include "rclcpp/node.hpp"
 #include "std_srvs/srv/trigger.hpp"
 

--- a/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/camera.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <rclcpp/callback_group.hpp>
 #include <string>
 #include <vector>
 
@@ -92,9 +93,10 @@ class Camera : public rclcpp::Node {
     std::shared_ptr<dai::Pipeline> pipeline;
     std::shared_ptr<dai::Device> device;
     std::vector<std::unique_ptr<dai_nodes::BaseNode>> daiNodes;
-    bool camRunning = false;
+    std::atomic<bool> camRunning = false;
     bool initialized = false;
     std::unique_ptr<dai::ros::TFPublisher> tfPub;
     rclcpp::TimerBase::SharedPtr startTimer;
+    rclcpp::CallbackGroup::SharedPtr srvGroup;
 };
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -65,7 +65,7 @@ void Camera::onConfigure() {
                                                         ph->getParam<std::string>("i_tf_custom_xacro_args"),
                                                         ph->getParam<bool>("i_rs_compat"));
     }
-    // diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
+    diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
     RCLCPP_INFO(get_logger(), "Camera ready!");
 }
 
@@ -94,9 +94,9 @@ void Camera::start() {
 void Camera::stop() {
     RCLCPP_INFO(get_logger(), "Stopping camera.");
     if(camRunning) {
-        // for(const auto& node : daiNodes) {
-        //     node->closeQueues();
-        // }
+        for(const auto& node : daiNodes) {
+            node->closeQueues();
+        }
         daiNodes.clear();
         device.reset();
         pipeline.reset();

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -30,10 +30,15 @@ void Camera::onConfigure() {
     setupQueues();
     setIR();
     paramCBHandle = this->add_on_set_parameters_callback(std::bind(&Camera::parameterCB, this, std::placeholders::_1));
-    startSrv = this->create_service<Trigger>("~/start_camera", std::bind(&Camera::startCB, this, std::placeholders::_1, std::placeholders::_2));
-    stopSrv = this->create_service<Trigger>("~/stop_camera", std::bind(&Camera::stopCB, this, std::placeholders::_1, std::placeholders::_2));
-    savePipelineSrv = this->create_service<Trigger>("~/save_pipeline", std::bind(&Camera::savePipelineCB, this, std::placeholders::_1, std::placeholders::_2));
-    saveCalibSrv = this->create_service<Trigger>("~/save_calibration", std::bind(&Camera::saveCalibCB, this, std::placeholders::_1, std::placeholders::_2));
+    srvGroup = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+    startSrv = this->create_service<Trigger>(
+        "~/start_camera", std::bind(&Camera::startCB, this, std::placeholders::_1, std::placeholders::_2), rmw_qos_profile_services_default, srvGroup);
+    stopSrv = this->create_service<Trigger>(
+        "~/stop_camera", std::bind(&Camera::stopCB, this, std::placeholders::_1, std::placeholders::_2), rmw_qos_profile_services_default, srvGroup);
+    savePipelineSrv = this->create_service<Trigger>(
+        "~/save_pipeline", std::bind(&Camera::savePipelineCB, this, std::placeholders::_1, std::placeholders::_2), rmw_qos_profile_services_default, srvGroup);
+    saveCalibSrv = this->create_service<Trigger>(
+        "~/save_calibration", std::bind(&Camera::saveCalibCB, this, std::placeholders::_1, std::placeholders::_2), rmw_qos_profile_services_default, srvGroup);
 
     // If model name not set get one from the device
     std::string camModel = ph->getParam<std::string>("i_tf_camera_model");
@@ -60,7 +65,7 @@ void Camera::onConfigure() {
                                                         ph->getParam<std::string>("i_tf_custom_xacro_args"),
                                                         ph->getParam<bool>("i_rs_compat"));
     }
-    diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
+    // diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
     RCLCPP_INFO(get_logger(), "Camera ready!");
 }
 
@@ -89,13 +94,14 @@ void Camera::start() {
 void Camera::stop() {
     RCLCPP_INFO(get_logger(), "Stopping camera.");
     if(camRunning) {
-        for(const auto& node : daiNodes) {
-            node->closeQueues();
-        }
+        // for(const auto& node : daiNodes) {
+        //     node->closeQueues();
+        // }
         daiNodes.clear();
         device.reset();
         pipeline.reset();
         camRunning = false;
+        RCLCPP_INFO(get_logger(), "Camera stopped!");
     } else {
         RCLCPP_INFO(get_logger(), "Camera already stopped!");
     }


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/657
Issue description: Deadlock occurs when service and topics are in the same callback group and stop is called. Note that this only happens on Jazzy
Related PRs

## Changes
ROS distro: Jazzy
List of changes:
- Add separate callback group for services

## Testing
Hardware used: OAK-D Pro
Depthai library version: 2.29.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
