### PR TITLE
Add color order and fix low_bandwidth - Humble

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -82,7 +82,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -79,9 +79,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.3.0
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -69,7 +69,7 @@ jobs:
 
   docker-build:
     name: Build and Upload to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     env: 
@@ -80,6 +80,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/depthai-ros/CHANGELOG.rst
+++ b/depthai-ros/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package depthai-ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.11.1 (2025-03-12)
+-------------------
+* Add color order parameter for color sensors
+* (ROS2) Fix low bandwidth issue
+* (ROS1) Joint state remapping fix
+
 2.11.0 (2025-02-19)
 -------------------
 * Add Thermal support
@@ -55,8 +62,7 @@ Changelog for package depthai-ros
 * Syncing & RS updates Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/586
 
 2.9.0 (2024-01-24)
--------------------
-
+------------------
 * New documentation homepage
 * Updated support for LR and SR cameras
 * Added parameter to toggle restart on logging error
@@ -65,16 +71,14 @@ Changelog for package depthai-ros
 * Added option to run Spatial NN as part of stereo node
 
 2.8.2 (2023-10-17)
--------------------
-
+------------------
 * Fixed default resolution for Stereo cameras
 * Added CameraInfo update based on alpha scaling
 * Logger restart bugfix
 * URDF parameters fix
 
 2.8.1 (2023-09-12)
--------------------
-
+------------------
 * Added support for OpenCV Stereo order convention
 * Added disparity to depth use spec translation parameter
 * Updated sensor socket logic
@@ -82,7 +86,7 @@ Changelog for package depthai-ros
 * Added missing tf2 dependencies
 
 2.8.0 (2023-09-01)
--------------------
+------------------
 * Add camera image orientation param 
 * Performance update
 * Feature tracker
@@ -96,16 +100,16 @@ Changelog for package depthai-ros
 * Add exposure offset
 
 2.7.5 (2023-08-07)
--------------------
+------------------
 * IMU sync fix
 
 2.7.4 (2023-06-26)
--------------------
+------------------
 * ROS time update
 * Minor bugfixes
 
 2.7.3 (2023-06-16)
--------------------
+------------------
 * Pipeline generation as a plugin
 * Fixed bounding box generation issue
 * Stereo rectified streams publishing
@@ -113,15 +117,15 @@ Changelog for package depthai-ros
 * Brightness filter
 
 2.7.2 (2023-05-08)
--------------------
+------------------
 * IMU improvements
 
 2.7.1 (2023-03-29)
--------------------
+------------------
 * Add custom output size option for streams
 
 2.7.0 (2023-03-28)
--------------------
+------------------
 * Added depthai_descriptions package
 * Added depthai_filters package
 * XLinkIn option for image subscription
@@ -129,45 +133,45 @@ Changelog for package depthai-ros
 * Bugfixes
 
 2.6.4 (2023-02-23)
--------------------
+------------------
 * Fix sensor name detection
 * Enable subpixel mode
 * Update camera start/stop services
 
 2.6.3 (2023-02-10)
--------------------
+------------------
 * Camera calibration updates
 * Option to connect to the device via USB port id
 
 2.6.2 (2023-02-01)
--------------------
+------------------
 * Fixed timestamp in SpatialDetector
 * Updated topic names in stereo_inertial_node
 
 2.6.1 (2023-01-11)
--------------------
+------------------
 * Update docker image building
 
 2.6.0 (2023-01-11)
--------------------
+------------------
 * Added depthai_ros_driver package
 
 2.5.3 (2022-08-21)
--------------------
+------------------
 * Updated release version
 * Contributors: Sachin
 
 2.5.2 (2022-06-01)
--------------------
+------------------
 * Upgraded examples
 * Fixed bugs for Noetic
 
 2.5.1 (2022-05-20)
--------------------
+------------------
 * Fix Build farm issues
 
 2.5.0 (2022-05-20)
--------------------
+------------------
 * Release 2.5.0
 * add ament package:
 * created Bridge and Coverters to handle images, IMU and camera Info

--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai-ros VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai-ros VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/depthai-ros/package.xml
+++ b/depthai-ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai-ros</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai-ros package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-project(depthai_bridge VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_bridge VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_bridge</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_bridge package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -6,6 +6,7 @@
 #include "depthai_bridge/depthaiUtility.hpp"
 #include "opencv2/calib3d.hpp"
 #include "opencv2/imgcodecs.hpp"
+#include "sensor_msgs/image_encodings.hpp"
 
 namespace dai {
 
@@ -100,6 +101,12 @@ ImageMsgs::Image ImageConverter::toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> i
         switch(srcType) {
             case dai::RawImgFrame::Type::BGR888i: {
                 encoding = sensor_msgs::image_encodings::BGR8;
+                decodeFlags = cv::IMREAD_COLOR;
+                channels = CV_8UC3;
+                break;
+            }
+            case dai::RawImgFrame::Type::RGB888i: {
+                encoding = sensor_msgs::image_encodings::RGB8;
                 decodeFlags = cv::IMREAD_COLOR;
                 channels = CV_8UC3;
                 break;

--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_descriptions VERSION 2.11.0)
+project(depthai_descriptions VERSION 2.11.1)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_descriptions/package.xml
+++ b/depthai_descriptions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_descriptions</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_descriptions package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
-project(depthai_examples VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_examples VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_examples</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_examples package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_filters VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_filters VERSION 2.11.1 LANGUAGES CXX C)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_filters/include/depthai_filters/thermal_temp.hpp
+++ b/depthai_filters/include/depthai_filters/thermal_temp.hpp
@@ -15,7 +15,6 @@ class ThermalTemp : public rclcpp::Node {
     rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr colorPub;
     int mouseX = 0;
     int mouseY = 0;
-
 };
 
 }  // namespace depthai_filters

--- a/depthai_filters/package.xml
+++ b/depthai_filters/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_filters</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>Depthai filters package</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
   <license>MIT</license>

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(depthai_ros_driver VERSION 2.11.0)
+project(depthai_ros_driver VERSION 2.11.1)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -56,6 +56,7 @@ extern const std::unordered_map<std::string, dai::MonoCameraProperties::SensorRe
 extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
+extern const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap;
 bool rsCompabilityMode(std::shared_ptr<rclcpp::Node> node);
 std::string tfPrefix(std::shared_ptr<rclcpp::Node> node);
 std::string getSocketName(std::shared_ptr<rclcpp::Node> node, dai::CameraBoardSocket socket);

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  ќversion>2.11.1</version>
+  <version>2.11.1</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
 

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  <version>2.11.0</version>
+  ќversion>2.11.1</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
 

--- a/depthai_ros_driver/src/camera.cpp
+++ b/depthai_ros_driver/src/camera.cpp
@@ -65,7 +65,6 @@ void Camera::onConfigure() {
     saveCalibSrv = this->create_service<Trigger>(
         "~/save_calibration", std::bind(&Camera::saveCalibCB, this, std::placeholders::_1, std::placeholders::_2), rmw_qos_profile_services_default, srvGroup);
 
-
     diagSub = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10, std::bind(&Camera::diagCB, this, std::placeholders::_1));
     RCLCPP_INFO(get_logger(), "Camera ready!");
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -88,7 +88,7 @@ void ImagePublisher::createImageConverter(std::shared_ptr<dai::Device> device) {
     converter->setUpdateRosBaseTimeOnToRosMsg(convConfig.updateROSBaseTimeOnRosMsg);
     if(convConfig.lowBandwidth) {
         converter->convertFromBitstream(convConfig.encoding);
-        if(!convConfig.outputDisparity) {
+        if(convConfig.isStereo && !convConfig.outputDisparity) {
             try {
                 auto calHandler = device->readCalibration();
                 double baseline = calHandler.getBaselineDistance(pubConfig.leftSocket, pubConfig.rightSocket, false);

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -72,7 +72,11 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
         convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
         convConfig.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
-        convConfig.encoding = dai::RawImgFrame::Type::BGR888i;
+        if(ph->getParam<std::string>("i_color_order") == "BGR") {
+            convConfig.encoding = dai::RawImgFrame::Type::BGR888i;
+        } else {
+            convConfig.encoding = dai::RawImgFrame::Type::RGB888i;
+        }
         convConfig.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
         convConfig.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
         convConfig.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -62,6 +62,11 @@ const std::unordered_map<NodeNameEnum, std::string> NodeNameMap = {
     {NodeNameEnum::NN, "nn"},
 };
 
+const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap = {
+    {"BGR", dai::ColorCameraProperties::ColorOrder::BGR},
+    {"RGB", dai::ColorCameraProperties::ColorOrder::RGB},
+};
+
 bool rsCompabilityMode(std::shared_ptr<rclcpp::Node> node) {
     return node->get_parameter("camera.i_rs_compat").as_bool();
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/thermal.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/thermal.cpp
@@ -40,10 +40,12 @@ void Thermal::setXinXout(std::shared_ptr<dai::Pipeline> pipeline) {
         encConfig.quality = ph->getParam<int>("i_low_bandwidth_quality");
         encConfig.enabled = ph->getParam<bool>("i_low_bandwidth");
 
-        thermalPub = setupOutput(pipeline, thermalQName, [&](auto input) { camNode->video.link(input); }, ph->getParam<bool>("i_synced"), encConfig);
+        thermalPub = setupOutput(
+            pipeline, thermalQName, [&](auto input) { camNode->video.link(input); }, ph->getParam<bool>("i_synced"), encConfig);
     }
     if(ph->getParam<bool>("i_publish_raw")) {
-        thermalRawPub = setupOutput(pipeline, rawQName, [&](auto input) { camNode->raw.link(input); }, ph->getParam<bool>("i_synced"));
+        thermalRawPub = setupOutput(
+            pipeline, rawQName, [&](auto input) { camNode->raw.link(input); }, ph->getParam<bool>("i_synced"));
     }
 }
 

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -137,6 +137,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     int height = colorCam->getResolutionHeight();
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
+    colorCam->setColorOrder(utils::getValFromMap(declareAndLogParam<std::string>("i_color_order", "BGR"), dai_nodes::sensor_helpers::colorOrderMap));
 
     bool setIspScale = true;
     if(sensor.defaultResolution != "1080P"
@@ -160,7 +161,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
             err_stream << " which are not divisible by 16.\n";
             err_stream << "This will result in errors when aligning stereo to RGB. To fix that, either adjust i_num and i_den values";
             err_stream << " or set i_output_isp parameter to false and set i_width and i_height parameters accordingly.";
-            RCLCPP_ERROR(getROSNode()->get_logger(), err_stream.str().c_str());
+            RCLCPP_ERROR(getROSNode()->get_logger(), "%s", err_stream.str().c_str());
         }
     }
     int maxVideoWidth = 3840;

--- a/depthai_ros_driver/src/pipeline/base_types.cpp
+++ b/depthai_ros_driver/src/pipeline/base_types.cpp
@@ -209,9 +209,9 @@ std::vector<std::unique_ptr<dai_nodes::BaseNode>> RGBToF::createPipeline(std::sh
     return daiNodes;
 }
 std::vector<std::unique_ptr<dai_nodes::BaseNode>> Thermal::createPipeline(std::shared_ptr<rclcpp::Node> node,
-                                                                         std::shared_ptr<dai::Device> device,
-                                                                         std::shared_ptr<dai::Pipeline> pipeline,
-                                                                         const std::string& nnType) {
+                                                                          std::shared_ptr<dai::Device> device,
+                                                                          std::shared_ptr<dai::Pipeline> pipeline,
+                                                                          const std::string& nnType) {
     using namespace dai_nodes::sensor_helpers;
     std::string nTypeUpCase = utils::getUpperCaseStr(nnType);
     auto nType = utils::getValFromMap(nTypeUpCase, nnTypeMap);

--- a/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
+++ b/depthai_ros_driver/src/pipeline/pipeline_generator.cpp
@@ -106,7 +106,7 @@ std::string PipelineGenerator::validatePipeline(std::shared_ptr<rclcpp::Node> no
             return "RGB";
         }
     } else if(sensorNum == 2) {
-        if(pType != PipelineType::Stereo && pType != PipelineType::Depth &&  pType != PipelineType::CamArray && pType != PipelineType::Thermal) {
+        if(pType != PipelineType::Stereo && pType != PipelineType::Depth && pType != PipelineType::CamArray && pType != PipelineType::Thermal) {
             RCLCPP_ERROR(node->get_logger(), "Invalid pipeline chosen for camera as it has only stereo pair. Switching to Depth.");
             return "DEPTH";
         }

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai_ros_msgs VERSION 2.11.0)
+project(depthai_ros_msgs VERSION 2.11.1)
 
 if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_ros_msgs</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>Package to keep interface independent of the driver</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/685 https://github.com/luxonis/depthai-ros/issues/687
Issue description: Adding the option to change color order, bringing back fix for low bandwidth which was removed accidentally
Related PRs

## Changes
ROS distro: Humble
List of changes:
- Add new parameter to set color order for cameras

## Testing
Hardware used: OAK-D Pro
Depthai library version: 2.29.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
