### PR TITLE
 Add color order - Noetic

### DIFF
--- a/depthai-ros/CHANGELOG.rst
+++ b/depthai-ros/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Changelog for package depthai-ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+2.11.1 (2025-03-12)
+-------------------
+* Add color order parameter for color sensors
+* (ROS2) Fix low bandwidth issue
+* (ROS1) Joint state remapping fix
+
 2.11.0 (2025-02-19)
 -------------------
 * Add Thermal support
@@ -56,7 +63,6 @@ Changelog for package depthai-ros
 
 2.9.0 (2024-01-24)
 -------------------
-
 * New documentation homepage
 * Updated support for LR and SR cameras
 * Added parameter to toggle restart on logging error
@@ -65,8 +71,7 @@ Changelog for package depthai-ros
 * Added option to run Spatial NN as part of stereo node
 
 2.8.2 (2023-10-17)
--------------------
-
+------------------
 * Fixed default resolution for Stereo cameras
 * Added CameraInfo update based on alpha scaling
 * Logger restart bugfix
@@ -74,8 +79,7 @@ Changelog for package depthai-ros
 
 
 2.8.1 (2023-09-12)
--------------------
-
+------------------
 * Added support for OpenCV Stereo order convention
 * Added disparity to depth use spec translation parameter
 * Updated sensor socket logic
@@ -83,7 +87,7 @@ Changelog for package depthai-ros
 * Added missing tf2 dependencies
 
 2.8.0 (2023-09-01)
--------------------
+------------------
 * Add camera image orientation param 
 * Performance update
 * Feature tracker
@@ -97,16 +101,16 @@ Changelog for package depthai-ros
 * Add exposure offset
 
 2.7.5 (2023-08-07)
--------------------
+------------------
 * IMU sync fix
 
 2.7.4 (2023-06-26)
--------------------
+------------------
 * ROS time update
 * Minor bugfixes
 
 2.7.3 (2023-06-16)
--------------------
+------------------
 * Pipeline generation as a plugin
 * Fixed bounding box generation issue
 * Stereo rectified streams publishing
@@ -114,15 +118,15 @@ Changelog for package depthai-ros
 * Brightness filter
 
 2.7.2 (2023-05-08)
--------------------
+------------------
 * IMU improvements
 
 2.7.1 (2023-03-29)
--------------------
+------------------
 * Add custom output size option for streams
 
 2.7.0 (2023-03-28)
--------------------
+------------------
 * Added depthai_descriptions package
 * Added depthai_filters package
 * XLinkIn option for image subscription
@@ -130,31 +134,31 @@ Changelog for package depthai-ros
 * Bugfixes
 
 2.6.4 (2023-02-23)
--------------------
+------------------
 * Fix sensor name detection
 * Enable subpixel mode
 * Update camera start/stop services
 
 2.6.3 (2023-02-10)
--------------------
+------------------
 * Camera calibration updates
 * Option to connect to the device via USB port id
 
 2.6.2 (2023-02-01)
--------------------
+------------------
 * Fixed timestamp in SpatialDetector
 * Updated topic names in stereo_inertial_node
 
 2.6.1 (2023-01-11)
--------------------
+------------------
 * Update docker image building
 
 2.6.0 (2023-01-11)
--------------------
+------------------
 * Added depthai_ros_driver package
 
 2.5.3 (2022-08-21)
--------------------
+------------------
 * Updated release version
 * Contributors: Sachin
 
@@ -164,11 +168,11 @@ Changelog for package depthai-ros
 * Fixed bugs for Noetic
 
 2.5.1 (2022-05-20)
--------------------
+------------------
 * Fix Build farm issues
 
 2.5.0 (2022-05-20)
--------------------
+------------------
 * Release 2.5.0
 * add ament package:
 * created Bridge and Coverters to handle images, IMU and camera Info

--- a/depthai-ros/package.xml
+++ b/depthai-ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai-ros</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai-ros package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-project(depthai_bridge VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_bridge VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_bridge</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_bridge package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -100,6 +100,12 @@ ImageMsgs::Image ImageConverter::toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> i
                 channels = CV_8UC3;
                 break;
             }
+            case dai::RawImgFrame::Type::RGB888i: {
+                encoding = sensor_msgs::image_encodings::RGB8;
+                decodeFlags = cv::IMREAD_COLOR;
+                channels = CV_8UC3;
+                break;
+            }
             case dai::RawImgFrame::Type::GRAY8: {
                 encoding = sensor_msgs::image_encodings::MONO8;
                 decodeFlags = cv::IMREAD_GRAYSCALE;

--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(depthai_descriptions VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_descriptions VERSION 2.11.1 LANGUAGES CXX C)
 
 
 find_package(catkin REQUIRED

--- a/depthai_descriptions/launch/urdf.launch
+++ b/depthai_descriptions/launch/urdf.launch
@@ -34,5 +34,6 @@
 	<node name="$(arg tf_prefix)_state_publisher" pkg="robot_state_publisher"
 		type="robot_state_publisher" output="screen" required="true">
 		<remap from="robot_description" to="$(arg tf_prefix)/robot_description" />
+        <remap from="joint_states" to="$(arg tf_prefix)/joint_states"/>
 	</node>
 </launch>

--- a/depthai_descriptions/package.xml
+++ b/depthai_descriptions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>depthai_descriptions</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_descriptions package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
-project(depthai_examples VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_examples VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_examples</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_examples package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(depthai_filters VERSION 2.11.0 LANGUAGES CXX C)
+project(depthai_filters VERSION 2.11.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_filters/package.xml
+++ b/depthai_filters/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>depthai_filters</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>The depthai_filters package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
-project(depthai_ros_driver VERSION 2.11.0)
+project(depthai_ros_driver VERSION 2.11.1)
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()

--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp
@@ -53,6 +53,7 @@ extern const std::unordered_map<std::string, dai::MonoCameraProperties::SensorRe
 extern const std::unordered_map<std::string, dai::ColorCameraProperties::SensorResolution> rgbResolutionMap;
 extern const std::unordered_map<std::string, dai::CameraControl::FrameSyncMode> fSyncModeMap;
 extern const std::unordered_map<std::string, dai::CameraImageOrientation> cameraImageOrientationMap;
+extern const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap;
 bool rsCompabilityMode(ros::NodeHandle node);
 std::string tfPrefix(ros::NodeHandle node);
 std::string getSocketName(ros::NodeHandle node, dai::CameraBoardSocket socket);

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
   <author>Adam Serafin</author>

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -72,7 +72,7 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
         convConfig.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
         if(ph->getParam<std::string>("i_color_order") == "BGR") {
-            convConfig.encoding = dai::RawImgFrame::Type::BGR888p;
+            convConfig.encoding = dai::RawImgFrame::Type::BGR888i;
         } else {
             convConfig.encoding = dai::RawImgFrame::Type::RGB888i;
         }

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -71,7 +71,11 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         convConfig.getBaseDeviceTimestamp = ph->getParam<bool>("i_get_base_device_timestamp");
         convConfig.updateROSBaseTimeOnRosMsg = ph->getParam<bool>("i_update_ros_base_time_on_ros_msg");
         convConfig.lowBandwidth = ph->getParam<bool>("i_low_bandwidth");
-        convConfig.encoding = dai::RawImgFrame::Type::BGR888i;
+        if(ph->getParam<std::string>("i_color_order") == "BGR") {
+            convConfig.encoding = dai::RawImgFrame::Type::BGR888p;
+        } else {
+            convConfig.encoding = dai::RawImgFrame::Type::RGB888i;
+        }
         convConfig.addExposureOffset = ph->getParam<bool>("i_add_exposure_offset");
         convConfig.expOffset = static_cast<dai::CameraExposureOffset>(ph->getParam<int>("i_exposure_offset"));
         convConfig.reverseSocketOrder = ph->getParam<bool>("i_reverse_stereo_socket_order");

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -93,10 +93,8 @@ const std::unordered_map<NodeNameEnum, std::string> NodeNameMap = {
     {NodeNameEnum::NN, "nn"},
 };
 
-const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap = {
-    {"BGR", dai::ColorCameraProperties::ColorOrder::BGR},
-    {"RGB", dai::ColorCameraProperties::ColorOrder::RGB}
-};
+const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap = {{"BGR", dai::ColorCameraProperties::ColorOrder::BGR},
+                                                                                               {"RGB", dai::ColorCameraProperties::ColorOrder::RGB}};
 
 bool rsCompabilityMode(ros::NodeHandle node) {
     bool compat = false;

--- a/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/sensor_helpers.cpp
@@ -93,6 +93,11 @@ const std::unordered_map<NodeNameEnum, std::string> NodeNameMap = {
     {NodeNameEnum::NN, "nn"},
 };
 
+const std::unordered_map<std::string, dai::ColorCameraProperties::ColorOrder> colorOrderMap = {
+    {"BGR", dai::ColorCameraProperties::ColorOrder::BGR},
+    {"RGB", dai::ColorCameraProperties::ColorOrder::RGB}
+};
+
 bool rsCompabilityMode(ros::NodeHandle node) {
     bool compat = false;
     node.getParam("camera_i_rs_compat", compat);

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -129,6 +129,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     int height = colorCam->getResolutionHeight();
 
     colorCam->setInterleaved(declareAndLogParam<bool>("i_interleaved", false));
+    colorCam->setColorOrder(utils::getValFromMap(declareAndLogParam<std::string>("i_color_order", "BGR"), dai_nodes::sensor_helpers::colorOrderMap));
 
     bool setIspScale = true;
     if(sensor.defaultResolution != "1080P"

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project (depthai_ros_msgs VERSION 2.11.0)
+project (depthai_ros_msgs VERSION 2.11.1)
 
 if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_ros_msgs</name>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <description>Package to keep interface independent of the driver</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/685 https://github.com/luxonis/depthai-ros/issues/688
Issue description: Adding the option to change color order, bringing back fix for low bandwidth which was removed accidentally
Related PRs

## Changes
ROS distro: Jazzy
List of changes:
- Add new parameter to set color order for cameras
- Update TF publishing with remapping of joint states

## Testing
Hardware used: OAK-D Pro
Depthai library version: 2.29.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
