### PR TITLE
Add autoexposure region - Humble

### DIFF
--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -95,6 +95,14 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
     if(declareAndLogParam("r_set_luma_denoise", false)) {
         monoCam->initialControl.setLumaDenoise(lumaDenoise);
     }
+    bool setAutoExpRegion = declareAndLogParam<bool>("r_set_auto_exp_region", false);
+    int autoExpStartX = declareAndLogParam<int>("r_auto_exp_region_start_x", 0);
+    int autoExpStartY = declareAndLogParam<int>("r_auto_exp_region_start_y", 0);
+    int autoExpWidth = declareAndLogParam<int>("r_auto_exp_region_width", 0);
+    int autoExpHeight = declareAndLogParam<int>("r_auto_exp_region_height", 0);
+    if(setAutoExpRegion) {
+        monoCam->initialControl.setAutoExposureRegion(autoExpStartX, autoExpStartY, autoExpWidth, autoExpHeight);
+    }
 }
 void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> colorCam, dai_nodes::sensor_helpers::ImageSensor sensor, bool publish) {
     declareAndLogParam<bool>("i_publish_topic", publish);
@@ -210,6 +218,14 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     if(declareAndLogParam("r_set_luma_denoise", false)) {
         colorCam->initialControl.setLumaDenoise(lumaDenoise);
     }
+    bool setAutoExpRegion = declareAndLogParam<bool>("r_set_auto_exp_region", false);
+    int autoExpStartX = declareAndLogParam<int>("r_auto_exp_region_start_x", 0);
+    int autoExpStartY = declareAndLogParam<int>("r_auto_exp_region_start_y", 0);
+    int autoExpWidth = declareAndLogParam<int>("r_auto_exp_region_width", 0);
+    int autoExpHeight = declareAndLogParam<int>("r_auto_exp_region_height", 0);
+    if(setAutoExpRegion) {
+        colorCam->initialControl.setAutoExposureRegion(autoExpStartX, autoExpStartY, autoExpWidth, autoExpHeight);
+    }
 }
 dai::CameraControl SensorParamHandler::setRuntimeParams(const std::vector<rclcpp::Parameter>& params) {
     dai::CameraControl ctrl;
@@ -279,6 +295,34 @@ dai::CameraControl SensorParamHandler::setRuntimeParams(const std::vector<rclcpp
         } else if(p.get_name() == getFullParamName("r_luma_denoise")) {
             if(getParam<bool>("r_set_luma_denoise")) {
                 ctrl.setLumaDenoise(p.get_value<int>());
+            }
+        } else if(p.get_name() == getFullParamName("r_auto_exp_region_start_x")) {
+            if(getParam<bool>("r_set_auto_exp_region")) {
+                ctrl.setAutoExposureRegion(p.get_value<int>(),
+                                           getParam<int>("r_auto_exp_region_start_y"),
+                                           getParam<int>("r_auto_exp_region_width"),
+                                           getParam<int>("r_auto_exp_region_height"));
+            }
+        } else if(p.get_name() == getFullParamName("r_auto_exp_region_start_y")) {
+            if(getParam<bool>("r_set_auto_exp_region")) {
+                ctrl.setAutoExposureRegion(getParam<int>("r_auto_exp_region_start_x"),
+                                           p.get_value<int>(),
+                                           getParam<int>("r_auto_exp_region_width"),
+                                           getParam<int>("r_auto_exp_region_height"));
+            }
+        } else if(p.get_name() == getFullParamName("r_auto_exp_region_width")) {
+            if(getParam<bool>("r_set_auto_exp_region")) {
+                ctrl.setAutoExposureRegion(getParam<int>("r_auto_exp_region_start_x"),
+                                           getParam<int>("r_auto_exp_region_start_y"),
+                                           p.get_value<int>(),
+                                           getParam<int>("r_auto_exp_region_height"));
+            }
+        } else if(p.get_name() == getFullParamName("r_auto_exp_region_height")) {
+            if(getParam<bool>("r_set_auto_exp_region")) {
+                ctrl.setAutoExposureRegion(getParam<int>("r_auto_exp_region_start_x"),
+                                           getParam<int>("r_auto_exp_region_start_y"),
+                                           getParam<int>("r_auto_exp_region_width"),
+                                           p.get_value<int>());
             }
         }
     }


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present): N/A
Issue description: Add parameters to set autoexposure region
Related PRs

## Changes
ROS distro: Humble
List of changes:
New parameters:
- r_set_autoexp_region (bool)
- r_autoexp_region_start_x (int)
- r_autoexp_region_start_y (int)
- r_autoexp_region_width (int)
- r_autoexp_region_height (int)
## Testing
Hardware used: OAK-D Pro
Depthai library version: 2.29.0


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
