### PR TITLE
fix disparity to depth conversion

### DIFF
--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -71,8 +71,9 @@ class ImageConverter {
     /**
      * @brief Sets converter behavior to convert from disparity to depth when converting messages from bitstream.
      * @param baseline: The baseline of the stereo pair.
+     * @param focalLength: The focal length of the camera.
      */
-    void convertDispToDepth(double baseline);
+    void convertDispToDepth(double baseline, double focalLength);
 
     /**
      * @brief Reverses the order of the stereo sockets when creating CameraInfo to calculate Tx component of Projection matrix.
@@ -140,6 +141,7 @@ class ImageConverter {
     dai::CameraExposureOffset expOffset;
     bool reversedStereoSocketOrder = false;
     double baseline;
+    double focalLength;
     double alphaScalingFactor = 0.0;
     int camHeight = -1;
     int camWidth = -1;

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -50,9 +50,10 @@ void ImageConverter::convertFromBitstream(dai::RawImgFrame::Type srcType) {
     this->srcType = srcType;
 }
 
-void ImageConverter::convertDispToDepth(double baseline) {
+void ImageConverter::convertDispToDepth(double baseline, double focalLength) {
     dispToDepth = true;
     this->baseline = baseline;
+    this->focalLength = focalLength;
 }
 
 void ImageConverter::addExposureOffset(dai::CameraExposureOffset& offset) {
@@ -133,7 +134,7 @@ ImageMsgs::Image ImageConverter::toRosMsgRawPtr(std::shared_ptr<dai::ImgFrame> i
 
         // converting disparity
         if(dispToDepth) {
-            auto factor = std::abs(baseline * 10) * info.p[0];
+            auto factor = std::abs(baseline * 10) * focalLength;
             cv::Mat depthOut = cv::Mat(cv::Size(output.cols, output.rows), CV_16UC1);
             depthOut.forEach<uint16_t>([&output, &factor](uint16_t& pixel, const int* position) -> void {
                 auto disp = output.at<uint8_t>(position);

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -92,10 +92,11 @@ void ImagePublisher::createImageConverter(std::shared_ptr<dai::Device> device) {
             try {
                 auto calHandler = device->readCalibration();
                 double baseline = calHandler.getBaselineDistance(pubConfig.leftSocket, pubConfig.rightSocket, false);
+                double focalLength = calHandler.getCameraIntrinsics(pubConfig.leftSocket).at(0).at(0);
                 if(convConfig.reverseSocketOrder) {
                     baseline = calHandler.getBaselineDistance(pubConfig.rightSocket, pubConfig.leftSocket, false);
                 }
-                converter->convertDispToDepth(baseline);
+                converter->convertDispToDepth(baseline, focalLength);
             } catch(const std::exception& e) {
                 RCLCPP_DEBUG(node->get_logger(), "Failed to convert disparity to depth: %s", e.what());
             }
@@ -113,10 +114,11 @@ void ImagePublisher::createImageConverter(std::shared_ptr<dai::Device> device) {
     if(convConfig.isStereo && !convConfig.outputDisparity) {
         auto calHandler = device->readCalibration();
         double baseline = calHandler.getBaselineDistance(pubConfig.leftSocket, pubConfig.rightSocket, false);
+        double focalLength = calHandler.getCameraIntrinsics(pubConfig.leftSocket).at(0).at(0);
         if(convConfig.reverseSocketOrder) {
             baseline = calHandler.getBaselineDistance(pubConfig.rightSocket, pubConfig.leftSocket, false);
         }
-        converter->convertDispToDepth(baseline);
+        converter->convertDispToDepth(baseline, focalLength);
     }
     converter->setFFMPEGEncoding(convConfig.ffmpegEncoder);
 }


### PR DESCRIPTION
## Overview
Author: Dawid Kmak

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/742
Issue description: Disparity to depth conversion uses wrong focal length

## Changes
ROS distro: Jazzy
List of changes:
- Add `focalLength` param to `convertDispToDepth` function
- Use left camera focal length for conversion

## Testing
Hardware used: OAK-D-PRO-W-POE
Depthai library version: ros-jazzy-depthai/noble,now 2.30.0-1noble.20250424.110737 amd64

## Visuals from testing
Measured distance to object: 600mm

Before:
<img width="805" height="454" alt="image" src="https://github.com/user-attachments/assets/69f779fd-72cd-402a-8a08-d385431328a8" />
After:
<img width="867" height="486" alt="image" src="https://github.com/user-attachments/assets/264155c2-bf62-4480-a38e-fa85dca9776b" /> |