### PR TITLE
Always use image transport even when intra-process comms is enabled

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/img_pub.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/dai_nodes/sensors/img_pub.hpp
@@ -89,8 +89,6 @@ class ImagePublisher {
     std::shared_ptr<dai::node::VideoEncoder> createEncoder(std::shared_ptr<dai::Pipeline> pipeline, const utils::VideoEncoderConfig& encoderConfig);
 
    private:
-    bool detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
-                            const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub);
     std::shared_ptr<rclcpp::Node> node;
     utils::VideoEncoderConfig encConfig;
     utils::ImgPublisherConfig pubConfig;
@@ -100,7 +98,6 @@ class ImagePublisher {
     std::shared_ptr<dai::node::XLinkOut> xout;
     std::shared_ptr<dai::node::VideoEncoder> encoder;
     std::function<void(dai::Node::Input in)> linkCB;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr imgPub;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub;
     rclcpp::Publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>::SharedPtr ffmpegPub;
     rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressedImgPub;

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -70,10 +70,6 @@ void ImagePublisher::setup(std::shared_ptr<dai::Device> device, const utils::Img
         }
         infoPub =
             node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
-    } else if(ipcEnabled) {
-        imgPub = node->create_publisher<sensor_msgs::msg::Image>(pubConfig.topicName + pubConfig.topicSuffix, rclcpp::QoS(10), pubOptions);
-        infoPub =
-            node->create_publisher<sensor_msgs::msg::CameraInfo>(pubConfig.topicName + pubConfig.infoSuffix + "/camera_info", rclcpp::QoS(10), pubOptions);
     } else {
         imgPubIT = image_transport::create_camera_publisher(node.get(), pubConfig.topicName + pubConfig.topicSuffix);
     }
@@ -201,11 +197,8 @@ void ImagePublisher::publish(std::shared_ptr<Image> img) {
         }
         infoPub->publish(std::move(img->info));
     } else {
-        if(ipcEnabled && (!pubConfig.lazyPub || detectSubscription(imgPub, infoPub))) {
-            imgPub->publish(std::move(img->image));
-            infoPub->publish(std::move(img->info));
-        } else {
-            if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(*img->image, *img->info);
+        if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) {
+            imgPubIT.publish(*img->image, *img->info);
         }
     }
 }
@@ -228,12 +221,6 @@ void ImagePublisher::publish(const std::shared_ptr<dai::ADatatype>& data) {
         auto img = convertData(data);
         publish(img);
     }
-}
-
-bool ImagePublisher::detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
-                                        const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub) {
-    return (pub->get_subscription_count() > 0 || pub->get_intra_process_subscription_count() > 0 || infoPub->get_subscription_count() > 0
-            || infoPub->get_intra_process_subscription_count() > 0);
 }
 }  // namespace sensor_helpers
 }  // namespace dai_nodes


### PR DESCRIPTION
## Overview
Author:  Jan Hernas

## Issue 
Issue link: https://github.com/luxonis/depthai-ros/issues/557
Issue description: Image transport now (since Jazzy) supports intra-process communication so there is no need to create a separate publisher when ipc is enabled. I'd like to be able to take advantage of image transport functionalities even when using intra-process comms.

## Changes
ROS distro: Jazzy
List of changes: 
- Image transport is now a default publisher even when ipc is enabled.

## Testing
Hardware used: OAK-D W PRO


## Visuals from testing
Launch file used:
```xml
<launch version="0.1.1">

  <node_container namespace=""
    name="oak_container"
    pkg="rclcpp_components"
    exec="component_container_isolated">
    <composable_node namespace=""
      name="oak"
      pkg="depthai_ros_driver"
      plugin="depthai_ros_driver::Camera">
      <extra_arg name="use_intra_process_comms" value="true" />
      <param from="$(find-pkg-share raph_bringup)/config/oak.yaml" />
    </composable_node>
    <composable_node namespace="oak"
      name="point_cloud_xyz"
      pkg="depth_image_proc"
      plugin="depth_image_proc::PointCloudXyzNode">
      <extra_arg name="use_intra_process_comms" value="true" />
      <remap from="image_rect" to="stereo/image_raw" />
      <remap from="camera_info" to="stereo/camera_info" />
    </composable_node>
  </node_container>

</launch>
```
Ros2 topics with image transport plugins and intra-process comms enabled:
<img width="419" height="552" alt="ros2topiclist" src="https://github.com/user-attachments/assets/d24c9d1a-fe75-412e-a0cd-ba7d9e8986f7" />

