### PR TITLE
Image flipping on publishing to ROS

### DIFF
--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -20,9 +20,6 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(OpenCV REQUIRED COMPONENTS core imgcodecs imgproc)
-find_package(cv_bridge REQUIRED)
-
 set(COMMON_DEPS
 camera_info_manager
 cv_bridge

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -85,10 +85,6 @@ add_library(
 
 ament_target_dependencies(${COMMON_LIB_NAME} ${COMMON_DEPS})
 
-# Link OpenCV to the common lib so cv headers/libs are available
-target_link_libraries(${COMMON_LIB_NAME} ${OpenCV_LIBS})
-target_link_libraries(${COMMON_LIB_NAME} cv_bridge::cv_bridge)
-
 set(SENSOR_LIB_NAME ${PROJECT_NAME}_sensor_nodes)
 add_library(
   ${SENSOR_LIB_NAME} SHARED

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -20,6 +20,9 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs imgproc)
+find_package(cv_bridge REQUIRED)
+
 set(COMMON_DEPS
 camera_info_manager
 cv_bridge
@@ -81,6 +84,10 @@ add_library(
 )
 
 ament_target_dependencies(${COMMON_LIB_NAME} ${COMMON_DEPS})
+
+# Link OpenCV to the common lib so cv headers/libs are available
+target_link_libraries(${COMMON_LIB_NAME} ${OpenCV_LIBS})
+target_link_libraries(${COMMON_LIB_NAME} cv_bridge::cv_bridge)
 
 set(SENSOR_LIB_NAME ${PROJECT_NAME}_sensor_nodes)
 add_library(

--- a/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/utils.hpp
@@ -76,6 +76,7 @@ struct ImgPublisherConfig {
     int maxQSize = 8;
     bool qBlocking = false;
     bool publishCompressed = false;
+    bool flipImage = false;
 };
 std::shared_ptr<dai::node::XLinkOut> setupXout(std::shared_ptr<dai::Pipeline> pipeline, const std::string& name);
 }  // namespace utils

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -18,7 +18,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>cv_bridge</depend>
-  <depend>opencv4</depend>
+  <depend>libopencv-dev</depend>
   <depend>image_transport</depend>
   <depend>image_transport_plugins</depend>
   <depend>image_pipeline</depend>

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -18,6 +18,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>cv_bridge</depend>
+  <depend>opencv4</depend>
   <depend>image_transport</depend>
   <depend>image_transport_plugins</depend>
   <depend>image_pipeline</depend>

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -10,6 +10,9 @@
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/utils.hpp"
 #include "image_transport/image_transport.hpp"
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#include <cv_bridge/cv_bridge.hpp>
 
 namespace depthai_ros_driver {
 namespace dai_nodes {
@@ -193,6 +196,26 @@ std::shared_ptr<Image> ImagePublisher::convertData(const std::shared_ptr<dai::AD
     return img;
 }
 void ImagePublisher::publish(std::shared_ptr<Image> img) {
+    // Rotate only uncompressed images - compressed image rotation is too costly
+    if(pubConfig.flipImage && !pubConfig.publishCompressed) {
+        try {
+            if(img->image) {
+                auto imgPtr = std::make_shared<sensor_msgs::msg::Image>(*img->image);
+                cv_bridge::CvImagePtr cvPtr = cv_bridge::toCvCopy(imgPtr, imgPtr->encoding);
+                cv::Mat rotated;
+                cv::flip(cvPtr->image, rotated, -1);
+                cv_bridge::CvImage outCv;
+                outCv.header = imgPtr->header;
+                outCv.encoding = imgPtr->encoding;
+                outCv.image = rotated;
+                sensor_msgs::msg::Image newMsg;
+                outCv.toImageMsg(newMsg);
+                img->image = std::make_unique<sensor_msgs::msg::Image>(newMsg);
+            }
+        } catch(const std::exception& e) {
+            RCLCPP_WARN(node->get_logger(), "Failed to rotate image before publish: %s", e.what());
+        }
+    }
     if(pubConfig.publishCompressed) {
         if(encConfig.profile == dai::VideoEncoderProperties::Profile::MJPEG) {
             compressedImgPub->publish(std::move(img->compressedImg));

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -10,9 +10,9 @@
 #include "depthai_ros_driver/dai_nodes/sensors/sensor_helpers.hpp"
 #include "depthai_ros_driver/utils.hpp"
 #include "image_transport/image_transport.hpp"
-#include <opencv2/imgcodecs.hpp>
-#include <opencv2/imgproc.hpp>
-#include <cv_bridge/cv_bridge.hpp>
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/imgproc.hpp"
+#include "cv_bridge/cv_bridge.hpp"
 
 namespace depthai_ros_driver {
 namespace dai_nodes {

--- a/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/mono.cpp
@@ -73,6 +73,7 @@ void Mono::setupQueues(std::shared_ptr<dai::Device> device) {
         pubConf.height = ph->getParam<int>("i_height");
         pubConf.maxQSize = ph->getParam<int>("i_max_q_size");
         pubConf.publishCompressed = ph->getParam<bool>("i_publish_compressed");
+        pubConf.flipImage = ph->getParam<bool>("i_flip_published_image");
 
         imagePublisher->setup(device, convConf, pubConf);
     }

--- a/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/rgb.cpp
@@ -92,6 +92,7 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         pubConfig.height = ph->getParam<int>("i_height");
         pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
         pubConfig.publishCompressed = ph->getParam<bool>("i_publish_compressed");
+        pubConfig.flipImage = ph->getParam<bool>("i_flip_published_image");
 
         rgbPub->setup(device, convConfig, pubConfig);
     }
@@ -113,6 +114,7 @@ void RGB::setupQueues(std::shared_ptr<dai::Device> device) {
         pubConfig.height = ph->getParam<int>("i_preview_height");
         pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
         pubConfig.topicSuffix = "/preview/image_raw";
+        pubConfig.flipImage = ph->getParam<bool>("i_flip_published_image");
 
         previewPub->setup(device, convConfig, pubConfig);
     };

--- a/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/stereo.cpp
@@ -161,6 +161,7 @@ void Stereo::setupRectQueue(std::shared_ptr<dai::Device> device,
     pubConfig.socket = sensorInfo.socket;
     pubConfig.infoMgrSuffix = "rect";
     pubConfig.publishCompressed = ph->getParam<bool>(isLeft ? "i_left_rect_publish_compressed" : "i_right_rect_publish_compressed");
+    pubConfig.flipImage = ph->getParam<bool>("i_flip_published_image");
 
     pub->setup(device, convConfig, pubConfig);
 }
@@ -210,6 +211,7 @@ void Stereo::setupStereoQueue(std::shared_ptr<dai::Device> device) {
     pubConf.lazyPub = ph->getParam<bool>("i_enable_lazy_publisher");
     pubConf.maxQSize = ph->getParam<int>("i_max_q_size");
     pubConf.publishCompressed = ph->getParam<bool>("i_publish_compressed");
+    pubConf.flipImage = ph->getParam<bool>("i_flip_published_image");
 
     stereoPub->setup(device, convConfig, pubConf);
 }

--- a/depthai_ros_driver/src/dai_nodes/sensors/thermal.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/thermal.cpp
@@ -70,6 +70,7 @@ void Thermal::setupQueues(std::shared_ptr<dai::Device> device) {
         pubConfig.width = ph->getParam<int>("i_width");
         pubConfig.height = ph->getParam<int>("i_height");
         pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
+        pubConfig.flipImage = ph->getParam<bool>("i_flip_published_image");
 
         thermalPub->setup(device, convConfig, pubConfig);
     }
@@ -96,6 +97,8 @@ void Thermal::setupQueues(std::shared_ptr<dai::Device> device) {
         pubConfig.width = ph->getParam<int>("i_width");
         pubConfig.height = ph->getParam<int>("i_height");
         pubConfig.maxQSize = ph->getParam<int>("i_max_q_size");
+        pubConfig.flipImage = ph->getParam<bool>("i_flip_published_image");
+        
         thermalRawPub->setup(device, convConfig, pubConfig);
     }
 }

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -75,6 +75,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::MonoCamera> mo
     monoCam->setResolution(utils::getValFromMap(resString, dai_nodes::sensor_helpers::monoResolutionMap));
     declareAndLogParam<int>("i_width", monoCam->getResolutionWidth());
     declareAndLogParam<int>("i_height", monoCam->getResolutionHeight());
+    declareAndLogParam<bool>("i_flip_published_image", false);
     size_t iso = declareAndLogParam("r_iso", 800, getRangedIntDescriptor(100, 1600));
     size_t exposure = declareAndLogParam("r_exposure", 1000, getRangedIntDescriptor(1, 33000));
 

--- a/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/sensor_param_handler.cpp
@@ -48,6 +48,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::Camera> cam, d
     cam->setBoardSocket(socketID);
     cam->setFps(declareAndLogParam<double>("i_fps", 30.0));
     declareAndLogParam<bool>("i_publish_topic", publish);
+    declareAndLogParam<bool>("i_flip_published_image", false);
 
     int width = declareAndLogParam<int>("i_width", features.width);
     int height = declareAndLogParam<int>("i_height", features.height);
@@ -124,6 +125,7 @@ void SensorParamHandler::declareParams(std::shared_ptr<dai::node::ColorCamera> c
     colorCam->setBoardSocket(socketID);
     declareAndLogParam<bool>("i_output_isp", true);
     declareAndLogParam<bool>("i_enable_preview", false);
+    declareAndLogParam<bool>("i_flip_published_image", false);
     colorCam->setFps(declareAndLogParam<double>("i_fps", 30.0));
     int preview_size = declareAndLogParam<int>("i_preview_size", 300);
     int preview_width = declareAndLogParam<int>("i_preview_width", preview_size);

--- a/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
+++ b/depthai_ros_driver/src/param_handlers/stereo_param_handler.cpp
@@ -73,6 +73,7 @@ void StereoParamHandler::declareParams(std::shared_ptr<dai::node::StereoDepth> s
     declareAndLogParam<bool>("i_reverse_stereo_socket_order", false);
     declareAndLogParam<bool>("i_publish_compressed", false);
     declareAndLogParam<std::string>("i_calibration_file", "");
+    declareAndLogParam<bool>("i_flip_published_image", false);
 
     declareAndLogParam<bool>("i_publish_synced_rect_pair", false);
     declareAndLogParam<bool>("i_left_rect_publish_topic", false);


### PR DESCRIPTION
## Overview
Author: Jan Hernas

## Issue 
Issue link: https://github.com/luxonis/depthai-ros/issues/750 
Issue description: Current image rotating options affect the generated depth image making it unusable. This PR adds `i_flip_published_image` parameter to Sensors and Stereo that rotates uncompressed images just before publishing them to ROS. This will work on mono, rgb and thermal sensors as well as the stereo image.

I kept the `i_sensor_img_orientation` since it can be used to rotate images on camera and not do any post-processing if depth image can be disregarded.

Only uncompressed images are flipped since to rotate a ffmpeg image it would have to be decoded.

## Changes
ROS distro: Jazzy
List of changes:
- Added `i_flip_published_image` to sensor and stereo parameters
- Uncompressed images are rotated if `i_flip_published_image` is `true` 

## Testing
Hardware used: OAK-D W PRO

## Visuals from testing
Flipped image and pointcloud (camera was upside down):
<img width="1547" height="857" alt="oakrotated" src="https://github.com/user-attachments/assets/4823b99c-47b4-41f3-b9a9-2ec9a61caeb9" />
