### PR TITLE
Allow substituting launch args in camera launch file

### DIFF
--- a/depthai_ros_driver/launch/driver.launch.py
+++ b/depthai_ros_driver/launch/driver.launch.py
@@ -11,7 +11,7 @@ from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node
-from launch_ros.descriptions import ComposableNode
+from launch_ros.descriptions import ComposableNode, ParameterFile
 from launch.events import Shutdown
 
 
@@ -67,7 +67,7 @@ def launch_setup(context, *args, **kwargs):
         "publish_tf_from_calibration", default="true"
     )
     override_cam_model = LaunchConfiguration("override_cam_model", default="false")
-    params_file = LaunchConfiguration("params_file")
+    params_file = ParameterFile(LaunchConfiguration("params_file"), allow_substs="true")
     camera_model = LaunchConfiguration("camera_model", default="OAK-D")
     rs_compat = LaunchConfiguration("rs_compat", default="false")
     pointcloud_enable = LaunchConfiguration("pointcloud.enable", default="false")

--- a/depthai_ros_driver/launch/driver.launch.py
+++ b/depthai_ros_driver/launch/driver.launch.py
@@ -67,7 +67,7 @@ def launch_setup(context, *args, **kwargs):
         "publish_tf_from_calibration", default="true"
     )
     override_cam_model = LaunchConfiguration("override_cam_model", default="false")
-    params_file = ParameterFile(LaunchConfiguration("params_file"), allow_substs="true")
+    params_file = ParameterFile(LaunchConfiguration("params_file"), allow_substs=True)
     camera_model = LaunchConfiguration("camera_model", default="OAK-D")
     rs_compat = LaunchConfiguration("rs_compat", default="false")
     pointcloud_enable = LaunchConfiguration("pointcloud.enable", default="false")


### PR DESCRIPTION
## Overview
Author: Martin Pecka @peci1

## Issue 
Issue link (if present): N/A
Issue description: It is impossible to parametrize the YAML param files for cameras, which leads to unmanageable duplication of files.

## Changes
ROS distro: kilted
List of changes: Updated driver.launch.py to add `allow_substs=True` to the param file so that launch substitutions are performed there.

## Testing
Hardware used: OAK-D-LR
Depthai library version: 3.1.0
