### PR TITLE
Humble 2.12.1

### DIFF
--- a/depthai-ros/CHANGELOG.rst
+++ b/depthai-ros/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package depthai-ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.12.1 (2025-12-23)
+-------------------
+* Messages fix
+
 2.12.0 (2025-12-12)
 -------------------
 * Fix timeshift bug

--- a/depthai-ros/CMakeLists.txt
+++ b/depthai-ros/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai-ros VERSION 2.12.0 LANGUAGES CXX C)
+project(depthai-ros VERSION 2.12.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 

--- a/depthai-ros/package.xml
+++ b/depthai-ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai-ros</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>The depthai-ros package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
@@ -13,6 +13,7 @@
   <license>MIT</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   
+  <build_depend>ros_environment</build_depend>
   <exec_depend>depthai</exec_depend>
   <exec_depend>depthai_ros_msgs</exec_depend>
   <exec_depend>depthai_bridge</exec_depend>

--- a/depthai_bridge/CMakeLists.txt
+++ b/depthai_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-project(depthai_bridge VERSION 2.12.0 LANGUAGES CXX C)
+project(depthai_bridge VERSION 2.12.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -20,7 +20,6 @@
   <depend>depthai_ros_msgs</depend>
   <depend>image_transport</depend>
   <depend>libopencv-dev</depend>
-  <depend>ros_environment</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>stereo_msgs</depend>

--- a/depthai_bridge/package.xml
+++ b/depthai_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_bridge</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>The depthai_bridge package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>libboost-dev</depend>
+  <build_depend>ros_environment</build_depend>
   <depend>rclcpp</depend>
 
   <depend>cv_bridge</depend>

--- a/depthai_descriptions/CMakeLists.txt
+++ b/depthai_descriptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_descriptions VERSION 2.12.0)
+project(depthai_descriptions VERSION 2.12.1)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_descriptions/package.xml
+++ b/depthai_descriptions/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_descriptions</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>The depthai_descriptions package</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
@@ -10,6 +10,7 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/depthai_examples/CMakeLists.txt
+++ b/depthai_examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
-project(depthai_examples VERSION 2.12.0 LANGUAGES CXX C)
+project(depthai_examples VERSION 2.12.1 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -24,7 +24,6 @@
   <depend>depthai_descriptions</depend>
   <depend>image_transport</depend>
   <depend>libopencv-dev</depend>
-  <depend>ros_environment</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>stereo_msgs</depend>

--- a/depthai_examples/package.xml
+++ b/depthai_examples/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_examples</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>The depthai_examples package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
@@ -13,6 +13,7 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   
   <depend>rclcpp</depend>
   <depend>cv_bridge</depend>

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(depthai_filters VERSION 2.12.0 LANGUAGES CXX C)
+project(depthai_filters VERSION 2.12.1 LANGUAGES CXX C)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/depthai_filters/package.xml
+++ b/depthai_filters/package.xml
@@ -2,13 +2,14 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_filters</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>Depthai filters package</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>
   <depend>sensor_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(depthai_ros_driver VERSION 2.12.0)
+project(depthai_ros_driver VERSION 2.12.1)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_BUILD_SHARED_LIBS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -2,13 +2,14 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>depthai_ros_driver</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>Depthai ROS Monolithic node.</description>
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
 
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   <depend>ament_cmake_auto</depend>
   <depend>camera_calibration</depend>
   <depend>rclcpp</depend>

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-project(depthai_ros_msgs VERSION 2.12.0)
+project(depthai_ros_msgs VERSION 2.12.1)
 
 if(POLICY CMP0057)
     cmake_policy(SET CMP0057 NEW)
@@ -8,6 +8,13 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  find_library(
+    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+endif()
 # Not adding -DUSING_ROS since xml_parsing.cpp hasn't been ported to ROS2
 message(STATUS "------------------------------------------")
 message(STATUS "Depthai ROS MSGS/INTERFACES is being built using AMENT.")
@@ -19,13 +26,6 @@ find_package(vision_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-  find_library(
-    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
-    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
-    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
-  )
-endif()
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/AutoFocusCtrl.msg"
   "msg/HandLandmark.msg"

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>depthai_ros_msgs</name>
-  <version>2.12.0</version>
+  <version>2.12.1</version>
   <description>Package to keep interface independent of the driver</description>
 
   <maintainer email="adam.serafin@luxonis.com">Adam Serafin</maintainer>
@@ -10,6 +10,7 @@
   <license>MIT</license>
   
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   
   <depend>builtin_interfaces</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
## Overview
Author: @Serafadam 

## Issue 
Issue link (if present):
Issue description: `depthai_ros_msgs` aren't being built on APT for aarch64, most likely due to missing $ROS_DISTRO message
Related PRs

## Changes
ROS distro: Humble
List of changes:
- Add `ros_environment` to package.xmls
## Testing
Hardware used:
Depthai library version:


## Visuals from testing
Add screenshots/gifs/videos from RVIZ or other visualizers demonstrating the effect of the changes when applicable. 
