### PR TITLE
Fixed camera info for low_bandwidth streams.

### DIFF
--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -158,8 +158,8 @@ std::shared_ptr<Image> ImagePublisher::convertData(const std::shared_ptr<dai::AD
     auto img = std::make_shared<Image>();
     if(encConfig.enabled) {
         auto daiImg = std::dynamic_pointer_cast<dai::EncodedFrame>(data);
+        info = converter->generateCameraInfo(daiImg);
         if(pubConfig.publishCompressed) {
-            info = converter->generateCameraInfo(daiImg);
             auto rawMsg = converter->toRosMsgRawPtr(daiImg, info);
             info.header = rawMsg.header;
             if(encConfig.profile == dai::VideoEncoderProperties::Profile::MJPEG) {
@@ -173,6 +173,7 @@ std::shared_ptr<Image> ImagePublisher::convertData(const std::shared_ptr<dai::AD
             }
         } else {
             auto rawMsg = converter->toRosMsgRawPtr(daiImg, info);
+            info.header = rawMsg.header;
             sensor_msgs::msg::Image::UniquePtr msg = std::make_unique<sensor_msgs::msg::Image>(rawMsg);
             img->image = std::move(msg);
         }


### PR DESCRIPTION
## Overview
Author: Martin Pecka

## Issue 
Issue link (if present): https://github.com/luxonis/depthai-ros/issues/719#issuecomment-3729356224
Issue description: Camera info is all zeros for low_bandwidth streams

## Changes
ROS distro: Kilted
List of changes: Fixed camera info.

## Testing
Hardware used: OAK-D-SR-POE
Depthai library version: 3.1.0-1noble.20251107.215718
