### PR TITLE
fix(driver): handle X_LINK_GATE state for RVC4 PoE device connection

### DIFF
--- a/depthai_ros_driver/src/driver.cpp
+++ b/depthai_ros_driver/src/driver.cpp
@@ -247,7 +247,7 @@ void Driver::startDevice() {
                         }
                     } else if(!ip.empty() && info.name == ip) {
                         RCLCPP_INFO(get_logger(), "Connecting to the device using ip: %s", ip.c_str());
-                        if(info.state == X_LINK_UNBOOTED || info.state == X_LINK_BOOTLOADER) {
+                        if(info.state == X_LINK_UNBOOTED || info.state == X_LINK_BOOTLOADER || info.state == X_LINK_GATE) {
                             device = std::make_shared<dai::Device>(info);
                             camRunning = true;
                         } else if(info.state == X_LINK_BOOTED) {


### PR DESCRIPTION
## Overview
Author: Anish Mathew Oommen P

## Issue
Issue link: https://github.com/luxonis/depthai-ros/issues/778
Issue description: RVC4-based OAK PoE devices (OAK-4-PRO-W) report X_LINK_GATE 
as their XLink state when ready to accept connections. The driver's startDevice() 
only handled X_LINK_UNBOOTED and X_LINK_BOOTLOADER states for IP-based connections, 
causing the driver to silently skip the connection attempt and loop indefinitely 
without any error, resulting in no topics being published.

Related PRs: None

## Changes
ROS distro: Humble

List of changes:
- Added X_LINK_GATE to the allowed connection states in the IP connection 
  path inside startDevice() in depthai_ros_driver/src/driver.cpp

## Testing
Hardware used: OAK-4-PRO-W (RVC4, PoE)

Depthai library version:
- depthai (Python): 3.1.0
- depthai-core (C++): 3.2.2
- depthai-ros-driver-v3: 3.1.1

## Visuals from testing
Driver successfully connects to OAK-4-PRO-W over PoE and publishes topics 
after the fix:
[oak]: Connecting to the device using ip: <device-ip>
[oak]: Driver with ID: XXXXXXXX and Name: <device-ip> connected!
[oak]: PoE device detected.
[oak]: Device type: OAK-4-PRO-W
[oak]: Driver ready!