### PR TITLE
Fix ipcEnabled publish using image_transport shared memory publisher

### DIFF
--- a/depthai_ros_driver/include/depthai_ros_driver_v3/dai_nodes/sensors/img_pub.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver_v3/dai_nodes/sensors/img_pub.hpp
@@ -90,8 +90,6 @@ class ImagePublisher {
     std::shared_ptr<dai::node::VideoEncoder> createEncoder(std::shared_ptr<dai::Pipeline> pipeline, const utils::VideoEncoderConfig& encoderConfig);
 
    private:
-    bool detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
-                            const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub);
     std::shared_ptr<rclcpp::Node> node;
     utils::VideoEncoderConfig encConfig;
     utils::ImgPublisherConfig pubConfig;
@@ -101,7 +99,6 @@ class ImagePublisher {
     std::shared_ptr<dai::node::XLinkOut> xout;
     std::shared_ptr<dai::node::VideoEncoder> encoder;
     dai::Node::Output* out;
-    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr imgPub;
     rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr infoPub;
     rclcpp::Publisher<ffmpeg_image_transport_msgs::msg::FFMPEGPacket>::SharedPtr ffmpegPub;
     rclcpp::Publisher<sensor_msgs::msg::CompressedImage>::SharedPtr compressedImgPub;

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -212,9 +212,8 @@ void ImagePublisher::publish(std::shared_ptr<Image> img) {
         }
         infoPub->publish(std::move(img->info));
     } else {
-        if(ipcEnabled && (!pubConfig.lazyPub || detectSubscription(imgPub, infoPub))) {
-            imgPub->publish(std::move(img->image));
-            infoPub->publish(std::move(img->info));
+        if(ipcEnabled && (!pubConfig.lazyPub)) {
+            imgPubIT.publish(std::move(img->image), std::move(img->info));
         } else {
             if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(*img->image, *img->info);
         }

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -212,8 +212,8 @@ void ImagePublisher::publish(std::shared_ptr<Image> img) {
         }
         infoPub->publish(std::move(img->info));
     } else {
-        if(ipcEnabled && (!pubConfig.lazyPub)) {
-            imgPubIT.publish(std::move(img->image), std::move(img->info));
+        if(ipcEnabled) {
+            if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(std::move(img->image), std::move(img->info));
         } else {
             if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(*img->image, *img->info);
         }

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -239,12 +239,6 @@ void ImagePublisher::publish(const std::shared_ptr<dai::ADatatype>& data) {
         publish(img);
     }
 }
-
-bool ImagePublisher::detectSubscription(const rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
-                                        const rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr& infoPub) {
-    return (pub->get_subscription_count() > 0 || pub->get_intra_process_subscription_count() > 0 || infoPub->get_subscription_count() > 0
-            || infoPub->get_intra_process_subscription_count() > 0);
-}
 }  // namespace sensor_helpers
 }  // namespace dai_nodes
 }  // namespace depthai_ros_driver

--- a/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
+++ b/depthai_ros_driver/src/dai_nodes/sensors/img_pub.cpp
@@ -212,10 +212,12 @@ void ImagePublisher::publish(std::shared_ptr<Image> img) {
         }
         infoPub->publish(std::move(img->info));
     } else {
-        if(ipcEnabled) {
-            if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(std::move(img->image), std::move(img->info));
-        } else {
-            if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) imgPubIT.publish(*img->image, *img->info);
+        if(!pubConfig.lazyPub || imgPubIT.getNumSubscribers() > 0) {
+            if(ipcEnabled) {
+                imgPubIT.publish(std::move(img->image), std::move(img->info));
+            } else {
+                imgPubIT.publish(*img->image, *img->info);
+            }
         }
     }
 }


### PR DESCRIPTION
## Overview
Author: kdubel@griddynamics.com

## Issue 
Issue link (if present): #781 
Issue description:
- Launching depthai-ros-driver `ComposableNode` with `use_intra_process_comms == false` works as expected.
- Launching depthai-ros-driver `ComposableNode` with `use_intra_process_comms == true` causes a `segmentation fault` error.

## Changes
ROS distro: `jazzy`
List of changes:
- Changed publisher to [image_transport::CameraPublisher](https://docs.ros.org/en/jade/api/image_transport/html/classimage__transport_1_1CameraPublisher.html#a9817973953b5c2a4abfcca5e8cdc0417) using shared memory pointers when `ipcEnabled == true`

## Testing
Hardware used: Luxonis 4 D Pro
Depthai library version: depthai-core `v3.2.2-jazzy.1`, depthai-ros `v3.1.1-jazzy.4`
