### PR TITLE
fix: depthai-core submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depthai-core"]
 	path = depthai-core
-	url = ../depthai-core
+	url = https://github.com/luxonis/depthai-core.git


### PR DESCRIPTION
This makes it work when repo was cloned from a fork